### PR TITLE
Self-host the plugin: bootstrap + CLAUDE.md routing

### DIFF
--- a/.board-superpowers/config.yml
+++ b/.board-superpowers/config.yml
@@ -1,0 +1,9 @@
+# board-superpowers project config.
+# Managed by using-board-superpowers. Safe to edit by hand.
+
+project: "PanQiWei/4"
+wip_limit: 5
+
+# Future fields (not yet consumed):
+#   base_branch: main
+#   default_execution_skill: superpowers:subagent-driven-development

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "board-superpowers-local",
+  "owner": {
+    "name": "board-superpowers contributors"
+  },
+  "plugins": [
+    {
+      "name": "board-superpowers",
+      "source": "./",
+      "description": "Agile scheduling layer for Claude Code: turn GitHub Projects into the central dispatcher, one session = one PR. Depends on superpowers and gstack.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "board-superpowers-local": {
+      "source": {
+        "source": "directory",
+        "path": "."
+      }
+    }
+  },
+  "enabledPlugins": {
+    "board-superpowers@board-superpowers-local": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,13 @@ __pycache__/
 .venv/
 venv/
 
-# Per-project Claude Code artifacts
-.claude/
+# Per-project Claude Code artifacts (local, per-user).
+# .claude/settings.json and .claude-plugin/marketplace.json are
+# team-shared (this repo dogfoods its own plugin), so they stay tracked.
+.claude/settings.local.json
+.claude/cache/
+.claude/logs/
+.claude/tmp/
+
+# board-superpowers local state (claim markers are per-session)
+.board-superpowers/claims/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# board-superpowers — project instructions
+
+This repo **is** the plugin. Sessions here are plugin-maintainer
+sessions, not product-user sessions. See @README.md for the
+user-facing overview.
+
+## Self-hosting
+
+This repo uses its own plugin. The `board-superpowers:routing` block
+at the bottom of this file is mirrored verbatim from
+`skills/using-board-superpowers/references/claudemd-routing.md` —
+edits to one must land in the other in the same commit.
+
+The `<!-- board-superpowers:routing -->` / `<!-- /board-superpowers:routing -->`
+marker pair is matched by tooling. Do not rename, indent, or merge
+into surrounding prose.
+
+## Protocol invariants
+
+These are load-bearing because downstream installs depend on them:
+
+- **`scripts/*.sh` are a public contract.** Hooks, skills (via
+  `${CLAUDE_PLUGIN_ROOT}`), and user automations call them. Breaking
+  changes need a migration note in the PR body.
+- **`check-deps.sh` exit codes:** `0` = deps present, `2` = missing.
+  No new non-zero codes without updating every caller + branching
+  skill.
+- **Skill `description` frontmatter is behavior.** Downstream models
+  match on it. Treat edits with the same care as code.
+
+## Project-specific skill routing
+
+The global `~/.claude/CLAUDE.md` already routes gstack ↔ superpowers.
+In addition, for this repo:
+
+- Editing any `skills/*/SKILL.md` → invoke
+  `superpowers:writing-skills` first.
+- Second opinion on shell logic → `gstack:/codex`.
+- Before tagging a release that touches `scripts/` or `hooks/` →
+  `gstack:/cso`.
+- **Not applicable here:** `gstack:/ship` `/land-and-deploy`
+  `/canary`. This plugin has no deploy target; release = bump
+  `plugin.json` + `marketplace.json`, push a git tag.
+
+## Commands
+
+```bash
+bash scripts/check-deps.sh                      # preflight; exits 0 or 2
+bash scripts/bootstrap-project.sh --help        # one-time per-repo setup
+bash scripts/create-card.sh --help              # Manager: create card
+bash scripts/claim-card.sh --help               # Consumer: atomic claim
+bash scripts/transition-card.sh --help          # move card status
+```
+
+<!-- board-superpowers:routing -->
+## board-superpowers session routing
+
+This project uses the `board-superpowers` plugin. Any Claude Code
+session in this project plays one of two roles:
+
+- **Board Consumer** — if the first message contains `[board-card:#N]`,
+  or the user asks to work on / claim / implement card N, invoke the
+  `consuming-card` skill immediately. That skill owns the full
+  lifecycle: claim → implement → PR → update board.
+- **Board Manager** — if the user asks about planning today's work,
+  reviewing the board, decomposing a requirement, triaging blocked
+  cards, or running a retro, invoke the `managing-board` skill.
+- When unsure, invoke `using-board-superpowers` first.
+
+board-superpowers depends on the `superpowers` and `gstack` plugins
+and will delegate design and execution work to them. Do not
+reimplement what they already do.
+<!-- /board-superpowers:routing -->


### PR DESCRIPTION
## Summary
- Bootstrap board-superpowers against its own repo — track `.board-superpowers/config.yml` (GitHub Project PanQiWei/4, WIP 5), `.claude-plugin/marketplace.json`, and `.claude/settings.json` so any clone of this repo auto-enables the plugin without a manual `/plugin add` dance.
- Add `CLAUDE.md` with the canonical `board-superpowers:routing` block (mirrored from `skills/using-board-superpowers/references/claudemd-routing.md`) so future sessions in this repo auto-route to Manager / Consumer.
- Narrow the `.gitignore` sweep on `.claude/` from a blanket exclude to per-user state only (`settings.local.json`, `cache/`, `logs/`, `tmp/`), so team-shared `settings.json` / `marketplace.json` stay tracked while per-user noise is still ignored.

## Test plan
- [ ] Fresh clone of this repo: open Claude Code, confirm the plugin loads automatically via `.claude/settings.json` (no `/plugin add` needed).
- [ ] Open a session and say "what should I work on today" — confirm routing hits `managing-board`.
- [ ] Open a session with `[board-card:#N]` in the first message — confirm routing hits `consuming-card`.
- [ ] Run `bash scripts/check-deps.sh` at repo root — expect exit 0 (routing marker detected, config.yml present).
- [ ] Sanity-check that `.claude/settings.local.json` is still gitignored (per-user override stays local).