### PR TITLE
bootstrap: full first-time onboarding + plugin developer guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,4 +70,82 @@ session in this project plays one of two roles:
 board-superpowers depends on the `superpowers` and `gstack` plugins
 and will delegate design and execution work to them. Do not
 reimplement what they already do.
+
+### How to compose gstack and superpowers
+
+Both plugins are runtime dependencies of board-superpowers. They are
+complementary, not alternatives — route by phase of work, not by
+preference.
+
+**Division of labor**
+
+- **gstack owns the bookends.** Direction-setting before a card is
+  claimed (is this worth building, what's the right shape) and
+  delivery-side verification (code review, QA, security). CEO /
+  design / QA / security-officer viewpoints.
+- **superpowers owns the middle.** The coding-discipline loop:
+  `brainstorming` → `writing-plans` → `test-driven-development` →
+  `systematic-debugging` → `verification-before-completion` →
+  `requesting-code-review`. TDD is mandatory inside this loop.
+- **Conflict arbitration** follows `superpowers:using-superpowers`:
+  **user instructions > skill > default behavior.** A gstack skill's
+  "plan is ready, start coding" advice does not override superpowers'
+  TDD discipline unless the user explicitly says so in the current
+  conversation.
+
+**Typical flow — menu, not checklist**
+
+Pick skills that fit the card; do not run them all.
+
+Pre-card intake (Manager's Intake routine routes here before a card
+is created):
+
+1. `gstack:/office-hours` or `/plan-ceo-review` — is this worth
+   building.
+2. `gstack:/plan-eng-review` — lock the architecture.
+3. `superpowers:brainstorming` — sharpen requirements and design.
+4. `superpowers:writing-plans` — turn the output into an executable
+   plan.
+
+Implementation (inside a Consumer session):
+
+5. `superpowers:test-driven-development` drives Red → Green →
+   Refactor.
+6. Stuck? `superpowers:systematic-debugging`, or
+   `gstack:/investigate` for a second angle.
+7. Parallelizable subtasks:
+   `superpowers:dispatching-parallel-agents` or
+   `superpowers:subagent-driven-development`.
+
+Self-check and delivery (still inside the Consumer session, before
+opening the PR):
+
+8. `superpowers:verification-before-completion` — evidence-first; do
+   not claim "done" without it.
+9. `gstack:/review` — production-bug viewpoint.
+10. `superpowers:requesting-code-review` — independent
+    second-pair-of-eyes.
+11. `gstack:/qa <url>` — real-browser QA. Mandatory for any
+    UI-touching card.
+12. `gstack:/cso` — security / OWASP / STRIDE audit. superpowers has
+    no equivalent.
+
+Release, deploy, canary, and document-release skills
+(`gstack:/ship`, `/canary`, `/land-and-deploy`,
+`/document-release`) are project-specific. Enable them only if they
+match this repo's deployment shape; otherwise use whatever release
+flow the project already has. board-superpowers does not prescribe
+a release process.
+
+**Pitfalls**
+
+- **Skill-name collisions.** Two large libraries have overlapping
+  descriptions. Route by this block, not by letting the model guess
+  from skill descriptions.
+- **Browser tools — one source.** Always use `gstack:/browse`. Do
+  not mix with other browser tooling.
+- **TDD is not optional** inside
+  `superpowers:test-driven-development`. An adjacent planning
+  skill's "start coding" suggestion does not excuse skipping
+  Red → Green → Refactor.
 <!-- /board-superpowers:routing -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,52 +4,374 @@ This repo **is** the plugin. Sessions here are plugin-maintainer
 sessions, not product-user sessions. See @README.md for the
 user-facing overview.
 
+This file is the developer guide for the plugin itself. Read it
+before editing anything under `skills/`, `scripts/`, `hooks/`, or
+`.claude-plugin/`. The routing block at the bottom is the same block
+the plugin injects into every downstream repo during bootstrap — it
+is mirrored verbatim from
+`skills/using-board-superpowers/references/claudemd-routing.md` and
+does not describe plugin-maintainer behavior.
+
+## Architecture at a glance
+
+board-superpowers is a scheduling layer on top of `superpowers` and
+`gstack`. At runtime it does four things:
+
+1. **Alerts** the architect if either dependency is missing. Three
+   layers, in increasing reliability:
+   1. `hooks/session-start.sh` — best-effort banner via
+      `additionalContext` (Claude Code's SessionStart delivery is
+      buggy — treat this layer as advisory).
+   2. `skills/using-board-superpowers/SKILL.md` Step 1 — the
+      reliable gate; every skill invocation routes through it.
+   3. Just-in-time re-checks inside `managing-board` and
+      `consuming-card` before any cross-plugin call, in case deps
+      got uninstalled mid-session.
+2. **Routes** each session into `managing-board` or `consuming-card`
+   based on the first user message (the routing block at the bottom
+   of this file tells the model how).
+3. **Coordinates** work through GitHub. No server-side state. The
+   board IS the state: Project v2 status column + Issue body
+   schema + `claim/<N>-<slug>` remote branches.
+4. **Delegates** real work — brainstorming, TDD, debugging, QA,
+   review, security audit — to `superpowers:*` and `gstack:/*`. We
+   compose; we don't reimplement.
+
+### Data plane
+
+- **GitHub Project v2** — the board. Its `Status` field drives the
+  state machine defined in `skills/board-protocol/SKILL.md`.
+- **GitHub Issues** — the cards. Body schema lives in
+  `skills/decomposing-into-milestones/references/card-schema.md`.
+- **Claim branches** — `claim/<N>-<slug>` on origin. Creating one
+  via `git push --force-with-lease=<ref>:` is the distributed lock
+  (first push wins, second one exits 10).
+- **Worktrees** — default at
+  `$HOME/.config/superpowers/worktrees/<project>/<branch>`, owned
+  by `claim-card.sh`. One per Consumer session, so N parallel
+  Consumers never share HEAD.
+- **`.board-superpowers/config.yml`** — committed per-repo config
+  (project coordinate + WIP limit).
+- **`.board-superpowers/claims/<N>.claim`** — marker file on the
+  claim branch. Gitignored locally but force-committed to the claim
+  branch, so the marker is visible on origin as proof of claim.
+
+### Control plane (plugin surfaces)
+
+| Surface | Called by | Promises |
+|---------|-----------|----------|
+| `hooks/session-start.sh` | Claude Code on session start | Best-effort dep alert via `additionalContext` |
+| `scripts/check-deps.sh` | The hook + every skill's preflight | Exit `0` deps OK, `2` missing. `--machine` mode emits `MISSING=` / `ROUTING_INJECTED=` key=value lines. |
+| `scripts/bootstrap-project.sh` | `using-board-superpowers` Step 3 | Labels + Status validation + `config.yml` + `.gitignore` entry |
+| `scripts/claim-card.sh` | `consuming-card` Step 2 | Atomic claim + isolated worktree; two-line stdout (`branch=` / `worktree=`) |
+| `scripts/create-card.sh` | `decomposing-into-milestones` Step 6 | Issue + Project-item in one shot |
+| `scripts/transition-card.sh` | Manager + Consumer | Move a card between Status options |
+| `skills/*/SKILL.md` | Claude Code model matching on `description` frontmatter | That description is behavior, not documentation |
+
+## Tech stack
+
+- **bash 3.2+** with strict mode. Callers `set -euo pipefail` before
+  sourcing `scripts/lib/common.sh`.
+- **gh CLI** with `project` scope (plus `issue` / `pr` implicitly).
+- **python3** for JSON parsing (gh output → field / option IDs).
+- **shellcheck** — the style + correctness gate for every script
+  and test.
+- **Claude Code plugin protocol** — `${CLAUDE_PLUGIN_ROOT}` env,
+  `hooks/hooks.json` schema, SKILL.md YAML frontmatter,
+  `hookSpecificOutput.additionalContext` payload shape.
+- No runtime dependencies beyond the above. No node, no go, no
+  compiled artifacts.
+
+## Directory layout and ownership
+
+```
+board-superpowers/
+├── .claude-plugin/
+│   ├── plugin.json                 # version source of truth
+│   └── marketplace.json            # local-marketplace manifest (dogfood)
+├── hooks/
+│   ├── hooks.json                  # Claude Code hook registration
+│   └── session-start.sh            # Layer 1 dep alert; self-contained
+├── scripts/
+│   ├── lib/common.sh               # shared bash utils; caller sets
+│   │                               # strict mode BEFORE sourcing
+│   ├── check-deps.sh               # exit 0/2; self-contained
+│   ├── bootstrap-project.sh
+│   ├── claim-card.sh
+│   ├── create-card.sh
+│   └── transition-card.sh
+├── skills/
+│   ├── using-board-superpowers/    # entry skill: preflight + routing
+│   │   └── references/             # + first-time bootstrap
+│   │       ├── claudemd-routing.md         # injected into downstream
+│   │       │                               # CLAUDE.md — mirror of the
+│   │       │                               # block at the bottom here
+│   │       └── first-time-user-guide.md    # delivered post-bootstrap
+│   ├── board-protocol/             # shared state machine + schema
+│   ├── managing-board/             # Manager main skill
+│   │   └── references/
+│   │       ├── daily-routine.md
+│   │       ├── intake-routine.md
+│   │       ├── review-queue.md
+│   │       └── retro-routine.md
+│   ├── decomposing-into-milestones/
+│   │   └── references/
+│   │       ├── card-schema.md
+│   │       └── decomposition-patterns.md
+│   └── consuming-card/
+│       └── references/
+│           ├── pr-template.md
+│           └── handoff-to-superpowers.md
+├── tests/
+│   ├── test-claim-card.sh              # force-add + .gitignore invariant
+│   └── test-claim-card-worktree.sh     # worktree isolation
+├── CLAUDE.md                       # this file — developer guide
+├── README.md                       # end-user overview
+└── LICENSE
+```
+
+Two files are **deliberately self-contained** — they must NOT source
+`scripts/lib/common.sh`, because a broken or missing lib must never
+break either dep detection or Claude Code startup:
+
+- `hooks/session-start.sh`
+- `scripts/check-deps.sh`
+
+Everything else under `scripts/` sources the lib.
+
 ## Self-hosting
 
-This repo uses its own plugin. The `board-superpowers:routing` block
-at the bottom of this file is mirrored verbatim from
-`skills/using-board-superpowers/references/claudemd-routing.md` —
-edits to one must land in the other in the same commit.
+The plugin dogfoods itself: this repo has its own
+`.claude-plugin/marketplace.json`, its own
+`.board-superpowers/config.yml`, and routes sessions through its own
+Manager / Consumer skills.
 
-The `<!-- board-superpowers:routing -->` / `<!-- /board-superpowers:routing -->`
-marker pair is matched by tooling. Do not rename, indent, or merge
-into surrounding prose.
+Two load-bearing consequences:
+
+- **The routing block at the bottom of this file is a mirror.** It
+  is the same text injected into downstream repos during bootstrap,
+  and it must match
+  `skills/using-board-superpowers/references/claudemd-routing.md`
+  verbatim between the marker pair. Edits to one land in the other
+  in the same commit.
+- **The `<!-- board-superpowers:routing -->` /
+  `<!-- /board-superpowers:routing -->` marker pair is matched by
+  `check-deps.sh`.** Do not rename, indent, or merge them into
+  surrounding prose.
+
+Non-trivial changes should go through the plugin's own Manager →
+Consumer flow — create a card, claim it, open a PR. Direct-edit on
+main is fine for typos and single-reference docs fixes; not for
+protocol changes.
 
 ## Protocol invariants
 
-These are load-bearing because downstream installs depend on them:
+These are load-bearing because downstream installs depend on them.
+Breaking any of them → migration note in the PR body, consider a
+version bump.
+
+### Script contracts
 
 - **`scripts/*.sh` are a public contract.** Hooks, skills (via
-  `${CLAUDE_PLUGIN_ROOT}`), and user automations call them. Breaking
-  changes need a migration note in the PR body.
-- **`check-deps.sh` exit codes:** `0` = deps present, `2` = missing.
-  No new non-zero codes without updating every caller + branching
-  skill.
-- **Skill `description` frontmatter is behavior.** Downstream models
-  match on it. Treat edits with the same care as code.
+  `${CLAUDE_PLUGIN_ROOT}`), and user automations call them.
+- **Exit-code discipline.** Each script documents its exit codes in
+  its header comment. Current conventions:
+  - `0` — success
+  - `1` — operational failure
+  - `2` — bad arguments OR (for `check-deps.sh` only) missing deps
+  - `3` — missing runtime command (gh / python3)
+  - `10` — `claim-card.sh`: already claimed (caller must stop, not retry)
+  - `20` — `claim-card.sh`: git / network error
+  - `30` — `claim-card.sh`: bad args / missing dep
+- **New exit codes require updating every caller plus every
+  branching skill.**
+- **`claim-card.sh` stdout is structured.** On success it prints
+  exactly two lines, in order:
+  ```
+  branch=<claim branch name>
+  worktree=<absolute path to worktree>
+  ```
+  `consuming-card/SKILL.md` Step 2 parses both. Changing the shape
+  is a breaking change.
+- **`check-deps.sh` `--machine` keys are `MISSING`,
+  `ROUTING_INJECTED`, `PROJECT`.** Renaming any of them breaks
+  `hooks/session-start.sh`'s parser.
+
+### File / path contracts
+
+- **`.board-superpowers/claims/` is gitignored** but individual
+  claim markers are force-committed to their claim branch (never to
+  main). `claim-card.sh` does the `git add -f`.
+- **`.board-superpowers/config.yml` is tracked** and hand-editable.
+- **Worktree default path** is
+  `$HOME/.config/superpowers/worktrees/<project>/<branch>`.
+  Override via `$BOARD_SP_WORKTREE_DIR`, or via project-local
+  `.worktrees/` (must both exist AND be gitignored).
+- **CLAUDE.md routing markers** `<!-- board-superpowers:routing -->`
+  / `<!-- /board-superpowers:routing -->` are matched by
+  `check-deps.sh`.
+- **Never commit absolute local paths to a public branch.** Claim
+  markers ride on claim branches that push to origin; a local path
+  leaks OS username / directory layout. See
+  `tests/test-claim-card-worktree.sh` for the regression guard.
+- **Plan briefs live at `docs/board-superpowers/plans/card-<N>.md`
+  and are gitignored.** The card body on GitHub is the source of
+  truth; the plan brief is scratch for
+  `superpowers:subagent-driven-development`.
+
+### Skill contracts
+
+- **Skill `description` frontmatter is behavior.** Downstream
+  models match on it — editing it changes which sessions the skill
+  fires in. Treat edits with the same care as code.
+- **Skill filenames are stable.** `SKILL.md` + `references/<name>.md`
+  — the Claude Code runtime enumerates these.
+- **Every skill that calls an external plugin must just-in-time
+  re-check deps** via `check-deps.sh` before the call, in case
+  deps got uninstalled mid-session.
+
+## Change-impact matrix
+
+Before editing, check what else has to land in the same PR. If you
+change what's on the left, update everything on the right.
+
+| If you change… | You must also update… |
+|----------------|----------------------|
+| `scripts/claim-card.sh` stdout shape | `skills/consuming-card/SKILL.md` Step 2 parser + `tests/test-claim-card*.sh` + `README.md` "Dispatching a Consumer" |
+| Any `scripts/*.sh` exit code | Every caller (grep `scripts/` + `skills/`) + the invariants section above |
+| `scripts/lib/common.sh` function signature | Every script that sources it |
+| `check-deps.sh` output keys (`MISSING`, `ROUTING_INJECTED`, `PROJECT`) | `hooks/session-start.sh` parser |
+| Marker string `board-superpowers:routing` | `check-deps.sh` marker detection + every skill that mentions it |
+| `skills/board-protocol` state machine | Every skill referencing transitions + `scripts/transition-card.sh` Status option names |
+| `skills/decomposing-into-milestones` card schema | `scripts/create-card.sh` body template + PR review gate in `managing-board/references/review-queue.md` |
+| Worktree default path | `scripts/claim-card.sh` + `README.md` + `skills/consuming-card/SKILL.md` + `skills/board-protocol/SKILL.md` + triage reassign recipe in `managing-board/SKILL.md` |
+| `skills/using-board-superpowers/references/claudemd-routing.md` | This file's routing block (mirror rule — verbatim between the markers) |
+| `skills/using-board-superpowers/references/first-time-user-guide.md` | If the guide's structure changes, `skills/using-board-superpowers/SKILL.md` Step 3 reference to it |
+| `.claude-plugin/plugin.json:version` | `.claude-plugin/marketplace.json:plugins[0].version` + git tag |
+| Any skill `description` frontmatter | `README.md` if the trigger phrases appear there |
+| `hooks/hooks.json` schema | `hooks/session-start.sh` if new hook entry points get added |
+
+## Maintaining skills
+
+1. Invoke `superpowers:writing-skills` first. It enforces frontmatter
+   rules, description discipline, and reference-splitting heuristics.
+2. If the edit changes the `description` field, re-read adjacent
+   skills' descriptions — overlaps cause mis-routing.
+3. If the edit changes a procedure step, check the change-impact
+   matrix for callers (the `scripts/*.sh` one is the usual bite).
+4. Skill bodies stay in English for shareability. Chinese discussion
+   belongs in commit messages or PR bodies.
+5. Reference files follow the pattern `skills/<name>/references/<topic>.md`.
+   Keep each file single-topic; SKILL.md is the dispatcher.
+
+## Maintaining scripts
+
+1. Header comment is mandatory: purpose, usage, exit codes, stdout
+   shape (if any), side effects, required deps. `bsp_show_help`
+   prints the header as `--help`.
+2. `set -euo pipefail` + source `scripts/lib/common.sh` at the top,
+   unless self-contained (`check-deps.sh`) — document the exception
+   inline.
+3. Run `shellcheck -x <script>` from the scripts directory before
+   committing. If you hit SC1091, it usually means you ran
+   shellcheck from the wrong cwd, not that the source line is wrong.
+4. Second opinion on non-trivial shell logic: `gstack:/codex`.
+5. If a script gains a new exit code or stdout line, update the
+   change-impact matrix in the same PR.
+6. `${CLAUDE_PLUGIN_ROOT}` is the only reliable way for scripts to
+   reference the plugin's own files. Never hard-code `~/.claude/plugins/...`.
+
+## Maintaining hooks
+
+1. `hooks/session-start.sh` must stay self-contained — no sourcing
+   `lib/common.sh`, no dependency on repo layout beyond reading its
+   own path via `${CLAUDE_PLUGIN_ROOT}`.
+2. Anything emitted to `additionalContext` is untrusted model
+   input. Sanitize every value derived from `check-deps.sh` before
+   interpolation — see `sanitize_dep_name` in `session-start.sh`
+   for the pattern.
+3. Hook failures must NEVER block Claude Code startup. Silent
+   no-op on error is the correct failure mode at this layer; the
+   SKILL preflight is the real safety net.
+4. `hooks.json` declares a 10s timeout. Keep new work well under it.
+
+## Testing
+
+Tests live in `tests/*.sh` — plain bash, no framework. They must be
+**hermetic**. See `tests/test-claim-card-worktree.sh` for the
+canonical pattern:
+
+- `export HOME=$TMP/home` — isolate user config.
+- `export XDG_CONFIG_HOME=$TMP/xdg` — isolate worktree default path.
+- `export GIT_CONFIG_GLOBAL=$TMP/.gitconfig-global` +
+  `GIT_CONFIG_SYSTEM=/dev/null` — neutralize the runner's git
+  config; write a minimal `user.name` / `user.email` to the test
+  global config.
+- Use a local bare repo as `origin`; never reach GitHub from a test.
+- Kill hooks and custom excludes: `core.hooksPath=/dev/null`,
+  `core.excludesFile=/dev/null`.
+
+Run everything:
+
+```bash
+for t in tests/*.sh; do bash "$t" || exit 1; done
+```
+
+Adding a test: name it `tests/test-<area>.sh`, make it executable,
+and assert on invariants — not only happy paths. The
+`worktree:` field info-leak fix landed a regression assertion
+precisely because the existing happy-path test had not caught it.
+
+## Releasing
+
+No deploy target. A release is bookkeeping:
+
+1. Decide the semver bump. Script / hook / skill contract breaks
+   are major. Additive behavior is minor. Docs-only is patch.
+2. Bump `.claude-plugin/plugin.json:version` AND
+   `.claude-plugin/marketplace.json:plugins[0].version` in the
+   same commit.
+3. If the release touches `scripts/` or `hooks/`, run `gstack:/cso`
+   before tagging.
+4. Tag: `git tag v<version> && git push origin v<version>`.
+5. Draft a GitHub release pointing at the tag, with migration notes
+   whenever a contract changed.
+
+**Not applicable here:** `gstack:/ship`, `/land-and-deploy`,
+`/canary`, `/document-release`. This plugin has no deploy target.
 
 ## Project-specific skill routing
 
-The global `~/.claude/CLAUDE.md` already routes gstack ↔ superpowers.
-In addition, for this repo:
+The global `~/.claude/CLAUDE.md` already routes gstack ↔ superpowers
+for day-to-day work. The injected routing block at the bottom of
+this file captures the project-agnostic version of that for
+downstream repos. In addition, for this repo:
 
 - Editing any `skills/*/SKILL.md` → invoke
   `superpowers:writing-skills` first.
 - Second opinion on shell logic → `gstack:/codex`.
 - Before tagging a release that touches `scripts/` or `hooks/` →
   `gstack:/cso`.
-- **Not applicable here:** `gstack:/ship` `/land-and-deploy`
-  `/canary`. This plugin has no deploy target; release = bump
-  `plugin.json` + `marketplace.json`, push a git tag.
+- Dogfood the board for non-trivial changes: create a card, claim
+  it via the plugin's own Consumer flow, open the PR. Direct edits
+  are fine only for typos and single-reference docs fixes.
+- **Not applicable here:** `gstack:/ship`, `/land-and-deploy`,
+  `/canary`, `/document-release`. See Releasing above.
 
 ## Commands
 
 ```bash
+# Public contract surfaces
 bash scripts/check-deps.sh                      # preflight; exits 0 or 2
 bash scripts/bootstrap-project.sh --help        # one-time per-repo setup
 bash scripts/create-card.sh --help              # Manager: create card
 bash scripts/claim-card.sh --help               # Consumer: atomic claim
 bash scripts/transition-card.sh --help          # move card status
+
+# Developer workflows
+for t in tests/*.sh; do bash "$t" || exit 1; done    # run all tests
+(cd scripts && shellcheck -x ./*.sh)                 # lint scripts
+(cd tests   && shellcheck -x ./*.sh)                 # lint tests
 ```
 
 <!-- board-superpowers:routing -->

--- a/skills/using-board-superpowers/SKILL.md
+++ b/skills/using-board-superpowers/SKILL.md
@@ -97,8 +97,14 @@ chore: bootstrap board-superpowers
 chore: add board-superpowers routing to CLAUDE.md
 ```
 
-Tell the architect: "Routing added. Future sessions in this project
-will route to Manager or Consumer without this dance."
+Then deliver the first-time user guide. Step 3 running is by
+definition a first-time bootstrap (only fires when the preflight
+reported `ROUTING_INJECTED=no`), so the architect does not yet know
+the shape of the plugin. Follow
+`references/first-time-user-guide.md` for the delivery structure
+(six short sections, paused between each) and the two "after
+delivery" options. Do not skip it; do not abbreviate past the six
+sections.
 
 ## Step 4 — Hand off
 

--- a/skills/using-board-superpowers/references/claudemd-routing.md
+++ b/skills/using-board-superpowers/references/claudemd-routing.md
@@ -23,6 +23,84 @@ session in this project plays one of two roles:
 board-superpowers depends on the `superpowers` and `gstack` plugins
 and will delegate design and execution work to them. Do not
 reimplement what they already do.
+
+### How to compose gstack and superpowers
+
+Both plugins are runtime dependencies of board-superpowers. They are
+complementary, not alternatives — route by phase of work, not by
+preference.
+
+**Division of labor**
+
+- **gstack owns the bookends.** Direction-setting before a card is
+  claimed (is this worth building, what's the right shape) and
+  delivery-side verification (code review, QA, security). CEO /
+  design / QA / security-officer viewpoints.
+- **superpowers owns the middle.** The coding-discipline loop:
+  `brainstorming` → `writing-plans` → `test-driven-development` →
+  `systematic-debugging` → `verification-before-completion` →
+  `requesting-code-review`. TDD is mandatory inside this loop.
+- **Conflict arbitration** follows `superpowers:using-superpowers`:
+  **user instructions > skill > default behavior.** A gstack skill's
+  "plan is ready, start coding" advice does not override superpowers'
+  TDD discipline unless the user explicitly says so in the current
+  conversation.
+
+**Typical flow — menu, not checklist**
+
+Pick skills that fit the card; do not run them all.
+
+Pre-card intake (Manager's Intake routine routes here before a card
+is created):
+
+1. `gstack:/office-hours` or `/plan-ceo-review` — is this worth
+   building.
+2. `gstack:/plan-eng-review` — lock the architecture.
+3. `superpowers:brainstorming` — sharpen requirements and design.
+4. `superpowers:writing-plans` — turn the output into an executable
+   plan.
+
+Implementation (inside a Consumer session):
+
+5. `superpowers:test-driven-development` drives Red → Green →
+   Refactor.
+6. Stuck? `superpowers:systematic-debugging`, or
+   `gstack:/investigate` for a second angle.
+7. Parallelizable subtasks:
+   `superpowers:dispatching-parallel-agents` or
+   `superpowers:subagent-driven-development`.
+
+Self-check and delivery (still inside the Consumer session, before
+opening the PR):
+
+8. `superpowers:verification-before-completion` — evidence-first; do
+   not claim "done" without it.
+9. `gstack:/review` — production-bug viewpoint.
+10. `superpowers:requesting-code-review` — independent
+    second-pair-of-eyes.
+11. `gstack:/qa <url>` — real-browser QA. Mandatory for any
+    UI-touching card.
+12. `gstack:/cso` — security / OWASP / STRIDE audit. superpowers has
+    no equivalent.
+
+Release, deploy, canary, and document-release skills
+(`gstack:/ship`, `/canary`, `/land-and-deploy`,
+`/document-release`) are project-specific. Enable them only if they
+match this repo's deployment shape; otherwise use whatever release
+flow the project already has. board-superpowers does not prescribe
+a release process.
+
+**Pitfalls**
+
+- **Skill-name collisions.** Two large libraries have overlapping
+  descriptions. Route by this block, not by letting the model guess
+  from skill descriptions.
+- **Browser tools — one source.** Always use `gstack:/browse`. Do
+  not mix with other browser tooling.
+- **TDD is not optional** inside
+  `superpowers:test-driven-development`. An adjacent planning
+  skill's "start coding" suggestion does not excuse skipping
+  Red → Green → Refactor.
 <!-- /board-superpowers:routing -->
 ```
 

--- a/skills/using-board-superpowers/references/first-time-user-guide.md
+++ b/skills/using-board-superpowers/references/first-time-user-guide.md
@@ -1,0 +1,147 @@
+# First-time user guide (post-bootstrap)
+
+When Step 3 of `using-board-superpowers` injects the routing block,
+it is by definition the architect's first time with the plugin in
+this repo (`check-deps.sh` sets `ROUTING_INJECTED=no` only in that
+case). Deliver this onboarding immediately after the two bootstrap
+commits land.
+
+Substitutions while delivering:
+
+- `{PROJECT}` — the `OWNER/NUMBER` the architect supplied to
+  `bootstrap-project.sh`.
+- `{WIP}` — the WIP limit written to `.board-superpowers/config.yml`
+  (default 5).
+
+## Delivery shape
+
+This is a conversation, not a wall of text. Open with one sentence,
+then walk through the six sections below. Pause between sections to
+let the architect ask or object. Do not paste the README; do not
+inline the individual routine references (`daily-routine.md` etc.) —
+those are for Manager / Consumer use, not architect onboarding.
+
+Opening line:
+
+> "Bootstrapping done for {PROJECT}. Before you close this session,
+> here's the shape of how you'll work in this repo from now on —
+> six short sections, ask at any point."
+
+### Section 1 — What just happened
+
+- GitHub Project `{PROJECT}` is now bound to this repo.
+- Standard labels created: `type:{feature,bug,chore,refactor,epic}`
+  and `size:{XS,S,M,L}`.
+- `.board-superpowers/config.yml` written (committed).
+  `.board-superpowers/claims/` gitignored (per-session scratch, but
+  individual claim markers *are* force-committed onto their claim
+  branches — that's how the claim is proven on origin).
+- Routing block injected into `CLAUDE.md` — every future Claude Code
+  session in this repo auto-picks Manager or Consumer based on the
+  first user message.
+
+### Section 2 — The mental model
+
+**One session = one card = one PR.** Two roles, only ever one per
+session:
+
+| Role | What it does | How to invoke |
+|------|--------------|---------------|
+| 🧭 Board Manager | Reads the board, plans, dispatches. Never writes code, never merges. | "what should I work on?", "review the board", "I have a new requirement: …", "weekly retro" |
+| 🔧 Board Consumer | Claims one card atomically, implements it in an isolated git worktree, opens one PR. | "work on card #N" or "pull a card from the board" |
+
+A Manager session typically stays open alongside you for a full day.
+Consumer sessions are per-card and disposable — open a fresh
+terminal, paste the kick-off prompt, walk away.
+
+### Section 3 — A day in this loop
+
+Describe this rhythm, do not table it:
+
+- **Morning.** Open Manager → "what should I work on?" → Manager
+  shows PRs that need your verification, cards in flight, cards
+  Ready to dispatch. Verify and merge pending PRs first (a waiting
+  PR = a Consumer's idle work). Then dispatch up to WIP-budget cards.
+- **Midday.** Consumer sessions finish and open PRs. Ask Manager
+  "what PRs need me?" — it groups them by verification surface (UI
+  batch, same-area batch, zero-TODO fast lane) so you verify in
+  batches, not context-switching per PR.
+- **Friday.** "weekly retro" → flow metrics + a decomposition-signal
+  digest from PR Retro Notes.
+
+### Section 4 — Three Manager phrases to memorize
+
+| You say | Manager runs | What it produces |
+|---------|--------------|------------------|
+| "what should I work on?" | Daily routine | Fixed-template board snapshot + one recommendation |
+| "I have a new requirement: `<desc>`" | Intake routine | Routes you to design (`superpowers:brainstorming` or `gstack:/office-hours`), then to decomposition → Backlog cards |
+| "what PRs need me?" | Review Queue | PRs grouped for batching, protocol violations flagged |
+
+Also useful: "card #N is blocked / too big" (triage), "promote card
+#N to Ready" (move from Backlog).
+
+### Section 5 — The PR contract
+
+Every Consumer PR is required to have three sections. Knowing them
+up front means you know what to expect when you open one:
+
+- `## Automated Verification` — what ran, what passed.
+- `## Human Verification TODO` — checkboxes the Consumer could not
+  automate. This is **your job** before merge.
+- `## Retro Notes` — estimate vs actual, surprises, suggested
+  re-decomposition. This feeds the weekly retro.
+
+If a PR is missing one of those, Manager flags it as a protocol
+violation during Review Queue — you reply to the Consumer ("please
+add Retro Notes per board-protocol, then re-request review").
+
+### Section 6 — Rules of the road
+
+- **WIP soft limit: {WIP}.** Manager warns at or over; never blocks.
+  Raise deliberately.
+- **Card flow:** Backlog → Ready → In Progress → In Review → Done.
+  `Blocked` is a side state. Manager does NOT promote Backlog → Ready
+  on its own; you do ("promote card #N to Ready").
+- **Humans merge PRs.** Agents do not self-merge, even their own.
+- **Pull-based.** Consumers claim cards; Manager never assigns. Even
+  the kick-off prompts Manager hands you are suggestions — you pick
+  which to paste into a terminal.
+- **Parallel Consumers are isolated.** Each claim creates its own
+  git worktree (default under
+  `~/.config/superpowers/worktrees/<project>/<branch>`). N Consumer
+  terminals do not trample each other's HEAD.
+- **Design comes before cards.** Requirements go through Intake →
+  design → decomposition. Cards never land on the board as "figure
+  it out in impl".
+
+## After delivery — offer two next steps
+
+Pick one based on whether the architect already has something to
+build:
+
+1. **Real intake.** If they have a feature in mind:
+   > "Want to try this end-to-end? Open a fresh terminal in this
+   > repo and say 'I have a new requirement: <your feature>'. The
+   > Manager will walk you through design → decomposition and land
+   > the cards in Backlog."
+
+2. **Dry-run Manager.** If nothing specific yet:
+   > "Or say 'what should I work on today?' in this same session.
+   > With an empty board you'll see the empty-state output — worth
+   > seeing once so the real one isn't a surprise."
+
+Then stop. Do not auto-create a card. Do not auto-open a Consumer
+session.
+
+## Hard do-nots during delivery
+
+- Do not paste `README.md` into chat — it's docs for someone reading
+  the plugin cold; the architect just finished bootstrap and is
+  already oriented.
+- Do not embed the routine references (`daily-routine.md`,
+  `intake-routine.md`, etc.) — those are procedure for Manager to
+  execute, not material for the architect to memorize.
+- Do not inline `board-protocol` — Manager and Consumer skills load
+  it themselves at preflight.
+- Do not auto-create an example card to "demo" the flow. The first
+  real card is the architect's call.


### PR DESCRIPTION
## Summary

Three docs-only commits covering the "first-time bootstrap +
plugin-maintainer onboarding" gap. Everything lands above or inside
already-mirrored regions — no runtime behavior change.

- **`bootstrap: extend routing block with gstack × superpowers composition`** —
  `skills/using-board-superpowers/references/claudemd-routing.md`
  now includes the "How to compose gstack and superpowers" subsection
  (project-agnostic rewrite of the guidance that used to live only in
  individual users' `~/.claude/CLAUDE.md`). Mirrored verbatim into
  this repo's `CLAUDE.md` routing block per the self-hosting
  invariant.
- **`bootstrap: deliver first-time user guide after Step 3`** — new
  `skills/using-board-superpowers/references/first-time-user-guide.md`
  + updated Step 3 of `using-board-superpowers/SKILL.md` to walk the
  architect through the plugin in six conversational sections after
  the routing block is injected. `ROUTING_INJECTED=no` is already
  proof of first-time use, so detection is unchanged.
- **`docs: turn CLAUDE.md into a plugin developer guide`** — expands
  `CLAUDE.md` above the routing block with architecture, tech stack,
  directory layout + ownership, expanded protocol invariants (script
  contracts / file-path contracts / skill contracts), a
  change-impact matrix, per-surface maintenance checklists, hermetic
  testing pattern, and the release flow.

## Test Plan

Docs-only, no runtime code paths touched.

- [x] `tests/test-claim-card.sh` — PASS
- [x] `tests/test-claim-card-worktree.sh` — PASS (4 scenarios)
- [x] `shellcheck -x scripts/*.sh` — 2 pre-existing SC2016 (info) on
      literal-backtick help strings, unrelated to this PR. No new
      findings.
- [x] `shellcheck tests/*.sh` — clean.
- [x] Mirror invariant — `awk` extraction of the block between
      `<!-- board-superpowers:routing -->` markers in `CLAUDE.md`
      vs `skills/using-board-superpowers/references/claudemd-routing.md`
      is byte-identical.

## Automated Verification

```
$ bash tests/test-claim-card.sh
PASS: claim-card.sh commits the marker despite .gitignore

$ bash tests/test-claim-card-worktree.sh
PASS: happy path (stdout contract, worktree isolated, primary untouched)
PASS: concurrent different-card claims get distinct worktrees
PASS: already-claimed card exits 10 without creating new worktree
ALL PASS: test-claim-card-worktree.sh

$ (cd scripts && shellcheck -x ./*.sh)
(only 2 pre-existing SC2016 info notes; no errors)

$ (cd tests && shellcheck ./*.sh)
(clean)

$ diff <(awk '/^<!-- board-superpowers:routing -->/,/^<!-- \/board-superpowers:routing -->/' CLAUDE.md) \
       <(awk '/^<!-- board-superpowers:routing -->/,/^<!-- \/board-superpowers:routing -->/' skills/using-board-superpowers/references/claudemd-routing.md)
(no diff — mirror verbatim)
```

No CI is configured for this repo yet, so the above is the full
automated gate.

## Human Verification TODO

- [ ] **Skim the expanded routing block
      (`skills/using-board-superpowers/references/claudemd-routing.md`).**
      Confirm the "Division of labor / Typical flow / Pitfalls"
      subsections match how you think about gstack × superpowers
      composition — this block now ships to every downstream
      `CLAUDE.md` at bootstrap, so word choice is durable.
- [ ] **Skim `skills/using-board-superpowers/references/first-time-user-guide.md`.**
      Six sections + opening line + "after delivery" options +
      hard do-nots. Confirm the tone matches how you'd onboard a
      new architect yourself, because the agent will follow this
      verbatim structure.
- [ ] **Spot-check the change-impact matrix in `CLAUDE.md`.** 13
      rows. If you spot a coupling that isn't listed (or a row that
      no longer matches reality after recent refactors), call it
      out before merge — this matrix is the gate future maintainers
      will trust without grepping.
- [ ] **Confirm the dogfood rule in "Project-specific skill routing"
      is phrased right.** Current wording: non-trivial changes go
      through the plugin's own Manager → Consumer flow; direct-edit
      on main is only for typos and single-reference docs fixes.
      Docs PRs like this one sit right on that line — if you want
      it stricter ("every change goes through a card") or looser
      ("docs sweeps don't count"), adjust.
- [ ] **Re-run first-time bootstrap in a scratch repo** (not
      required for merge, but good for next release). Clone this
      plugin, run `bootstrap-project.sh` in a fresh repo with a
      fresh Project, confirm the agent walks through the six-section
      guide and does NOT paste the README or auto-create a demo
      card.

## Retro Notes

- **Estimate vs actual:** Not card-tracked; this was a direct
  plugin-maintainer session. If it had been a card, Size M felt
  right (3 commits, ~500 lines of diff across 4 files, all docs).
- **Surprises:**
  - The `awk '/marker1/,/marker2/'` mirror-verification trick has
    a gotcha: if either marker string appears anywhere else in the
    file (even inside prose), the range matches too broadly. Had
    to anchor with `^` to restrict to actual block-delimiter lines.
    Worth remembering for any future doc that references the
    markers by name.
  - The original SKILL Step 3 sign-off ("Routing added. Future
    sessions will route...") was doing double duty: confirming
    success and implicitly teaching the workflow. Splitting those
    — keep the confirmation, add the real onboarding — was what
    made the content selection obvious. Before the split the scope
    kept oscillating between "one more sentence" and "full README".
  - Writing the change-impact matrix first-pass caught two
    couplings I hadn't realized were load-bearing: the
    `check-deps.sh --machine` key names (parsed by
    `session-start.sh` — renaming them silently breaks the hook)
    and the routing marker string (used by `check-deps.sh` itself
    for `ROUTING_INJECTED` detection — renaming it breaks the
    first-time-user-guide trigger we just added).
- **Suggested decomposition next time:** Three commits in one PR
  was right — all three edits share the "first-time bootstrap"
  theme and the change-impact matrix references the other two
  commits directly. Splitting them would have produced commits
  where the matrix in CLAUDE.md pointed to files not yet added.

<!-- board-superpowers:pr -->
