### PR TITLE
chore: remove orphan claim-marker tombstones for #15 and #16

### DIFF
--- a/.board-superpowers/claims/15.claim
+++ b/.board-superpowers/claims/15.claim
@@ -1,7 +1,0 @@
-card: 15
-session: s-7baf
-claimed_at: 2026-04-24T10:16:03Z
-base: main
-branch: claim/15-fix-claim-card-force-add
-manual_claim: true
-manual_claim_reason: claim-card.sh broken by .gitignore conflict; this card fixes it

--- a/.board-superpowers/claims/16.claim
+++ b/.board-superpowers/claims/16.claim
@@ -1,6 +1,0 @@
-card: 16
-session: s-manual-bootstrap
-claimed_at: 2026-04-24T00:00:00Z
-base: main
-branch: claim/16-consumer-self-select-worktree
-note: manual bootstrap claim — claim-card.sh does not yet support worktree isolation (this card adds it)


### PR DESCRIPTION
## Summary

- `git rm` the two `.board-superpowers/claims/<N>.claim` files that
  shipped to main as a side-effect of merging #17 and #18.
- Not a protocol change — the atomic-lock mechanism still needs the
  markers to be force-added on their respective claim branches. They
  just shouldn't persist past merge.

## Test Plan

- `git log --follow` on either removed file shows its only commits
  are the claim commits on the respective claim branches; nothing on
  main references them.
- `.gitignore` already excludes `.board-superpowers/claims/`, so
  future Consumer sessions' local marker files stay untracked.

## Automated Verification

Ran `git ls-tree -r origin/main --name-only | grep claims/` before
and after locally — before: 2 files, after: 0 files.

## Human Verification TODO

- [ ] None — this is a pure file-deletion chore; no code paths touch
      main's `.board-superpowers/claims/` directly.

## Retro Notes

- **Estimate vs actual:** XS. Two `git rm`, one commit.
- **Surprises:** none.
- **Suggested decomposition next time:** n/a — the structural fix
  (auto-remove marker before PR) is a separate card.

<!-- board-superpowers:pr -->