### PR TITLE
[Card 1] Plumbing precursor: v0.1.0-minimum spec drift fixes + helpers for Card 2 (closes #24)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "board-superpowers",
       "source": "./",
       "description": "Agile scheduling layer for Claude Code: turn GitHub Projects into the central dispatcher, one session = one PR. Depends on superpowers and gstack.",
-      "version": "0.1.0-minimum"
+      "version": "0.1.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "board-superpowers",
-  "version": "0.1.0-minimum",
+  "version": "0.1.1",
   "description": "Agile scheduling layer for Claude Code: turn GitHub Projects into the central dispatcher, turn one session into one deliverable milestone (one PR). Depends on superpowers and gstack.",
   "author": {
     "name": "board-superpowers contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "board-superpowers",
-  "version": "0.1.0-minimum",
+  "version": "0.1.1",
   "description": "Agile scheduling layer for Codex CLI: turn GitHub Projects into the central dispatcher, one session = one PR. Depends on superpowers and gstack.",
   "author": "board-superpowers contributors",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "interface": {
     "displayName": "board-superpowers",
     "shortDescription": "GitHub-Project-driven scheduling for AI coding sessions",
-    "longDescription": "board-superpowers turns a GitHub Project into the central dispatcher for AI-driven coding sessions. Routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode. Delegates real work — TDD, debugging, review, QA, security — to superpowers and gstack. v0.1.0-minimum ships 5 of 10 v1 skills.",
+    "longDescription": "board-superpowers turns a GitHub Project into the central dispatcher for AI-driven coding sessions. Routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode. Delegates real work — TDD, debugging, review, QA, security — to superpowers and gstack. v0.1.1 ships 5 of 10 v1 skills.",
     "developerName": "board-superpowers contributors",
     "category": "developer-tools",
     "websiteURL": "https://github.com/PanQiWei/board-superpowers"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,8 @@ The v1-minimum plugin is loadable. The operational checklist:
 ### Release flow
 
 - Bump `.claude-plugin/plugin.json` + `.codex-plugin/plugin.json`
-  `version` field per semver (this PR: `v0.1.0-minimum`).
+  `version` field per semver (e.g., `v0.1.0-minimum` → `v0.1.1`
+  is a patch; `v0.1.x` → `v0.2.0` is a minor).
 - For deferred-atomic landings, also bump per-skill
   `.skill-meta.yaml` `version` (per
   [`SKILL_DEVELOPMENT.md`](./SKILL_DEVELOPMENT.md) § "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ deferred atomics ship):
   triage from `classifying-actions` is inlined as one block per
   v1-minimum molecular SKILL.md.
 - All audit entries write to a **local jsonl trace file** at
-  `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`. The
+  `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`. The
   full BYO RDBMS schema from `auditing-actions` is deferred.
 - **No `bootstrapping-repo` skill yet** — the plugin assumes
   the repo's GitHub Project + standard labels are already set

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ deferred atomics ship):
   up manually. The hook never injects `INVOKE: bootstrapping-repo`
   in v1-minimum.
 - **No `migrating-repo-version` skill yet** — current plugin
-  version is `v0.1.0-minimum`; nothing to migrate from. The
+  version is `v0.1.1`; nothing to migrate from. The
   hook never injects `INVOKE: migrating-repo-version` in
   v1-minimum.
 
@@ -554,7 +554,7 @@ ls docs/architecture/adr/                      # what's decided
 <!-- board-superpowers:routing -->
 ## board-superpowers session routing
 
-This project uses the `board-superpowers` plugin (v0.1.0-minimum).
+This project uses the `board-superpowers` plugin (v0.1.1).
 Any Claude Code session in this project plays one of two roles:
 
 - **Board Consumer** — if the first message contains `[board-card:#N]`,

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -317,7 +317,7 @@ means for board-superpowers" #3 for the full rationale.
   inlined 5 times.
 - **v1-minimum degradation**: until this skill ships, every
   v1-minimum molecular SKILL.md appends a one-line jsonl entry
-  to a local `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`
+  to a local `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`
   file as an interim trace. Replace with full schema + BYO
   RDBMS write when this skill lands.
 

--- a/SKILL_DEVELOPMENT.md
+++ b/SKILL_DEVELOPMENT.md
@@ -1435,7 +1435,7 @@ NOT in SKILL.md.
 | Phase narrative (anti-pattern) | Current-behavior framing (correct) |
 |--------------------------------|-------------------------------------|
 | "v1-minimum: all mutating actions = R-class default" | "Every mutating action this skill performs follows propose → wait for ack → act → audit" |
-| "Audit log writes go to local jsonl in v1-minimum; BYO RDBMS in v1-complete" | "Audit log writes append a JSON line to `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`" |
+| "Audit log writes go to local jsonl in v1-minimum; BYO RDBMS in v1-complete" | "Audit log writes append a JSON line to `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`" |
 | "Mode-2 Producer-spawned Consumer is CC-only at v1-minimum" | "When this skill runs as a Producer-spawned subagent (Claude Code only), ..." |
 | "F-09 (decomposition) deferred to v1-complete; Producer hand-decomposes for now" | (just describe the manual hand-decomposition flow as the actual procedure) |
 

--- a/docs/architecture/0005-contracts/07-path-conventions.md
+++ b/docs/architecture/0005-contracts/07-path-conventions.md
@@ -114,7 +114,7 @@ table.
 - ADR-0003 — "Path resolution priority" (the canonical 3-priority
   list landing here as a contract).
 - `scripts/lib/common.sh` — `bsp_pick_worktree_dir` is the
-  implementation; lines 132–160 are the canonical reference.
+  canonical implementation of the 3-priority resolution.
 - `AGENTS.md` "Worktree default path" — the same priority list
   surfaced in the developer guide; it points here.
 - I-7 (one-card-one-worktree).

--- a/docs/architecture/0005-contracts/07-path-conventions.md
+++ b/docs/architecture/0005-contracts/07-path-conventions.md
@@ -50,7 +50,7 @@ These rules apply to every path in this section:
 
 Three-priority list for `<WORKTREE_DIR>` (the **parent** directory
 under which a per-claim worktree lives). Pinned by ADR-0003 and
-implemented in `scripts/claim-card.sh` (`bsp_pick_worktree_dir`).
+implemented in `scripts/lib/common.sh` (`bsp_pick_worktree_dir`).
 
 | Priority | Source | Condition | Path |
 |----------|--------|-----------|------|

--- a/docs/architecture/0005-contracts/07-path-conventions.md
+++ b/docs/architecture/0005-contracts/07-path-conventions.md
@@ -113,7 +113,7 @@ table.
 
 - ADR-0003 — "Path resolution priority" (the canonical 3-priority
   list landing here as a contract).
-- `scripts/claim-card.sh` — `bsp_pick_worktree_dir` is the
+- `scripts/lib/common.sh` — `bsp_pick_worktree_dir` is the
   implementation; lines 132–160 are the canonical reference.
 - `AGENTS.md` "Worktree default path" — the same priority list
   surfaced in the developer guide; it points here.

--- a/docs/architecture/0005-contracts/08-environment-variables.md
+++ b/docs/architecture/0005-contracts/08-environment-variables.md
@@ -61,7 +61,7 @@ follow-up; no current consumer.
 |----------|-------|
 | Format | Absolute filesystem path. Relative paths are rejected. |
 | Default | unset → falls through to project-local `.worktrees/` (priority 2) → `$HOME/.config/superpowers/worktrees/<project>/` (priority 3) |
-| Read by | `scripts/claim-card.sh` (`bsp_pick_worktree_dir`) |
+| Read by | `scripts/lib/common.sh` (`bsp_pick_worktree_dir`) |
 | Validation | If set, MUST start with `/`. Relative input → `bsp_die "BOARD_SP_WORKTREE_DIR must be absolute, got: ..." 30` (exit `30`). |
 
 When set, this is the **highest-priority** worktree-parent

--- a/docs/architecture/0005-contracts/08-environment-variables.md
+++ b/docs/architecture/0005-contracts/08-environment-variables.md
@@ -74,7 +74,7 @@ where `$HOME` is ephemeral.
 #### Cited rationale
 
 - ADR-0003 — "Path resolution priority" (priority-1 entry).
-- `scripts/claim-card.sh` lines 132–160 — implementation.
+- `scripts/lib/common.sh` `bsp_pick_worktree_dir` — implementation.
 - [`07-path-conventions.md`](./07-path-conventions.md) "Worktree
   path resolution" — canonical contract pin.
 - `AGENTS.md` "Override via `$BOARD_SP_WORKTREE_DIR`" — protocol

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -55,7 +55,7 @@ dep_ok = "${DEP_OK}"
 has_config = "${HAS_CONFIG}"
 dep_output = """${DEP_OUTPUT}"""
 
-lines = ["board-superpowers v0.1.0-minimum loaded."]
+lines = ["board-superpowers v0.1.1 loaded."]
 if dep_ok != "yes":
     lines.append("⚠️  Dependency check failed:")
     lines.append(dep_output)

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,24 +1,51 @@
 #!/usr/bin/env bash
-# scripts/check-deps.sh — verify required CLI dependencies for board-superpowers.
+# scripts/check-deps.sh — verify required CLI dependencies + routing block
+# for board-superpowers.
 #
 # Called by:
 #   - hooks/session-start.sh (every session, fast-path verification)
 #   - using-board-superpowers SKILL.md (fallback when hook output is missing)
 #
-# Exit codes:
-#   0 — all dependencies present at acceptable versions
-#   1 — at least one dependency missing or below minimum version
+# Exit codes (per docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § "Layer 1 dep check (§1.5.0)" and 0005-contracts/02-hook-contracts.md):
+#   0 — all dependencies present + routing block present
+#       (or no AGENTS.md / CLAUDE.md exists, in which case the routing
+#       check is skipped — the asymmetric "no file is fine, file without
+#       marker is not" rule keeps the dep check silent in repos that
+#       don't use these files at all)
+#   2 — required binary is NOT installed, OR AGENTS.md / CLAUDE.md
+#       exists but lacks the "## board-superpowers session routing"
+#       heading
+#   3 — required binary IS installed but a runtime invariant fails
+#       (e.g., `gh` exists but lacks the `project` / `read:project`
+#       scope, or `gh` is not authenticated)
 #
 # Stdout: human-readable status banner suitable for hookSpecificOutput.additionalContext
+#
+# Layer-classification rationale: a missing binary is a static
+# "install something" problem (exit 2 = caller can prompt the user to
+# install the dep). A binary present but unauthenticated/under-scoped is
+# a runtime invariant problem (exit 3 = caller can prompt the user to
+# re-authenticate). Card 2's hook uses these distinct codes to choose
+# between two different INVOKE markers; Card 1 establishes the contract.
 
 set -euo pipefail
 
 # Resolve our own location and source common helpers.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
 # shellcheck source=lib/common.sh
 . "${SCRIPT_DIR}/lib/common.sh"
 
-declare -i FAILED=0
+# --- Failure tracking ---------------------------------------------------
+# Three independent counters — order of priority for exit-code resolution:
+#   MISSING_DEPS or MISSING_ROUTING -> exit 2
+#   else RUNTIME_FAILURES           -> exit 3
+#   else                            -> exit 0
+
+declare -i MISSING_DEPS=0
+declare -i MISSING_ROUTING=0
+declare -i RUNTIME_FAILURES=0
 
 check_cmd() {
     local cmd="${1:?}"
@@ -27,20 +54,65 @@ check_cmd() {
         printf '  ✓ %s\n' "${cmd}"
     else
         printf '  ✗ %s — MISSING (%s)\n' "${cmd}" "${hint}"
-        FAILED=$((FAILED + 1))
+        MISSING_DEPS=$((MISSING_DEPS + 1))
     fi
 }
 
 check_gh_scope() {
     if ! command -v gh >/dev/null 2>&1; then
-        return  # Already counted by check_cmd above.
+        return  # Already counted by check_cmd above as a missing dep.
     fi
     # gh auth status emits scopes on stderr; grep them.
     if gh auth status 2>&1 | grep -qE "'(read:project|project)'"; then
         printf '  ✓ gh auth has project scope\n'
     else
         printf '  ✗ gh auth missing project scope — run: gh auth refresh -s project,read:project\n'
-        FAILED=$((FAILED + 1))
+        RUNTIME_FAILURES=$((RUNTIME_FAILURES + 1))
+    fi
+}
+
+check_routing_block() {
+    # Resolve the git toplevel for the cwd. If we're not inside a git
+    # repo, the routing-block check is meaningless — skip silently.
+    local toplevel
+    if ! toplevel="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        return
+    fi
+
+    # Asymmetric rule (per 05-bootstrap-surface.md):
+    #   - no AGENTS.md AND no CLAUDE.md → skipped (silent, exit 0 path)
+    #   - either file present without the heading → exit 2
+    # Detection is heading-presence only. Card 2 will tighten this to a
+    # SHA-hash protocol; for v0.1.1 a literal heading match suffices.
+    local agents="${toplevel}/AGENTS.md"
+    local claude="${toplevel}/CLAUDE.md"
+    local heading='## board-superpowers session routing'
+    local saw_file=0
+    local saw_marker=0
+
+    if [ -f "${agents}" ]; then
+        saw_file=1
+        if grep -qF "${heading}" "${agents}"; then
+            saw_marker=1
+        fi
+    fi
+    if [ -f "${claude}" ]; then
+        saw_file=1
+        if grep -qF "${heading}" "${claude}"; then
+            saw_marker=1
+        fi
+    fi
+
+    if [ "${saw_file}" -eq 0 ]; then
+        # Neither file exists — silent skip per spec.
+        return
+    fi
+
+    if [ "${saw_marker}" -eq 1 ]; then
+        printf '  ✓ board-superpowers routing block present\n'
+    else
+        printf '  ✗ AGENTS.md / CLAUDE.md present but routing block missing\n'
+        MISSING_ROUTING=$((MISSING_ROUTING + 1))
     fi
 }
 
@@ -49,10 +121,23 @@ check_cmd gh "install via 'brew install gh'"
 check_cmd python3 "macOS / Linux ship python3 by default"
 check_cmd git "macOS ships git via Xcode CLT"
 check_gh_scope
+check_routing_block
 
-if [ "${FAILED}" -gt 0 ]; then
-    printf '\n%d dependency check(s) failed. Fix before using board-superpowers.\n' "${FAILED}" >&2
-    exit 1
+# --- Exit-code resolution ----------------------------------------------
+# Priority: install-time failures (deps / routing block) outrank runtime
+# failures (auth / scope), because a fix-it prompt that says "install
+# the binary" is meaningless if the binary is already installed.
+
+if [ "${MISSING_DEPS}" -gt 0 ] || [ "${MISSING_ROUTING}" -gt 0 ]; then
+    printf '\nDependency check failed: %d missing dep(s), %d missing routing block(s).\n' \
+        "${MISSING_DEPS}" "${MISSING_ROUTING}" >&2
+    exit 2
+fi
+
+if [ "${RUNTIME_FAILURES}" -gt 0 ]; then
+    printf '\nRuntime check failed: %d runtime invariant(s) unsatisfied.\n' \
+        "${RUNTIME_FAILURES}" >&2
+    exit 3
 fi
 
 printf '\nAll dependencies satisfied (board-superpowers v0.1.0-minimum).\n'

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -6,13 +6,27 @@
 #   - hooks/session-start.sh (every session, fast-path verification)
 #   - using-board-superpowers SKILL.md (fallback when hook output is missing)
 #
+# SELF-CONTAINED: this script MUST NOT source scripts/lib/common.sh, per
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § "Self-contained scripts at the dep-check layer". A broken lib must
+# never break dependency detection. The same self-containment rule applies
+# to hooks/session-start.sh.
+#
+# Inputs (per spec § 1.5.0):
+#   $CLAUDE_PROJECT_DIR — project root for the routing-block check;
+#                         defaults to $PWD if unset.
+#   $HOME               — used implicitly by called tools.
+#
 # Exit codes (per docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
 # § "Layer 1 dep check (§1.5.0)" and 0005-contracts/02-hook-contracts.md):
 #   0 — all dependencies present + routing block present
 #       (or no AGENTS.md / CLAUDE.md exists, in which case the routing
 #       check is skipped — the asymmetric "no file is fine, file without
 #       marker is not" rule keeps the dep check silent in repos that
-#       don't use these files at all)
+#       don't use these files at all). Also reached when
+#       $CLAUDE_PROJECT_DIR resolves to a non-git directory: outside-git
+#       means there is no project to validate, so the routing check is
+#       skipped.
 #   2 — required binary is NOT installed, OR AGENTS.md / CLAUDE.md
 #       exists but lacks the "## board-superpowers session routing"
 #       heading
@@ -30,12 +44,6 @@
 # between two different INVOKE markers; Card 1 establishes the contract.
 
 set -euo pipefail
-
-# Resolve our own location and source common helpers.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source-path=SCRIPTDIR
-# shellcheck source=lib/common.sh
-. "${SCRIPT_DIR}/lib/common.sh"
 
 # --- Failure tracking ---------------------------------------------------
 # Three independent counters — order of priority for exit-code resolution:
@@ -72,10 +80,20 @@ check_gh_scope() {
 }
 
 check_routing_block() {
-    # Resolve the git toplevel for the cwd. If we're not inside a git
-    # repo, the routing-block check is meaningless — skip silently.
+    # Per spec § 1.5.0 Inputs: $CLAUDE_PROJECT_DIR (defaults to $PWD)
+    # is the project root for the routing-block check. Resolve it first;
+    # then ask git for that directory's toplevel. If git cannot resolve
+    # a toplevel (CLAUDE_PROJECT_DIR is not inside a git repo), treat as
+    # outside-git and skip silently — exit 0 path stays valid.
+    local project_dir="${CLAUDE_PROJECT_DIR:-${PWD}}"
+
+    if [ ! -d "${project_dir}" ]; then
+        # Defensive: caller pointed at a non-existent path — skip.
+        return
+    fi
+
     local toplevel
-    if ! toplevel="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    if ! toplevel="$(git -C "${project_dir}" rev-parse --show-toplevel 2>/dev/null)"; then
         return
     fi
 

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -16,53 +16,134 @@
 #   $CLAUDE_PROJECT_DIR — project root for the routing-block check;
 #                         defaults to $PWD if unset.
 #   $HOME               — used implicitly by called tools.
+#   $1                  — optional `--machine` flag (default = human mode).
 #
-# Exit codes (per docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
-# § "Layer 1 dep check (§1.5.0)" and 0005-contracts/02-hook-contracts.md):
-#   0 — all dependencies present + routing block present
-#       (or no AGENTS.md / CLAUDE.md exists, in which case the routing
-#       check is skipped — the asymmetric "no file is fine, file without
-#       marker is not" rule keeps the dep check silent in repos that
-#       don't use these files at all). Also reached when
-#       $CLAUDE_PROJECT_DIR resolves to a non-git directory: outside-git
-#       means there is no project to validate, so the routing check is
-#       skipped.
-#   2 — required binary is NOT installed, OR AGENTS.md / CLAUDE.md
-#       exists but lacks the "## board-superpowers session routing"
-#       heading
-#   3 — required binary IS installed but a runtime invariant fails
-#       (e.g., `gh` exists but lacks the `project` / `read:project`
-#       scope, or `gh` is not authenticated)
+# --- Modes --------------------------------------------------------------
 #
-# Stdout: human-readable status banner suitable for hookSpecificOutput.additionalContext
+# HUMAN MODE (default; bash check-deps.sh):
+#   stdout — human-readable status banner suitable for hookSpecificOutput
+#            additionalContext when invoked from session-start.sh.
+#   exit 0 — all dependencies present + routing block present (or no
+#            AGENTS.md / CLAUDE.md exists, in which case the routing
+#            check is skipped — the asymmetric "no file is fine, file
+#            without marker is not" rule keeps the dep check silent in
+#            repos that don't use these files at all). Also reached
+#            when $CLAUDE_PROJECT_DIR resolves to a non-git directory.
+#   exit 2 — required binary is NOT installed, OR AGENTS.md / CLAUDE.md
+#            exists but lacks the "## board-superpowers session routing"
+#            heading.
+#   exit 3 — required binary IS installed but a runtime invariant fails
+#            (e.g., `gh` exists but lacks the `project` / `read:project`
+#            scope, or `gh` is not authenticated).
 #
-# Layer-classification rationale: a missing binary is a static
-# "install something" problem (exit 2 = caller can prompt the user to
-# install the dep). A binary present but unauthenticated/under-scoped is
-# a runtime invariant problem (exit 3 = caller can prompt the user to
-# re-authenticate). Card 2's hook uses these distinct codes to choose
-# between two different INVOKE markers; Card 1 establishes the contract.
+# MACHINE MODE (bash check-deps.sh --machine):
+#   exit 0 — ALWAYS. The output channel signals state, not the exit code,
+#            per docs/architecture/0005-contracts/01-script-contracts.md
+#            line 106.
+#   stdout — empty when everything is OK (callers test `-z`); otherwise
+#            exactly three LF-terminated lines:
+#                MISSING=<csv>
+#                ROUTING_INJECTED=<yes|no>
+#                PROJECT=<absolute path>
+#
+#   The keys MISSING / ROUTING_INJECTED / PROJECT are protocol — renaming
+#   any of them breaks hooks/session-start.sh's parser (per AGENTS.md
+#   change-impact matrix entry "Hook intent-injection marker grammar").
+#
+#   MISSING bucketing rule (per spec line 93 + Slice 2 contract):
+#     - tool absent from PATH (`command -v X` fails) → token = bare name
+#     - tool present but failing a runtime check (e.g., gh lacking
+#       project scope) → also token = bare name. The hook side sees
+#       `gh` flagged either way; the install-vs-reauth distinction is
+#       not surfaced through machine mode (human mode keeps it via
+#       the exit-code split).
+#
+#   ROUTING_INJECTED semantics (asymmetric skip, mirrors human-mode logic):
+#     yes — at least one of AGENTS.md / CLAUDE.md carries the heading
+#     yes — neither file exists (silent-skip, same rule as human mode)
+#     yes — $CLAUDE_PROJECT_DIR is not inside a git repo (skip semantics)
+#     no  — at least one file exists but neither carries the heading
+#
+#   PROJECT semantics: absolute path of $CLAUDE_PROJECT_DIR; resolved to
+#   the git toplevel when inside a repo, otherwise the directory as-is.
+#
+#   "Wrong" predicate (when machine mode emits the three lines):
+#     MISSING is non-empty OR ROUTING_INJECTED is `no`. Otherwise the
+#     stdout is empty so `[ -z "$output" ]` works in callers.
 
 set -euo pipefail
 
-# --- Failure tracking ---------------------------------------------------
-# Three independent counters — order of priority for exit-code resolution:
-#   MISSING_DEPS or MISSING_ROUTING -> exit 2
-#   else RUNTIME_FAILURES           -> exit 3
-#   else                            -> exit 0
+# --- Arg parsing --------------------------------------------------------
+
+MACHINE_MODE=0
+case "${1:-}" in
+    --machine)
+        MACHINE_MODE=1
+        ;;
+    "")
+        # No arg → human mode (default).
+        ;;
+    *)
+        printf 'check-deps.sh: unknown argument: %s (only --machine is supported)\n' "$1" >&2
+        exit 64  # EX_USAGE
+        ;;
+esac
+
+# --- State accumulators -------------------------------------------------
+# Both modes collect the same state; the bottom of the script picks an
+# emitter based on $MACHINE_MODE.
+#
+# Counters drive human-mode exit code resolution:
+#   MISSING_DEPS or MISSING_ROUTING → exit 2
+#   else RUNTIME_FAILURES           → exit 3
+#   else                            → exit 0
+#
+# MISSING_TOOLS collects the bare tool names (gh / python3 / git) that
+# are unusable, in stable detection order. Used by machine mode to build
+# the MISSING= csv. A tool failing a runtime check is recorded here too,
+# bucketed under the same bare name as a PATH miss.
 
 declare -i MISSING_DEPS=0
 declare -i MISSING_ROUTING=0
 declare -i RUNTIME_FAILURES=0
+MISSING_TOOLS=()
+
+# ROUTING_STATE: yes/no after check_routing_block runs. Default `yes`
+# (the silent-skip default — flipped to `no` only when a file exists
+# without the heading).
+ROUTING_STATE="yes"
+
+# PROJECT_PATH: absolute path of $CLAUDE_PROJECT_DIR, resolved to git
+# toplevel when applicable. Computed once, shared by both modes.
+PROJECT_PATH=""
+
+# Append a tool name to MISSING_TOOLS if not already present.
+record_missing_tool() {
+    local tool="${1:?}"
+    local existing
+    for existing in "${MISSING_TOOLS[@]:-}"; do
+        if [ "${existing}" = "${tool}" ]; then
+            return
+        fi
+    done
+    MISSING_TOOLS+=("${tool}")
+}
+
+# --- Checks -------------------------------------------------------------
 
 check_cmd() {
     local cmd="${1:?}"
     local hint="${2:-}"
     if command -v "${cmd}" >/dev/null 2>&1; then
-        printf '  ✓ %s\n' "${cmd}"
+        if [ "${MACHINE_MODE}" -eq 0 ]; then
+            printf '  ✓ %s\n' "${cmd}"
+        fi
     else
-        printf '  ✗ %s — MISSING (%s)\n' "${cmd}" "${hint}"
+        if [ "${MACHINE_MODE}" -eq 0 ]; then
+            printf '  ✗ %s — MISSING (%s)\n' "${cmd}" "${hint}"
+        fi
         MISSING_DEPS=$((MISSING_DEPS + 1))
+        record_missing_tool "${cmd}"
     fi
 }
 
@@ -72,19 +153,40 @@ check_gh_scope() {
     fi
     # gh auth status emits scopes on stderr; grep them.
     if gh auth status 2>&1 | grep -qE "'(read:project|project)'"; then
-        printf '  ✓ gh auth has project scope\n'
+        if [ "${MACHINE_MODE}" -eq 0 ]; then
+            printf '  ✓ gh auth has project scope\n'
+        fi
     else
-        printf '  ✗ gh auth missing project scope — run: gh auth refresh -s project,read:project\n'
+        if [ "${MACHINE_MODE}" -eq 0 ]; then
+            printf '  ✗ gh auth missing project scope — run: gh auth refresh -s project,read:project\n'
+        fi
         RUNTIME_FAILURES=$((RUNTIME_FAILURES + 1))
+        # Bucket under the bare tool name so the hook sees `gh` flagged
+        # whether the failure is install-time or runtime-time.
+        record_missing_tool "gh"
     fi
+}
+
+# Resolve PROJECT_PATH from $CLAUDE_PROJECT_DIR (or $PWD). Used by both
+# the routing check and machine-mode emission. If the dir is inside a
+# git repo, prefer the toplevel; otherwise use the dir as-is.
+resolve_project_path() {
+    local project_dir="${CLAUDE_PROJECT_DIR:-${PWD}}"
+    if [ -d "${project_dir}" ]; then
+        local toplevel
+        if toplevel="$(git -C "${project_dir}" rev-parse --show-toplevel 2>/dev/null)"; then
+            PROJECT_PATH="${toplevel}"
+            return
+        fi
+    fi
+    PROJECT_PATH="${project_dir}"
 }
 
 check_routing_block() {
     # Per spec § 1.5.0 Inputs: $CLAUDE_PROJECT_DIR (defaults to $PWD)
-    # is the project root for the routing-block check. Resolve it first;
-    # then ask git for that directory's toplevel. If git cannot resolve
-    # a toplevel (CLAUDE_PROJECT_DIR is not inside a git repo), treat as
-    # outside-git and skip silently — exit 0 path stays valid.
+    # is the project root for the routing-block check. If the resolved
+    # path is not a git repo, treat as outside-git and skip silently.
+    # ROUTING_STATE stays at its `yes` default (silent-skip semantics).
     local project_dir="${CLAUDE_PROJECT_DIR:-${PWD}}"
 
     if [ ! -d "${project_dir}" ]; then
@@ -98,8 +200,8 @@ check_routing_block() {
     fi
 
     # Asymmetric rule (per 05-bootstrap-surface.md):
-    #   - no AGENTS.md AND no CLAUDE.md → skipped (silent, exit 0 path)
-    #   - either file present without the heading → exit 2
+    #   - no AGENTS.md AND no CLAUDE.md → skipped (silent, ROUTING_STATE=yes)
+    #   - either file present without the heading → ROUTING_STATE=no
     # Detection is heading-presence only. Card 2 will tighten this to a
     # SHA-hash protocol; for v0.1.1 a literal heading match suffices.
     local agents="${toplevel}/AGENTS.md"
@@ -127,21 +229,52 @@ check_routing_block() {
     fi
 
     if [ "${saw_marker}" -eq 1 ]; then
-        printf '  ✓ board-superpowers routing block present\n'
+        if [ "${MACHINE_MODE}" -eq 0 ]; then
+            printf '  ✓ board-superpowers routing block present\n'
+        fi
     else
-        printf '  ✗ AGENTS.md / CLAUDE.md present but routing block missing\n'
+        if [ "${MACHINE_MODE}" -eq 0 ]; then
+            printf '  ✗ AGENTS.md / CLAUDE.md present but routing block missing\n'
+        fi
         MISSING_ROUTING=$((MISSING_ROUTING + 1))
+        ROUTING_STATE="no"
     fi
 }
 
-printf 'board-superpowers dependency check:\n'
+# --- Run checks (mode-agnostic) ----------------------------------------
+
+if [ "${MACHINE_MODE}" -eq 0 ]; then
+    printf 'board-superpowers dependency check:\n'
+fi
+
+resolve_project_path
 check_cmd gh "install via 'brew install gh'"
 check_cmd python3 "macOS / Linux ship python3 by default"
 check_cmd git "macOS ships git via Xcode CLT"
 check_gh_scope
 check_routing_block
 
-# --- Exit-code resolution ----------------------------------------------
+# --- Emitters -----------------------------------------------------------
+
+if [ "${MACHINE_MODE}" -eq 1 ]; then
+    # Machine mode: ALWAYS exit 0. Emit the three lines only when the
+    # "wrong" predicate trips (MISSING non-empty OR ROUTING_INJECTED=no).
+    # Build the MISSING csv from the collected tool list, preserving the
+    # detection order (gh, python3, git per check_cmd order).
+    missing_csv=""
+    if [ "${#MISSING_TOOLS[@]}" -gt 0 ]; then
+        IFS=',' missing_csv="${MISSING_TOOLS[*]}"
+    fi
+
+    if [ -n "${missing_csv}" ] || [ "${ROUTING_STATE}" = "no" ]; then
+        printf 'MISSING=%s\n' "${missing_csv}"
+        printf 'ROUTING_INJECTED=%s\n' "${ROUTING_STATE}"
+        printf 'PROJECT=%s\n' "${PROJECT_PATH}"
+    fi
+    exit 0
+fi
+
+# --- Human-mode exit-code resolution -----------------------------------
 # Priority: install-time failures (deps / routing block) outrank runtime
 # failures (auth / scope), because a fix-it prompt that says "install
 # the binary" is meaningless if the binary is already installed.

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -310,5 +310,5 @@ if [ "${RUNTIME_FAILURES}" -gt 0 ]; then
     exit 3
 fi
 
-printf '\nAll dependencies satisfied (board-superpowers v0.1.0-minimum).\n'
+printf '\nAll dependencies satisfied (board-superpowers v0.1.1).\n'
 exit 0

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -167,9 +167,28 @@ check_gh_scope() {
     fi
 }
 
+# Absolutize a path. Existing dir → physical absolute (resolves
+# symlinks via `pwd -P`). Non-existent or non-dir → cwd-joined when
+# relative, kept as-is when already absolute. Output ALWAYS starts
+# with `/` so the spec's `PROJECT=<absolute path>` invariant
+# (01-script-contracts.md line 93) holds in every branch.
+absolutize() {
+    local p="$1"
+    if [ -d "${p}" ]; then
+        (cd "${p}" 2>/dev/null && pwd -P) && return 0
+    fi
+    case "${p}" in
+        /*) printf '%s\n' "${p}" ;;
+        *)  printf '%s/%s\n' "$(pwd -P)" "${p}" ;;
+    esac
+}
+
 # Resolve PROJECT_PATH from $CLAUDE_PROJECT_DIR (or $PWD). Used by both
 # the routing check and machine-mode emission. If the dir is inside a
-# git repo, prefer the toplevel; otherwise use the dir as-is.
+# git repo, prefer the toplevel (already absolute — git rev-parse
+# returns a physical path); otherwise absolutize via `absolutize()` so
+# a relative CLAUDE_PROJECT_DIR like `../foo` never leaks into
+# machine-mode `PROJECT=` output.
 resolve_project_path() {
     local project_dir="${CLAUDE_PROJECT_DIR:-${PWD}}"
     if [ -d "${project_dir}" ]; then
@@ -179,7 +198,7 @@ resolve_project_path() {
             return
         fi
     fi
-    PROJECT_PATH="${project_dir}"
+    PROJECT_PATH="$(absolutize "${project_dir}")"
 }
 
 check_routing_block() {

--- a/scripts/claim-card.sh
+++ b/scripts/claim-card.sh
@@ -28,6 +28,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
+# shellcheck source-path=SCRIPTDIR
 . "${SCRIPT_DIR}/lib/common.sh"
 
 OWNER=""

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -331,20 +331,25 @@ bsp_worktree_path() {
 }
 
 # bsp_pick_worktree_dir [repo_root] — return BASE worktree dir (not
-# per-repo or per-branch). Three-priority resolution per ADR-0003:
+# per-repo or per-branch). Three-priority resolution per
+# docs/architecture/0005-contracts/07-path-conventions.md lines 51-58
+# and ADR-0003 § "Path resolution priority":
 #
 #   1. $BOARD_SP_WORKTREE_DIR (if set + non-empty)
-#   2. <repo_root>/.board-superpowers/config.yml `worktree_dir:` entry
-#      (only consulted when repo_root is supplied AND the config file
-#      exists). Parser is a simple regex grep — assumes the v1 simple-yaml
-#      convention: one key per line, no nesting at root, optional
-#      single/double quotes around the value.
+#   2. Project-local <repo_root>/.worktrees/ — only when the directory
+#      exists AND `git check-ignore -q .worktrees` (run from repo_root)
+#      returns 0, i.e. the path is gitignored. This protects against a
+#      stray .worktrees/ accidentally getting committed.
 #   3. Default: ${HOME}/.config/superpowers/worktrees
 #
 # This helper is RICHER than bsp_worktree_path (which honors only env +
 # default). bsp_worktree_path stays unchanged so existing callers
 # (claim-card.sh) keep working with their current `<repo> <branch>`
 # signature.
+#
+# NOTE: spec line 53 cites this helper as living in scripts/claim-card.sh;
+# it actually lives here in scripts/lib/common.sh (where reusable helpers
+# live). Spec drift to be reconciled in a later card.
 
 bsp_pick_worktree_dir() {
     local repo_root="${1:-}"
@@ -355,22 +360,15 @@ bsp_pick_worktree_dir() {
         return 0
     fi
 
-    # Priority 2: per-repo config.yml `worktree_dir:`.
-    if [ -n "${repo_root}" ]; then
-        local cfg="${repo_root}/.board-superpowers/config.yml"
-        if [ -f "${cfg}" ]; then
-            local val
-            val="$(
-                grep -E '^worktree_dir:[[:space:]]*' "${cfg}" \
-                    | head -n 1 \
-                    | sed -e 's/^worktree_dir:[[:space:]]*//' \
-                          -e 's/^"\(.*\)"$/\1/' \
-                          -e "s/^'\(.*\)'\$/\1/"
-            )" || val=""
-            if [ -n "${val}" ]; then
-                printf '%s\n' "${val}"
-                return 0
-            fi
+    # Priority 2: project-local <repo_root>/.worktrees/ when it exists
+    # AND is gitignored. `git check-ignore -q <path>` exits 0 iff the
+    # path matches a gitignore rule; non-zero otherwise (including when
+    # not in a git repo). Wrap in `2>/dev/null` to swallow git's stderr
+    # when invoked outside a repo.
+    if [ -n "${repo_root}" ] && [ -d "${repo_root}/.worktrees" ]; then
+        if (cd "${repo_root}" && git check-ignore -q .worktrees) 2>/dev/null; then
+            printf '%s\n' "${repo_root}/.worktrees"
+            return 0
         fi
     fi
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -34,19 +34,57 @@ bsp_plugin_root() {
     printf '%s\n' "${lib_dir%/scripts/lib}"
 }
 
+# --- Path normalization --------------------------------------------------
+#
+# Per docs/architecture/0005-contracts/07-path-conventions.md
+# § "Path-normalization rule for the per-repo sub-directory":
+#
+#   1. Strip leading "/".
+#   2. Replace remaining "/" with "-".
+#
+# Examples:
+#   /Users/foo/bar-baz                                  -> Users-foo-bar-baz
+#   /Users/panqiwei/Dev/repos/nemori-ai/board-superpowers
+#                                                       -> Users-panqiwei-Dev-repos-nemori-ai-board-superpowers
+#
+# Defensive: strip any trailing "/" first so a path like "/Users/foo/"
+# normalizes cleanly to "Users-foo" (instead of "Users-foo-").
+#
+# Input MUST be absolute (start with "/"); relative input is a usage
+# error that exits non-zero.
+
+bsp_normalize_repo_path() {
+    local p="${1:?usage: bsp_normalize_repo_path <abs-repo-root>}"
+    case "${p}" in
+        /*) ;;
+        *) bsp_die "bsp_normalize_repo_path: path must be absolute, got: ${p}" ;;
+    esac
+    # Strip trailing slash (defensive for "/Users/foo/" inputs).
+    p="${p%/}"
+    # Strip leading slash.
+    p="${p#/}"
+    # Replace remaining "/" with "-".
+    printf '%s\n' "${p//\//-}"
+}
+
 # --- Host-local + per-repo state paths ----------------------------------
 #
-# Per AGENTS.md Architecture-at-a-glance and ADR-0006 path conventions:
-#   ~/.board-superpowers/<host>/<repo>/state.yml         (host-local, not in git)
-#   <repo>/.board-superpowers/config.yml                  (per-repo, in git)
-#   ~/.board-superpowers/<host>/<repo>/audit-local.jsonl  (degraded audit)
+# Per AGENTS.md Architecture-at-a-glance + 07-path-conventions.md
+# "Per-host layout" (post-Card 1 normalized layout):
+#   ~/.board-superpowers/repos/<normalized>/state.yml         (host-local, not in git)
+#   ~/.board-superpowers/repos/<normalized>/audit-local.jsonl (degraded audit)
+#   <repo>/.board-superpowers/config.yml                       (per-repo, in git)
 #
-# For v1-minimum the (host, repo) tuple is derived from `gh repo view`.
+# <normalized> is computed from the repo's absolute path via
+# bsp_normalize_repo_path (above). All three helpers below take a
+# single <repo_root> argument and derive the canonical sub-directory
+# name internally.
 
 bsp_host_state_dir() {
-    local host="${1:?usage: bsp_host_state_dir <host> <repo>}"
-    local repo="${2:?usage: bsp_host_state_dir <host> <repo>}"
-    printf '%s/.board-superpowers/%s/%s\n' "${HOME}" "${host}" "${repo}"
+    local repo_root="${1:?usage: bsp_host_state_dir <repo_root>}"
+    local normalized
+    normalized="$(bsp_normalize_repo_path "${repo_root}")"
+    printf '%s/.board-superpowers/repos/%s\n' "${HOME}" "${normalized}"
 }
 
 bsp_repo_config_path() {
@@ -55,10 +93,9 @@ bsp_repo_config_path() {
 }
 
 bsp_audit_local_path() {
-    local host="${1:?usage: bsp_audit_local_path <host> <repo>}"
-    local repo="${2:?usage: bsp_audit_local_path <host> <repo>}"
+    local repo_root="${1:?usage: bsp_audit_local_path <repo_root>}"
     local dir
-    dir="$(bsp_host_state_dir "${host}" "${repo}")"
+    dir="$(bsp_host_state_dir "${repo_root}")"
     printf '%s/audit-local.jsonl\n' "${dir}"
 }
 
@@ -155,23 +192,110 @@ sys.exit(1)
 # --- Audit log degraded-mode writer --------------------------------------
 #
 # v1-minimum substitute for the auditing-actions skill's BYO-RDBMS write.
-# Appends one JSON line per action to the host-local audit-local.jsonl.
+# Appends one JSON line per action to the host-local audit-local.jsonl
+# at ~/.board-superpowers/repos/<normalized>/audit-local.jsonl.
 #
-# Args: <host> <repo> <action_id> <decision_class> <skill> <summary>
+# Args: <repo_root> <action_id> <decision_class> <skill> <summary>
 #
 # decision_class ∈ {A, R, N} (per ADR-0006 D-AUTONOMY-1).
 # action_id catalog lives inline in each v1-minimum molecular skill.
+#
+# Inline legacy migration:
+#   Before computing the new path, this function checks whether the
+#   canonical new path exists. If not, it scans the legacy
+#   ~/.board-superpowers/<host>/<repo>/audit-local.jsonl layout
+#   (excluding paths under ~/.board-superpowers/repos/) for a match.
+#
+#   Match heuristic:
+#     - The legacy path's last directory segment (the "<repo>" part)
+#       must equal the basename of the supplied <repo_root>.
+#     - On ambiguity (multiple matches), prefer the one whose
+#       grandparent segment (the "<host>" part) matches the
+#       owner slug parsed from `git -C <repo_root> remote get-url
+#       origin` (when the remote is reachable and parseable).
+#     - Fallback: basename-only match.
+#
+#   On match: mkdir -p the new directory and `mv` the legacy file
+#   to the new path. Subsequent calls see the new path exists and
+#   skip the migration scan entirely (idempotent).
+#
+#   On no match: no migration; just create the new path and append.
 
 bsp_audit_local_write() {
-    local host="${1:?usage: bsp_audit_local_write <host> <repo> <action_id> <class> <skill> <summary>}"
-    local repo="${2:?}"
-    local action_id="${3:?}"
-    local decision="${4:?}"
-    local skill="${5:?}"
-    local summary="${6:?}"
+    local repo_root="${1:?usage: bsp_audit_local_write <repo_root> <action_id> <class> <skill> <summary>}"
+    local action_id="${2:?}"
+    local decision="${3:?}"
+    local skill="${4:?}"
+    local summary="${5:?}"
 
     local path
-    path="$(bsp_audit_local_path "${host}" "${repo}")"
+    path="$(bsp_audit_local_path "${repo_root}")"
+
+    # --- Legacy migration (one-shot, idempotent) -------------------------
+    if [ ! -f "${path}" ]; then
+        local legacy_root="${HOME}/.board-superpowers"
+        local repo_basename
+        repo_basename="$(basename "${repo_root}")"
+        local legacy_match=""
+
+        if [ -d "${legacy_root}" ]; then
+            # Try owner-aware match first when origin remote is parseable.
+            local owner_slug=""
+            if command -v git >/dev/null 2>&1; then
+                local origin_url
+                origin_url="$(git -C "${repo_root}" remote get-url origin 2>/dev/null || true)"
+                if [ -n "${origin_url}" ]; then
+                    # Strip protocol + host: works for https://github.com/owner/repo(.git)
+                    # and git@github.com:owner/repo(.git).
+                    local trimmed="${origin_url}"
+                    trimmed="${trimmed%.git}"
+                    trimmed="${trimmed##*github.com[:/]}"
+                    trimmed="${trimmed##*/}"  # noop fallback if pattern didn't match
+                    # Re-parse: take the segment immediately after github.com[:/]
+                    case "${origin_url}" in
+                        *github.com[:/]*)
+                            trimmed="${origin_url##*github.com}"
+                            trimmed="${trimmed#:}"
+                            trimmed="${trimmed#/}"
+                            owner_slug="${trimmed%%/*}"
+                            ;;
+                    esac
+                fi
+            fi
+
+            # Scan legacy paths. Skip the new "repos/" subtree.
+            local candidate
+            for candidate in "${legacy_root}"/*/*/audit-local.jsonl; do
+                [ -f "${candidate}" ] || continue
+                # Path layout: <legacy_root>/<host>/<repo>/audit-local.jsonl
+                local cand_dir host_seg repo_seg
+                cand_dir="$(dirname "${candidate}")"
+                repo_seg="$(basename "${cand_dir}")"
+                host_seg="$(basename "$(dirname "${cand_dir}")")"
+                # Skip the new layout root.
+                [ "${host_seg}" = "repos" ] && continue
+                # Basename match required.
+                [ "${repo_seg}" = "${repo_basename}" ] || continue
+                # Strong match: host_seg equals owner_slug.
+                if [ -n "${owner_slug}" ] && [ "${host_seg}" = "${owner_slug}" ]; then
+                    legacy_match="${candidate}"
+                    break
+                fi
+                # Otherwise remember the first basename match as fallback.
+                if [ -z "${legacy_match}" ]; then
+                    legacy_match="${candidate}"
+                fi
+            done
+        fi
+
+        if [ -n "${legacy_match}" ]; then
+            mkdir -p "$(dirname "${path}")"
+            mv "${legacy_match}" "${path}"
+            bsp_log "audit-local: migrated legacy file ${legacy_match} → ${path}"
+        fi
+    fi
+    # --- End migration ---------------------------------------------------
+
     mkdir -p "$(dirname "${path}")"
 
     bsp_require_cmd python3
@@ -179,17 +303,16 @@ bsp_audit_local_write() {
 import json, sys, time
 entry = {
     'ts': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
-    'host': sys.argv[1],
-    'repo': sys.argv[2],
-    'action_id': sys.argv[3],
-    'decision_class': sys.argv[4],
-    'skill': sys.argv[5],
-    'summary': sys.argv[6],
+    'repo_root': sys.argv[1],
+    'action_id': sys.argv[2],
+    'decision_class': sys.argv[3],
+    'skill': sys.argv[4],
+    'summary': sys.argv[5],
     'mode': 'v1-minimum-degraded',
 }
-with open(sys.argv[7], 'a') as f:
+with open(sys.argv[6], 'a') as f:
     f.write(json.dumps(entry) + '\n')
-" "${host}" "${repo}" "${action_id}" "${decision}" "${skill}" "${summary}" "${path}"
+" "${repo_root}" "${action_id}" "${decision}" "${skill}" "${summary}" "${path}"
 
     bsp_log "audit-local: ${decision}-class action ${action_id} (${skill}) → ${path}"
 }
@@ -205,6 +328,54 @@ bsp_worktree_path() {
     local branch="${2:?usage: bsp_worktree_path <repo> <branch>}"
     local base="${BOARD_SP_WORKTREE_DIR:-${HOME}/.config/superpowers/worktrees}"
     printf '%s/%s/%s\n' "${base}" "${repo}" "${branch}"
+}
+
+# bsp_pick_worktree_dir [repo_root] — return BASE worktree dir (not
+# per-repo or per-branch). Three-priority resolution per ADR-0003:
+#
+#   1. $BOARD_SP_WORKTREE_DIR (if set + non-empty)
+#   2. <repo_root>/.board-superpowers/config.yml `worktree_dir:` entry
+#      (only consulted when repo_root is supplied AND the config file
+#      exists). Parser is a simple regex grep — assumes the v1 simple-yaml
+#      convention: one key per line, no nesting at root, optional
+#      single/double quotes around the value.
+#   3. Default: ${HOME}/.config/superpowers/worktrees
+#
+# This helper is RICHER than bsp_worktree_path (which honors only env +
+# default). bsp_worktree_path stays unchanged so existing callers
+# (claim-card.sh) keep working with their current `<repo> <branch>`
+# signature.
+
+bsp_pick_worktree_dir() {
+    local repo_root="${1:-}"
+
+    # Priority 1: env var.
+    if [ -n "${BOARD_SP_WORKTREE_DIR:-}" ]; then
+        printf '%s\n' "${BOARD_SP_WORKTREE_DIR}"
+        return 0
+    fi
+
+    # Priority 2: per-repo config.yml `worktree_dir:`.
+    if [ -n "${repo_root}" ]; then
+        local cfg="${repo_root}/.board-superpowers/config.yml"
+        if [ -f "${cfg}" ]; then
+            local val
+            val="$(
+                grep -E '^worktree_dir:[[:space:]]*' "${cfg}" \
+                    | head -n 1 \
+                    | sed -e 's/^worktree_dir:[[:space:]]*//' \
+                          -e 's/^"\(.*\)"$/\1/' \
+                          -e "s/^'\(.*\)'\$/\1/"
+            )" || val=""
+            if [ -n "${val}" ]; then
+                printf '%s\n' "${val}"
+                return 0
+            fi
+        fi
+    fi
+
+    # Priority 3: default.
+    printf '%s\n' "${HOME}/.config/superpowers/worktrees"
 }
 
 # --- Card slug helper ----------------------------------------------------

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -200,6 +200,16 @@ sys.exit(1)
 # decision_class ∈ {A, R, N} (per ADR-0006 D-AUTONOMY-1).
 # action_id catalog lives inline in each v1-minimum molecular skill.
 #
+# Concurrency: writes use Python's open(path, 'a') which on POSIX
+# uses O_APPEND. Single-line writes under PIPE_BUF (4096 bytes;
+# audit lines are ~200) are atomic at the kernel level — multiple
+# concurrent writers do not interleave. Migration mv is race-tolerant
+# (see body).
+#
+# Schema: a migrated audit-local.jsonl can contain both legacy entries
+# (with `host` + `repo` fields, mode=v1-minimum-degraded) and new
+# entries (with `repo_root` field). Future readers must handle both.
+#
 # Inline legacy migration:
 #   Before computing the new path, this function checks whether the
 #   canonical new path exists. If not, it scans the legacy
@@ -217,7 +227,10 @@ sys.exit(1)
 #
 #   On match: mkdir -p the new directory and `mv` the legacy file
 #   to the new path. Subsequent calls see the new path exists and
-#   skip the migration scan entirely (idempotent).
+#   skip the migration scan entirely (idempotent). The mv is
+#   race-tolerant: if another concurrent process beat us to the
+#   migration (legacy gone, new now exists), we proceed without
+#   error; the appended line lands on the canonical new path.
 #
 #   On no match: no migration; just create the new path and append.
 
@@ -290,8 +303,18 @@ bsp_audit_local_write() {
 
         if [ -n "${legacy_match}" ]; then
             mkdir -p "$(dirname "${path}")"
-            mv "${legacy_match}" "${path}"
-            bsp_log "audit-local: migrated legacy file ${legacy_match} → ${path}"
+            # Race-tolerant migration: another concurrent writer may
+            # have beaten us to the mv between our [ ! -f "${path}" ]
+            # check above and now. When that happens the mv fails
+            # because the legacy source is gone; the canonical new
+            # path is already in place, so we proceed normally.
+            if mv "${legacy_match}" "${path}" 2>/dev/null; then
+                bsp_log "audit-local: migrated legacy file ${legacy_match} → ${path}"
+            elif [ -f "${path}" ]; then
+                bsp_log "audit-local: migration was completed by another process — proceeding"
+            else
+                bsp_warn "audit-local: migration mv failed and new path absent — falling through to fresh write"
+            fi
         fi
     fi
     # --- End migration ---------------------------------------------------
@@ -354,10 +377,25 @@ bsp_worktree_path() {
 bsp_pick_worktree_dir() {
     local repo_root="${1:-}"
 
-    # Priority 1: env var.
+    # Priority 1: env var. MUST be absolute (start with "/"). All
+    # priority levels are contractually absolute (priority 2 inherits
+    # absoluteness from <repo_root>; priority 3 derives from $HOME).
+    # A relative env value would silently break audit-log writes and
+    # other path consumers. Per spec lines 51-58 (07-path-conventions.md).
+    #
+    # Recovery: warn to stderr and fall through to priority 2/3 instead
+    # of hard-fail — env var is user-set, a typo shouldn't break the
+    # session; the warning preserves visibility.
     if [ -n "${BOARD_SP_WORKTREE_DIR:-}" ]; then
-        printf '%s\n' "${BOARD_SP_WORKTREE_DIR}"
-        return 0
+        case "${BOARD_SP_WORKTREE_DIR}" in
+            /*)
+                printf '%s\n' "${BOARD_SP_WORKTREE_DIR}"
+                return 0
+                ;;
+            *)
+                bsp_warn "BOARD_SP_WORKTREE_DIR=${BOARD_SP_WORKTREE_DIR} is not absolute, ignoring; falling through"
+                ;;
+        esac
     fi
 
     # Priority 2: project-local <repo_root>/.worktrees/ when it exists

--- a/scripts/read-board.sh
+++ b/scripts/read-board.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
+# shellcheck source-path=SCRIPTDIR
 . "${SCRIPT_DIR}/lib/common.sh"
 
 OWNER=""

--- a/scripts/register-codex-hooks.sh
+++ b/scripts/register-codex-hooks.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
+# shellcheck source-path=SCRIPTDIR
 . "${SCRIPT_DIR}/lib/common.sh"
 
 PLUGIN_ROOT="$(bsp_plugin_root)"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,18 +1,40 @@
 #!/usr/bin/env bash
-# scripts/setup-labels.sh — create the 4 standard board-superpowers labels.
+# scripts/setup-labels.sh — create the 13 standard board-superpowers labels
+# (4 ops + 9 type+size).
 #
 # Run once per repo after installing the plugin. Idempotent — labels that
-# already exist are skipped (gh prints a warning).
+# already exist are skipped (detected via `gh label list`).
 #
 # Why this exists: GitHub labels are a per-repo resource that the plugin
 # can't auto-create at install time (no plugin-level setup hook on either
 # CC or Codex). This script does the one-shot create.
 #
-# Standard labels:
-#   wip-override          — claim past WIP cap (Producer-applied)
-#   suspended             — card paused mid-work, still counts toward WIP
-#   security              — triggers gstack:/cso review on PR submit
-#   pr-contract-override  — bypass three-section validation on PR
+# Standard labels (per docs/architecture/0005-contracts/05-github-artifact-schemas.md
+# § "Standard label set"):
+#
+#   Ops (4):
+#     wip-override          — claim past WIP cap (Producer-applied)
+#     suspended             — card paused mid-work, still counts toward WIP
+#     security              — triggers gstack:/cso review on PR submit
+#     pr-contract-override  — bypass three-section validation on PR
+#
+#   Type (5):
+#     type:feature          — A new user-visible capability
+#     type:bug              — A defect in existing behavior
+#     type:chore            — Non-code or infra work (deps, rename, config)
+#     type:refactor         — Internal restructuring with no behavior change
+#     type:epic             — A container for several vertical-slice cards
+#
+#   Size (4):
+#     size:XS               — Under 50 LOC / 1-2 files
+#     size:S                — 50-200 LOC / 2-5 files
+#     size:M                — 200-400 LOC / 5-10 files
+#     size:L                — 400-500 LOC / up to 10 files (ceiling)
+#
+# Rate-limit note: a 100ms sleep follows each successful create call to
+# defend against GitHub's secondary-rate-limit on cold-start when all 13
+# labels need creating in a row. Skipped labels (already present) do NOT
+# pause — only created ones do.
 #
 # Usage:
 #   bash scripts/setup-labels.sh                    # in current repo
@@ -21,7 +43,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/common.sh
+# shellcheck source=scripts/lib/common.sh
 . "${SCRIPT_DIR}/lib/common.sh"
 
 REPO_ARG=""
@@ -36,6 +58,7 @@ create_label() {
     local name="$1"
     local color="$2"
     local description="$3"
+    # shellcheck disable=SC2086  # REPO_ARG intentionally unquoted for splitting
     if gh label list ${REPO_ARG} --json name 2>/dev/null \
         | python3 -c "import json,sys; print('\n'.join(l['name'] for l in json.load(sys.stdin)))" \
         | grep -Fx "${name}" >/dev/null 2>&1; then
@@ -44,12 +67,30 @@ create_label() {
         # shellcheck disable=SC2086  # REPO_ARG intentionally unquoted for splitting
         gh label create "${name}" --color "${color}" --description "${description}" ${REPO_ARG}
         bsp_log "created label '${name}'"
+        # Defend against GitHub secondary-rate-limit on cold-start when all
+        # 13 labels need creating back-to-back. 100ms is the conservative
+        # floor; only the create path pauses (skips do not).
+        sleep 0.1
     fi
 }
 
+# Ops labels (4) — preserved from v0.1.0-minimum, untouched.
 create_label "wip-override"         "FBCA04" "Allows Consumer to claim past WIP cap"
 create_label "suspended"            "D4C5F9" "Card paused mid-work; still counts toward WIP"
 create_label "security"             "B60205" "Triggers gstack:/cso security review on PR submit"
 create_label "pr-contract-override" "C5DEF5" "Bypass PR three-section validation"
 
-bsp_log "done — 4 standard labels are present"
+# Type labels (5) — per spec table § "Type labels".
+create_label "type:feature"         "0e8a16" "A new user-visible capability"
+create_label "type:bug"             "d73a4a" "A defect in existing behavior"
+create_label "type:chore"           "c5def5" "Non-code or infra work (deps, rename, config)"
+create_label "type:refactor"        "fbca04" "Internal restructuring with no behavior change"
+create_label "type:epic"            "5319e7" "A container for several vertical-slice cards"
+
+# Size labels (4) — per spec table § "Size labels".
+create_label "size:XS"              "cccccc" "Under 50 LOC / 1-2 files"
+create_label "size:S"               "b0bec5" "50-200 LOC / 2-5 files"
+create_label "size:M"               "607d8b" "200-400 LOC / 5-10 files"
+create_label "size:L"               "455a64" "400-500 LOC / up to 10 files (ceiling — split if bigger)"
+
+bsp_log "done — 13 standard labels are present"

--- a/scripts/submit-pr.sh
+++ b/scripts/submit-pr.sh
@@ -105,7 +105,7 @@ trap 'rm -f "${TMP_BODY}"' EXIT
 cp "${BODY_FILE}" "${TMP_BODY}"
 {
     printf '\n\n---\n'
-    printf 'Closes #%s — board-superpowers v0.1.0-minimum claim trailer.\n' "${CARD}"
+    printf 'Closes #%s — board-superpowers v0.1.1 claim trailer.\n' "${CARD}"
 } >> "${TMP_BODY}"
 
 # --- Open the PR ---------------------------------------------------------

--- a/scripts/submit-pr.sh
+++ b/scripts/submit-pr.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
+# shellcheck source-path=SCRIPTDIR
 . "${SCRIPT_DIR}/lib/common.sh"
 
 TITLE=""

--- a/scripts/verify-skill-frontmatter.sh
+++ b/scripts/verify-skill-frontmatter.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
+# shellcheck source-path=SCRIPTDIR
 . "${SCRIPT_DIR}/lib/common.sh"
 
 PLUGIN_ROOT="$(bsp_plugin_root)"

--- a/scripts/verify-skill-metadata.sh
+++ b/scripts/verify-skill-metadata.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
+# shellcheck source-path=SCRIPTDIR
 . "${SCRIPT_DIR}/lib/common.sh"
 
 PLUGIN_ROOT="$(bsp_plugin_root)"

--- a/skills/board-canon/SKILL.md
+++ b/skills/board-canon/SKILL.md
@@ -21,7 +21,7 @@ This skill is the schema authority for the board-superpowers plugin. It answers 
 
 ## State machine
 
-A card lives in **exactly one** of six Status field values at any moment. Every transition writes one entry to the plugin's audit log (a local JSON-lines file at `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`).
+A card lives in **exactly one** of six Status field values at any moment. Every transition writes one entry to the plugin's audit log (a local JSON-lines file at `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`).
 
 ```
 Backlog ─────► Ready ─────► In Progress ─────► In Review ─────► Done
@@ -83,7 +83,7 @@ Every Card body MUST have this structure. Sections appear in this order. The Pro
 <free-form context the Consumer will need; design rationale; gotchas>
 
 <!-- bsp-bottom-marker:do-not-edit -->
-**Audit trail**: query ~/.board-superpowers/<host>/<repo>/audit-local.jsonl by `card_number = N`.
+**Audit trail**: query ~/.board-superpowers/repos/<normalized>/audit-local.jsonl by `card_number = N`.
 <!-- /bsp-bottom-marker -->
 ```
 

--- a/skills/board-canon/evals/evals.json
+++ b/skills/board-canon/evals/evals.json
@@ -30,7 +30,7 @@
     {
       "id": 5,
       "prompt": "What's the mandatory bottom marker block in a Card body for?",
-      "expected_output": "Auto-generated audit-trail pointer block — bsp-bottom-marker:do-not-edit. Hand edits are rejected by enforcing-pr-contract. Producer's tooling owns this block; it points at the audit log file at ~/.board-superpowers/<host>/<repo>/audit-local.jsonl.",
+      "expected_output": "Auto-generated audit-trail pointer block — bsp-bottom-marker:do-not-edit. Hand edits are rejected by enforcing-pr-contract. Producer's tooling owns this block; it points at the audit log file at ~/.board-superpowers/repos/<normalized>/audit-local.jsonl.",
       "files": []
     }
   ]

--- a/skills/board-canon/references/state-machine.md
+++ b/skills/board-canon/references/state-machine.md
@@ -2,7 +2,7 @@
 
 Per-transition checklist that the parent `SKILL.md` § "State machine" points at.
 
-Every transition writes one entry to the audit log at `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`. Helper: `bsp_audit_local_write` from `scripts/lib/common.sh`.
+Every transition writes one entry to the audit log at `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`. Helper: `bsp_audit_local_write` from `scripts/lib/common.sh`.
 
 ## Backlog → Ready
 

--- a/skills/consuming-card/SKILL.md
+++ b/skills/consuming-card/SKILL.md
@@ -167,7 +167,7 @@ Every mutating action this skill performs (Status flips, card body writes, PR cr
 1. **Propose** the action with a one-line description.
 2. **Wait** for explicit architect acknowledgement.
 3. **Act**.
-4. **Append an audit-log entry** to `~/.board-superpowers/<host>/<repo>/audit-local.jsonl` via `bsp_audit_local_write` (defined in `scripts/lib/common.sh`).
+4. **Append an audit-log entry** to `~/.board-superpowers/repos/<normalized>/audit-local.jsonl` via `bsp_audit_local_write` (defined in `scripts/lib/common.sh`).
 
 Some actions may be classified as auto-act-OK by per-repo or per-user override rules in `.board-superpowers/config.yml`; until those overrides are configured, treat every action as requiring acknowledgement.
 

--- a/skills/managing-board/SKILL.md
+++ b/skills/managing-board/SKILL.md
@@ -55,7 +55,7 @@ Goal: produce a one-screen briefing of the board's current state that helps the 
    - "Claim a Ready card" (if `Ready` count > 0 and the Producer wants to context-switch into Consumer mode)
    - "Run intake" (if all the above are empty — the board is idle)
 
-5. **Audit-log entry**. Append one line to `~/.board-superpowers/<host>/<repo>/audit-local.jsonl` recording that the daily routine ran (helper: `bsp_audit_local_write` from `scripts/lib/common.sh`).
+5. **Audit-log entry**. Append one line to `~/.board-superpowers/repos/<normalized>/audit-local.jsonl` recording that the daily routine ran (helper: `bsp_audit_local_write` from `scripts/lib/common.sh`).
 
 `references/daily.md` covers the empty-board case, single-Consumer projects, stale-claim detection mechanics, and tone notes.
 
@@ -114,6 +114,6 @@ Every mutating action this skill performs (Status flips, card body writes, PR co
 1. **Propose** the action to the architect with a one-line description.
 2. **Wait** for explicit acknowledgement.
 3. **Act**.
-4. **Append an audit-log entry** to `~/.board-superpowers/<host>/<repo>/audit-local.jsonl` via `bsp_audit_local_write` (defined in `scripts/lib/common.sh`).
+4. **Append an audit-log entry** to `~/.board-superpowers/repos/<normalized>/audit-local.jsonl` via `bsp_audit_local_write` (defined in `scripts/lib/common.sh`).
 
 Some actions may be classified as auto-act-OK by per-repo or per-user override rules in `.board-superpowers/config.yml`; until those overrides are configured, treat every action as requiring acknowledgement.

--- a/tests/audit-local-migration.sh
+++ b/tests/audit-local-migration.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# tests/audit-local-migration.sh — assert bsp_audit_local_write
+# performs the legacy → new path migration per Card 1 Phase D Slice 4c.
+#
+# Migration heuristic:
+#   - When new path (~/.board-superpowers/repos/<normalized>/audit-local.jsonl)
+#     does not exist, scan ~/.board-superpowers/*/*/audit-local.jsonl
+#     (legacy <host>/<repo> layout) and pick the file whose owning
+#     directory's basename matches basename of <repo_root>. If multiple
+#     match, prefer the one whose owning-grandparent matches the GitHub
+#     org slug derivable from `git remote get-url origin`. Fallback:
+#     basename only.
+#   - On match: mkdir -p new dir, mv legacy → new; subsequent calls
+#     see new path exists and skip detection (idempotent).
+#   - On no match: do not migrate; just create new path and append.
+#
+# Hermeticity: every scenario uses a fresh tmp HOME and a fresh tmp
+# repo_root; nothing touches the real ~/.board-superpowers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMMON_SH="${PLUGIN_ROOT}/scripts/lib/common.sh"
+
+if [ ! -f "${COMMON_SH}" ]; then
+    printf 'FATAL: %s not found\n' "${COMMON_SH}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+# check <label> <cmd...> — run cmd; PASS on exit 0, FAIL otherwise.
+# Avoids SC2319 (condition $? capture) and SC2251 (! masking errexit) by
+# never relying on the test's own $? after the conditional executes.
+check() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# check_not <label> <cmd...> — inverse: PASS when cmd fails.
+check_not() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Helpers for line-count checks (avoids inline arithmetic in callers).
+file_line_count() {
+    local f="$1"
+    [ -f "${f}" ] || { printf '0\n'; return 0; }
+    wc -l < "${f}" | tr -d ' '
+}
+
+count_eq() {
+    local f="$1"
+    local expected="$2"
+    [ "$(file_line_count "${f}")" = "${expected}" ]
+}
+
+# normalize_path: bash port of bsp_normalize_repo_path for test setup.
+# Tests verify the helper itself in tests/common-helpers.sh; here we
+# only need a normalized name to assert paths.
+normalize_path() {
+    local p="$1"
+    p="${p#/}"
+    p="${p%/}"
+    p="${p//\//-}"
+    printf '%s' "${p}"
+}
+
+run_audit_write() {
+    local home="$1"; shift
+    local repo_root="$1"; shift
+    # Args: <action_id> <decision> <skill> <summary>
+    bash -c "
+        set -euo pipefail
+        export HOME='${home}'
+        source '${COMMON_SH}'
+        bsp_audit_local_write '${repo_root}' '$1' '$2' '$3' '$4'
+    " >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: migration triggers when legacy file exists and new doesn't
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: migration triggers (legacy exists, new does not)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/board-superpowers/audit-local.jsonl"
+printf '{"ts":"old","action_id":"100"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '100' 'R' 'managing-board' 'first-write'
+
+# Legacy file gone (moved)
+check_not 'legacy file moved (no longer at old path)' test -f "${LEGACY_FILE}"
+
+# New file exists with both old line + new line
+check 'new file exists at canonical path' test -f "${NEW_FILE}"
+
+check 'new file contains both legacy + new entries (2 lines)' \
+    count_eq "${NEW_FILE}" 2
+
+# Verify legacy content preserved
+check 'legacy entry preserved in migrated file' \
+    grep -q '"ts":"old"' "${NEW_FILE}"
+
+# Verify new entry appended
+check 'new entry appended after migration' \
+    grep -q '"action_id": "100"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: no migration when new path already exists
+# ---------------------------------------------------------------------------
+printf 'Scenario 2: no migration when new file already exists\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+
+# Seed both legacy AND new
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/board-superpowers/audit-local.jsonl"
+printf '{"ts":"legacy-untouched"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+mkdir -p "$(dirname "${NEW_FILE}")"
+printf '{"ts":"already-migrated"}\n' > "${NEW_FILE}"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '101' 'R' 'managing-board' 'second-write'
+
+# Legacy still there, untouched
+check 'legacy file untouched when new already exists' \
+    test -f "${LEGACY_FILE}"
+
+check 'legacy file size unchanged' count_eq "${LEGACY_FILE}" 1
+
+# New has the pre-existing line + new line
+check 'new file got the new entry appended' count_eq "${NEW_FILE}" 2
+
+check 'pre-existing migrated content preserved' \
+    grep -q '"ts":"already-migrated"' "${NEW_FILE}"
+
+check 'new entry appended to existing new file' \
+    grep -q '"action_id": "101"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: no legacy match → no migration
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: unrelated legacy file → no migration\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+
+# Seed unrelated legacy file (different repo basename)
+mkdir -p "${HOME_DIR}/.board-superpowers/host/some-other-repo"
+UNRELATED="${HOME_DIR}/.board-superpowers/host/some-other-repo/audit-local.jsonl"
+printf '{"ts":"unrelated"}\n' > "${UNRELATED}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '102' 'R' 'managing-board' 'fresh'
+
+# Unrelated legacy untouched
+check 'unrelated legacy file untouched (no basename match)' \
+    test -f "${UNRELATED}"
+
+# New file created with single new entry
+check 'new file created at canonical path' test -f "${NEW_FILE}"
+
+check 'new file has single entry (no prepended legacy)' \
+    count_eq "${NEW_FILE}" 1
+
+check 'new entry written' \
+    grep -q '"action_id": "102"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: repeat call after migration is no-op for migration logic
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: repeat call is migration no-op (idempotent)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/board-superpowers/audit-local.jsonl"
+printf '{"ts":"original"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+# First write triggers migration
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '103' 'R' 'mgr' 'first'
+
+# Second write: legacy is gone, new exists; should NOT re-look for legacy
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '104' 'R' 'mgr' 'second'
+
+# Third write: same
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '105' 'R' 'mgr' 'third'
+
+# 1 legacy + 3 new = 4 lines
+check 'subsequent writes append without re-migration (4 lines)' \
+    count_eq "${NEW_FILE}" 4
+
+# Re-create a stale legacy: simulate accidental reappearance.
+# This SHOULD NOT be re-migrated, because new exists.
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+printf '{"ts":"stray"}\n' > "${LEGACY_FILE}"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '106' 'R' 'mgr' 'fourth'
+
+# Stray legacy still there (unmoved)
+check 'stray legacy not re-migrated (new path already canonical)' \
+    test -f "${LEGACY_FILE}"
+
+check 'fourth write appended cleanly (5 lines)' \
+    count_eq "${NEW_FILE}" 5
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: JSON line shape — drops host/repo, adds repo_root
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: JSON entry shape after signature change\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/some-app"
+mkdir -p "${REPO_ROOT}"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '200' 'A' 'managing-board' 'shape-check'
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+check 'audit file created' test -f "${NEW_FILE}"
+
+# repo_root field present
+check 'repo_root field present' \
+    grep -Fq "\"repo_root\": \"${REPO_ROOT}\"" "${NEW_FILE}"
+
+# host / repo fields absent
+check_not 'no separate host field' \
+    grep -q '"host":' "${NEW_FILE}"
+
+check_not 'no separate repo field' \
+    grep -q '"repo":' "${NEW_FILE}"
+
+# action_id, decision_class, skill, summary, mode, ts still present
+check 'action_id preserved' \
+    grep -q '"action_id": "200"' "${NEW_FILE}"
+
+check 'decision_class preserved' \
+    grep -q '"decision_class": "A"' "${NEW_FILE}"
+
+check 'mode field preserved' \
+    grep -q '"mode": "v1-minimum-degraded"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/audit-local-migration.sh
+++ b/tests/audit-local-migration.sh
@@ -172,6 +172,94 @@ check 'new entry appended to existing new file' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
+# Scenario 2b: race tolerance — both legacy AND new path exist before invoke
+# ---------------------------------------------------------------------------
+# Differs from Scenario 2 in intent. Scenario 2 asserts: "when new exists,
+# don't even look at legacy" (the migration block is skipped wholesale —
+# legacy stays untouched). Scenario 2b simulates the narrow race window
+# where this writer's earlier `[ ! -f "${path}" ]` check passed, then
+# another concurrent writer migrated, then we got the cpu and tried to
+# `mv legacy → new`. The mv should fail-but-tolerated; the appended line
+# still lands on the canonical new path; no error escapes.
+#
+# Hard to deterministically simulate the in-flight race in a test harness,
+# so we approximate by pre-populating BOTH paths to the state the racer
+# would leave behind. The first call's `[ ! -f "${path}" ]` check will
+# evaluate against the new path; if it sees new exists, the migration
+# block is skipped and we get Scenario 2 behavior. To genuinely exercise
+# the mv race-tolerance branch we need the migration block to enter, then
+# fail. We do that by making the new path NOT exist when bsp_audit_local_write
+# starts, then watch behavior when legacy disappears mid-flight: in real
+# systems this is the racer beating us. In the test harness the mv simply
+# fails (legacy actually present, but if we delete legacy between the
+# scan loop and the mv, it errors). Practical assertion below:
+#   - both files seeded → outer `[ ! -f "${path}" ]` is false, migration
+#     block is skipped, we hit the append directly. New path receives the
+#     new entry; legacy untouched. This already covers Scenario 2.
+#   - The race-tolerance branch fires when an external writer races us
+#     between the existence check and the mv. Mocking that needs a
+#     coprocess; out of scope for a single-file bash test.
+#
+# Concrete behavior we CAN assert: bsp_audit_local_write must not ERROR
+# when both paths happen to exist at function-entry time. Asserting
+# error-free completion + correct append covers the externally observable
+# guarantee.
+printf 'Scenario 2b: race tolerance — both paths seeded, no error, append succeeds\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/board-superpowers/audit-local.jsonl"
+printf '{"ts":"legacy-pre-race"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+mkdir -p "$(dirname "${NEW_FILE}")"
+printf '{"ts":"new-pre-race"}\n' > "${NEW_FILE}"
+
+# Run with stderr captured separately so we can fail loud on errors.
+RUN_ERR="$(mktemp)"
+set +e
+bash -c "
+    set -euo pipefail
+    export HOME='${HOME_DIR}'
+    source '${COMMON_SH}'
+    bsp_audit_local_write '${REPO_ROOT}' '199' 'R' 'managing-board' 'race-tolerant'
+" >/dev/null 2>"${RUN_ERR}"
+RC=$?
+set -e
+
+if [ "${RC}" = "0" ]; then
+    printf '  PASS — bsp_audit_local_write succeeded with both paths present (rc=0)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL — bsp_audit_local_write errored (rc=%s). stderr:\n%s\n' \
+        "${RC}" "$(cat "${RUN_ERR}")" >&2
+    FAIL=$((FAIL + 1))
+fi
+rm -f "${RUN_ERR}"
+
+# Append landed on new path (was 1 line, now 2).
+check 'race scenario: append landed on canonical new path' \
+    count_eq "${NEW_FILE}" 2
+
+check 'race scenario: pre-existing new entry preserved' \
+    grep -q '"ts":"new-pre-race"' "${NEW_FILE}"
+
+check 'race scenario: new entry written' \
+    grep -q '"action_id": "199"' "${NEW_FILE}"
+
+# Legacy stays untouched — the outer `[ ! -f "${path}" ]` short-circuits
+# the migration block when new exists.
+check 'race scenario: legacy file untouched' \
+    test -f "${LEGACY_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
 # Scenario 3: no legacy match → no migration
 # ---------------------------------------------------------------------------
 printf 'Scenario 3: unrelated legacy file → no migration\n'

--- a/tests/check-deps-exit-codes.sh
+++ b/tests/check-deps-exit-codes.sh
@@ -9,9 +9,14 @@
 #   3 — required binary present but a runtime invariant fails
 #       (e.g., `gh` exists but lacks the `project` / `read:project` scope)
 #
-# This test is hermetic: each scenario sets up its own environment in a
-# tmp dir + manipulates PATH, runs check-deps.sh, captures $?, and tears
-# down via trap. No global state is mutated.
+# Hermeticity policy: every scenario sets up its own tmp git repo + stubs
+# `gh` onto a controlled PATH. NO scenario depends on the host's real gh
+# auth state, on the plugin repo being checked out, or on any global env.
+# This way the suite passes on a vanilla CI runner (no gh credentials).
+#
+# An optional real-environment scenario at the bottom is gated on
+# BSP_TEST_REAL_ENV=1 for cases where the maintainer wants to additionally
+# verify the script behaves correctly against the live plugin repo.
 
 set -euo pipefail
 
@@ -40,29 +45,99 @@ assert_exit_code() {
     fi
 }
 
-# --- Scenario 1: happy path ---------------------------------------------
-# cwd = plugin repo (AGENTS.md routing block + all deps + gh has project scope).
+# Helper: write a `gh` stub into <dir> that responds to `gh auth status`
+# with the given scopes string. Real gh emits scopes on stderr; mimic that
+# so check-deps.sh's `gh auth status 2>&1 | grep` keeps working.
+#
+# Usage: stub_gh <dir> <scopes-string>
+#   <scopes-string> example: "'gist', 'project', 'repo'"
+stub_gh() {
+    local dir="${1:?usage: stub_gh <dir> <scopes>}"
+    local scopes="${2:?usage: stub_gh <dir> <scopes>}"
+    cat > "${dir}/gh" <<STUB
+#!/usr/bin/env bash
+# Stub gh: report fixed scopes on auth status; no-op otherwise.
+case "\${1:-}" in
+    auth)
+        printf 'github.com\n  Logged in to github.com\n  Token scopes: %s\n' "${scopes}" >&2
+        exit 0
+        ;;
+    *)
+        printf 'stub gh: subcommand %s unsupported\n' "\${1:-}" >&2
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
 
-scenario_happy() {
-    printf 'Scenario: happy path (cwd=plugin repo, all deps OK)\n'
-    local rc=0
-    ( cd "${PLUGIN_ROOT}" && bash "${CHECK_DEPS}" >/dev/null 2>&1 ) || rc=$?
+# Helper: run check-deps.sh in a fully controlled environment.
+#   - PATH = <stub-dir>:/usr/bin:/bin (stub gh wins; real python3+git remain)
+#   - cwd / CLAUDE_PROJECT_DIR = <project-dir>
+# Args: <stub-dir> <project-dir> [extra-env-pair ...]
+run_check_deps_in() {
+    local stub_dir="${1:?}"
+    local project_dir="${2:?}"
+    shift 2
+    (
+        cd "${project_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="${stub_dir}:/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${project_dir}" \
+            "$@" \
+            bash "${CHECK_DEPS}" >/dev/null 2>&1
+    )
+}
+
+# --- Scenario 1: hermetic happy path ------------------------------------
+# Tmp git repo with synthetic AGENTS.md routing heading. Stubbed gh
+# reports project scope. Real python3 + git on PATH. → exit 0.
+
+scenario_happy_hermetic() {
+    printf 'Scenario: hermetic happy path (synthetic repo + stubbed gh)\n'
+    local tmp project_dir stub_dir rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
+    (
+        cd "${project_dir}"
+        git init -q
+        printf '# Project agents file\n\n## board-superpowers session routing\n\nstub.\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    run_check_deps_in "${stub_dir}" "${project_dir}" || rc=$?
     assert_exit_code "happy path returns 0" "0" "${rc}"
 }
 
-# --- Scenario 2: missing dep ---------------------------------------------
-# Shadow `gh` by setting PATH to dirs containing python3 + git but not gh.
-# /usr/bin has python3 + git on macOS; gh lives in /opt/homebrew/bin which
-# we exclude. The cwd stays inside the plugin repo so the routing check
-# passes; only the missing dep should trip.
+# --- Scenario 2: missing dep --------------------------------------------
+# Empty stub dir (no gh shadow). PATH stripped to /usr/bin:/bin which has
+# python3 + git but not gh. Synthetic project with routing block so only
+# the missing-dep failure trips. → exit 2.
 
 scenario_missing_dep() {
     printf 'Scenario: missing dep (PATH lacks gh)\n'
-    local rc=0
+    local tmp project_dir rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    mkdir -p "${project_dir}"
     (
-        cd "${PLUGIN_ROOT}"
-        # /usr/bin + /bin gives us python3 + git but NOT gh.
-        PATH="/usr/bin:/bin" bash "${CHECK_DEPS}" >/dev/null 2>&1
+        cd "${project_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n' > AGENTS.md
+    )
+    (
+        cd "${project_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${project_dir}" \
+            bash "${CHECK_DEPS}" >/dev/null 2>&1
     ) || rc=$?
     assert_exit_code "missing gh → exit 2" "2" "${rc}"
 }
@@ -70,89 +145,166 @@ scenario_missing_dep() {
 # --- Scenario 3: missing routing block ----------------------------------
 # Per spec: AGENTS.md / CLAUDE.md exists but lacks the
 # "## board-superpowers session routing" heading → exit 2.
-# (If neither file exists the check is skipped — that case lives in
-# scenario_happy_no_md below.)
 
 scenario_missing_routing_block() {
     printf 'Scenario: AGENTS.md present but no routing-block heading\n'
-    local tmp rc=0
+    local tmp project_dir stub_dir rc=0
     tmp="$(mktemp -d)"
-    # shellcheck disable=SC2064  # tmp is already set; expansion at trap-set time is intentional.
+    # shellcheck disable=SC2064
     trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
     (
-        cd "${tmp}"
+        cd "${project_dir}"
         git init -q
         printf '# Bare project agents file\n\nNo routing block here.\n' > AGENTS.md
-        bash "${CHECK_DEPS}" >/dev/null 2>&1
-    ) || rc=$?
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    run_check_deps_in "${stub_dir}" "${project_dir}" || rc=$?
     assert_exit_code "AGENTS.md without routing → exit 2" "2" "${rc}"
 }
 
 # --- Scenario 4: skipped routing check (no markdown files) --------------
 # Spec asymmetric rule: no AGENTS.md AND no CLAUDE.md → routing check is
-# skipped entirely (exit 0 if deps OK). This guards against the dep check
-# becoming noisy in repos that don't use these files at all.
+# skipped entirely (exit 0 if deps OK).
 
 scenario_no_md_skipped() {
     printf 'Scenario: no AGENTS.md / CLAUDE.md (routing check skipped)\n'
-    local tmp rc=0
+    local tmp project_dir stub_dir rc=0
     tmp="$(mktemp -d)"
-    # shellcheck disable=SC2064  # tmp is already set; expansion at trap-set time is intentional.
+    # shellcheck disable=SC2064
     trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
     (
-        cd "${tmp}"
+        cd "${project_dir}"
         git init -q
-        # No AGENTS.md, no CLAUDE.md — routing check should be skipped.
-        bash "${CHECK_DEPS}" >/dev/null 2>&1
-    ) || rc=$?
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    run_check_deps_in "${stub_dir}" "${project_dir}" || rc=$?
     assert_exit_code "no AGENTS.md / CLAUDE.md → exit 0" "0" "${rc}"
 }
 
 # --- Scenario 5: runtime cmd unavailable (gh present, no project scope) -
-# Stub `gh` so `command -v gh` succeeds but `gh auth status` reports
-# scopes without the required `project` / `read:project` token. Per spec
-# this is a runtime failure (the binary is installed but the invariant
-# the script depends on doesn't hold) → exit 3.
+# Stubbed gh reports scopes WITHOUT project. → exit 3.
 
 scenario_runtime_unavailable() {
     printf 'Scenario: gh exists but lacks project scope (runtime failure)\n'
-    local tmp
+    local tmp project_dir stub_dir rc=0
     tmp="$(mktemp -d)"
-    # shellcheck disable=SC2064  # tmp is already set; expansion at trap-set time is intentional.
+    # shellcheck disable=SC2064
     trap "rm -rf '${tmp}'" RETURN
-    cat > "${tmp}/gh" <<'STUB'
-#!/usr/bin/env bash
-# Stub gh: report no project scope.
-case "${1:-}" in
-    auth)
-        # Mimic real gh: scopes line on stderr.
-        printf 'github.com\n  Logged in to github.com\n  Token scopes: '\''gist'\'', '\''repo'\''\n' >&2
-        exit 0
-        ;;
-    *)
-        printf 'stub gh: subcommand %s unsupported\n' "$1" >&2
-        exit 0
-        ;;
-esac
-STUB
-    chmod +x "${tmp}/gh"
-    local rc=0
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
     (
-        cd "${PLUGIN_ROOT}"
-        # Prepend stub dir BEFORE /usr/bin so the stub wins for `gh`,
-        # but real python3/git remain reachable.
-        PATH="${tmp}:/usr/bin:/bin" bash "${CHECK_DEPS}" >/dev/null 2>&1
-    ) || rc=$?
+        cd "${project_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'repo'"
+    run_check_deps_in "${stub_dir}" "${project_dir}" || rc=$?
     assert_exit_code "gh without project scope → exit 3" "3" "${rc}"
+}
+
+# --- Scenario 6: CLAUDE_PROJECT_DIR overrides cwd -----------------------
+# Per spec lines 161-162: $CLAUDE_PROJECT_DIR (defaults to $PWD) is the
+# input for plugin / skill path resolution. The routing-block check MUST
+# evaluate against $CLAUDE_PROJECT_DIR, not cwd. This scenario stands cwd
+# in a "good" git repo (with routing block) and points CLAUDE_PROJECT_DIR
+# at a different repo MISSING the routing block — the script must report
+# the missing routing block from the CLAUDE_PROJECT_DIR repo.
+
+scenario_claude_project_dir_overrides_cwd() {
+    printf 'Scenario: CLAUDE_PROJECT_DIR overrides cwd for routing check\n'
+    local tmp good_dir bad_dir stub_dir rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    good_dir="${tmp}/good"
+    bad_dir="${tmp}/bad"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${good_dir}" "${bad_dir}" "${stub_dir}"
+
+    # cwd-side repo: HAS the routing block (would pass on its own).
+    (
+        cd "${good_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n' > AGENTS.md
+    )
+    # CLAUDE_PROJECT_DIR-side repo: MISSING the routing block.
+    (
+        cd "${bad_dir}"
+        git init -q
+        printf '# Bare project — no routing block.\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+
+    # cwd = good_dir, CLAUDE_PROJECT_DIR = bad_dir → must report missing
+    # routing block from bad_dir → exit 2.
+    (
+        cd "${good_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="${stub_dir}:/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${bad_dir}" \
+            bash "${CHECK_DEPS}" >/dev/null 2>&1
+    ) || rc=$?
+    assert_exit_code "CLAUDE_PROJECT_DIR=bad_dir → exit 2 (not cwd's good_dir)" "2" "${rc}"
+}
+
+# --- Scenario 7: CLAUDE_PROJECT_DIR points at non-git dir ---------------
+# Spec rule: "If CLAUDE_PROJECT_DIR is set but is not a git repo, treat
+# as outside-git (skip routing check, exit 0 path stays valid)".
+
+scenario_claude_project_dir_non_git() {
+    printf 'Scenario: CLAUDE_PROJECT_DIR points at a non-git dir (skip routing)\n'
+    local tmp non_git_dir stub_dir rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    non_git_dir="${tmp}/not-a-repo"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${non_git_dir}" "${stub_dir}"
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    (
+        cd "${non_git_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="${stub_dir}:/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${non_git_dir}" \
+            bash "${CHECK_DEPS}" >/dev/null 2>&1
+    ) || rc=$?
+    assert_exit_code "non-git CLAUDE_PROJECT_DIR → exit 0" "0" "${rc}"
+}
+
+# --- Optional Scenario: real-environment cross-check --------------------
+# Gated on BSP_TEST_REAL_ENV=1. Verifies the plugin repo's actual state
+# satisfies the dep contract end-to-end. Skipped by default for hermeticity.
+
+scenario_real_env_optional() {
+    if [ "${BSP_TEST_REAL_ENV:-0}" != "1" ]; then
+        printf 'Scenario: real-environment cross-check (skipped — set BSP_TEST_REAL_ENV=1 to run)\n'
+        return
+    fi
+    printf 'Scenario: real-environment cross-check (BSP_TEST_REAL_ENV=1)\n'
+    local rc=0
+    ( cd "${PLUGIN_ROOT}" && bash "${CHECK_DEPS}" >/dev/null 2>&1 ) || rc=$?
+    assert_exit_code "real env happy path returns 0" "0" "${rc}"
 }
 
 # --- Run ---------------------------------------------------------------
 
-scenario_happy
+scenario_happy_hermetic
 scenario_missing_dep
 scenario_missing_routing_block
 scenario_no_md_skipped
 scenario_runtime_unavailable
+scenario_claude_project_dir_overrides_cwd
+scenario_claude_project_dir_non_git
+scenario_real_env_optional
 
 printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" -eq 0 ]

--- a/tests/check-deps-exit-codes.sh
+++ b/tests/check-deps-exit-codes.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# tests/check-deps-exit-codes.sh — assert scripts/check-deps.sh exit-code
+# contract per docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § "Layer 1 dep check (§1.5.0)" and 0005-contracts/02-hook-contracts.md.
+#
+# Contract under test:
+#   0 — all deps present, routing block present (or no AGENTS.md/CLAUDE.md exists)
+#   2 — required binary missing OR AGENTS.md/CLAUDE.md exists without routing marker
+#   3 — required binary present but a runtime invariant fails
+#       (e.g., `gh` exists but lacks the `project` / `read:project` scope)
+#
+# This test is hermetic: each scenario sets up its own environment in a
+# tmp dir + manipulates PATH, runs check-deps.sh, captures $?, and tears
+# down via trap. No global state is mutated.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CHECK_DEPS="${PLUGIN_ROOT}/scripts/check-deps.sh"
+
+if [ ! -x "${CHECK_DEPS}" ] && [ ! -f "${CHECK_DEPS}" ]; then
+    printf 'FATAL: %s not found\n' "${CHECK_DEPS}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+assert_exit_code() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s (exit=%s)\n' "${label}" "${actual}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s: expected exit=%s, got exit=%s\n' "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- Scenario 1: happy path ---------------------------------------------
+# cwd = plugin repo (AGENTS.md routing block + all deps + gh has project scope).
+
+scenario_happy() {
+    printf 'Scenario: happy path (cwd=plugin repo, all deps OK)\n'
+    local rc=0
+    ( cd "${PLUGIN_ROOT}" && bash "${CHECK_DEPS}" >/dev/null 2>&1 ) || rc=$?
+    assert_exit_code "happy path returns 0" "0" "${rc}"
+}
+
+# --- Scenario 2: missing dep ---------------------------------------------
+# Shadow `gh` by setting PATH to dirs containing python3 + git but not gh.
+# /usr/bin has python3 + git on macOS; gh lives in /opt/homebrew/bin which
+# we exclude. The cwd stays inside the plugin repo so the routing check
+# passes; only the missing dep should trip.
+
+scenario_missing_dep() {
+    printf 'Scenario: missing dep (PATH lacks gh)\n'
+    local rc=0
+    (
+        cd "${PLUGIN_ROOT}"
+        # /usr/bin + /bin gives us python3 + git but NOT gh.
+        PATH="/usr/bin:/bin" bash "${CHECK_DEPS}" >/dev/null 2>&1
+    ) || rc=$?
+    assert_exit_code "missing gh → exit 2" "2" "${rc}"
+}
+
+# --- Scenario 3: missing routing block ----------------------------------
+# Per spec: AGENTS.md / CLAUDE.md exists but lacks the
+# "## board-superpowers session routing" heading → exit 2.
+# (If neither file exists the check is skipped — that case lives in
+# scenario_happy_no_md below.)
+
+scenario_missing_routing_block() {
+    printf 'Scenario: AGENTS.md present but no routing-block heading\n'
+    local tmp rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064  # tmp is already set; expansion at trap-set time is intentional.
+    trap "rm -rf '${tmp}'" RETURN
+    (
+        cd "${tmp}"
+        git init -q
+        printf '# Bare project agents file\n\nNo routing block here.\n' > AGENTS.md
+        bash "${CHECK_DEPS}" >/dev/null 2>&1
+    ) || rc=$?
+    assert_exit_code "AGENTS.md without routing → exit 2" "2" "${rc}"
+}
+
+# --- Scenario 4: skipped routing check (no markdown files) --------------
+# Spec asymmetric rule: no AGENTS.md AND no CLAUDE.md → routing check is
+# skipped entirely (exit 0 if deps OK). This guards against the dep check
+# becoming noisy in repos that don't use these files at all.
+
+scenario_no_md_skipped() {
+    printf 'Scenario: no AGENTS.md / CLAUDE.md (routing check skipped)\n'
+    local tmp rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064  # tmp is already set; expansion at trap-set time is intentional.
+    trap "rm -rf '${tmp}'" RETURN
+    (
+        cd "${tmp}"
+        git init -q
+        # No AGENTS.md, no CLAUDE.md — routing check should be skipped.
+        bash "${CHECK_DEPS}" >/dev/null 2>&1
+    ) || rc=$?
+    assert_exit_code "no AGENTS.md / CLAUDE.md → exit 0" "0" "${rc}"
+}
+
+# --- Scenario 5: runtime cmd unavailable (gh present, no project scope) -
+# Stub `gh` so `command -v gh` succeeds but `gh auth status` reports
+# scopes without the required `project` / `read:project` token. Per spec
+# this is a runtime failure (the binary is installed but the invariant
+# the script depends on doesn't hold) → exit 3.
+
+scenario_runtime_unavailable() {
+    printf 'Scenario: gh exists but lacks project scope (runtime failure)\n'
+    local tmp
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064  # tmp is already set; expansion at trap-set time is intentional.
+    trap "rm -rf '${tmp}'" RETURN
+    cat > "${tmp}/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gh: report no project scope.
+case "${1:-}" in
+    auth)
+        # Mimic real gh: scopes line on stderr.
+        printf 'github.com\n  Logged in to github.com\n  Token scopes: '\''gist'\'', '\''repo'\''\n' >&2
+        exit 0
+        ;;
+    *)
+        printf 'stub gh: subcommand %s unsupported\n' "$1" >&2
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${tmp}/gh"
+    local rc=0
+    (
+        cd "${PLUGIN_ROOT}"
+        # Prepend stub dir BEFORE /usr/bin so the stub wins for `gh`,
+        # but real python3/git remain reachable.
+        PATH="${tmp}:/usr/bin:/bin" bash "${CHECK_DEPS}" >/dev/null 2>&1
+    ) || rc=$?
+    assert_exit_code "gh without project scope → exit 3" "3" "${rc}"
+}
+
+# --- Run ---------------------------------------------------------------
+
+scenario_happy
+scenario_missing_dep
+scenario_missing_routing_block
+scenario_no_md_skipped
+scenario_runtime_unavailable
+
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/tests/check-deps-machine-mode.sh
+++ b/tests/check-deps-machine-mode.sh
@@ -316,6 +316,81 @@ scenario_non_git_project_dir() {
     assert_match "stdout has MISSING=gh" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
     assert_match "stdout has ROUTING_INJECTED=yes" "^ROUTING_INJECTED=yes\$" "${STDOUT_CAPTURE}"
     assert_match "stdout PROJECT is the non-git path" "^PROJECT=.*/not-a-repo\$" "${STDOUT_CAPTURE}"
+    # Spec 01-script-contracts.md line 93: PROJECT=<absolute path>.
+    # Non-git CLAUDE_PROJECT_DIR must still emit an absolute path.
+    local project_value
+    project_value="$(printf '%s\n' "${STDOUT_CAPTURE}" | grep '^PROJECT=' | sed 's/^PROJECT=//')"
+    case "${project_value}" in
+        /*) assert_eq "PROJECT value is absolute (starts with /)" "absolute" "absolute" ;;
+        *)  assert_eq "PROJECT value is absolute (starts with /)" "absolute" "relative: ${project_value}" ;;
+    esac
+}
+
+# --- Scenario 8: relative CLAUDE_PROJECT_DIR (existing non-git dir) ------
+# Caller passes a relative CLAUDE_PROJECT_DIR resolving to an existing
+# non-git directory. Spec 01-script-contracts.md line 93 mandates
+# PROJECT=<absolute path> regardless of how the caller spelled the input.
+# Without the absolutize() fix the script leaks the literal `../foo`
+# value into machine-mode stdout.
+
+scenario_relative_existing_non_git() {
+    printf 'Scenario: relative CLAUDE_PROJECT_DIR (existing non-git) → PROJECT absolute\n'
+    local tmp non_git_dir cwd_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    non_git_dir="${tmp}/sibling-non-git"
+    cwd_dir="${tmp}/cwd"
+    mkdir -p "${non_git_dir}" "${cwd_dir}"
+    # cwd is ${cwd_dir}; relative path ../sibling-non-git points at
+    # the existing non-git dir. Bare PATH so MISSING=gh trips and forces
+    # machine-mode emission.
+    local rc=0
+    STDOUT_CAPTURE="$(
+        cd "${cwd_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="../sibling-non-git" \
+            bash "${CHECK_DEPS}" --machine 2>/dev/null
+    )" || rc=$?
+    RC_CAPTURE="${rc}"
+    assert_eq "relative non-git → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING=gh" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=yes" "^ROUTING_INJECTED=yes\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout PROJECT starts with /" "^PROJECT=/" "${STDOUT_CAPTURE}"
+    assert_match "stdout PROJECT resolves to sibling-non-git" "^PROJECT=.*/sibling-non-git\$" "${STDOUT_CAPTURE}"
+}
+
+# --- Scenario 9: nonexistent CLAUDE_PROJECT_DIR --------------------------
+# Caller passes a path that doesn't exist. Per spec, PROJECT= must still
+# be absolute. Routing check is skipped (dir doesn't exist) →
+# ROUTING_INJECTED=yes. We use a bare PATH so MISSING=gh trips and forces
+# the three-line emission.
+
+scenario_nonexistent_project_dir() {
+    printf 'Scenario: nonexistent CLAUDE_PROJECT_DIR → PROJECT absolute, ROUTING_INJECTED=yes\n'
+    local tmp cwd_dir bogus
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    cwd_dir="${tmp}/cwd"
+    mkdir -p "${cwd_dir}"
+    bogus="/nonexistent/path-that-does-not-exist-$$"
+    local rc=0
+    STDOUT_CAPTURE="$(
+        cd "${cwd_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${bogus}" \
+            bash "${CHECK_DEPS}" --machine 2>/dev/null
+    )" || rc=$?
+    RC_CAPTURE="${rc}"
+    assert_eq "nonexistent → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING=gh" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=yes" "^ROUTING_INJECTED=yes\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout PROJECT starts with /" "^PROJECT=/" "${STDOUT_CAPTURE}"
 }
 
 # --- Run ----------------------------------------------------------------
@@ -327,6 +402,8 @@ scenario_combined
 scenario_runtime_failure
 scenario_claude_project_dir_override
 scenario_non_git_project_dir
+scenario_relative_existing_non_git
+scenario_nonexistent_project_dir
 
 printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" -eq 0 ]

--- a/tests/check-deps-machine-mode.sh
+++ b/tests/check-deps-machine-mode.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# tests/check-deps-machine-mode.sh — assert scripts/check-deps.sh --machine
+# output contract per docs/architecture/0005-contracts/01-script-contracts.md
+# § "scripts/check-deps.sh" Stdout/stderr table (lines 90-97) and per
+# 0002-product-features-and-flows/05-bootstrap-surface.md lines 173-183.
+#
+# Contract under test:
+#   - exit code is ALWAYS 0 (output channel signals state, not exit code)
+#   - empty stdout when everything is OK (callers test `-z`)
+#   - exactly three lines, key order MISSING / ROUTING_INJECTED / PROJECT,
+#     when at least one of:
+#       * a dependency is missing (PATH or runtime-scope failure)
+#       * the routing block is missing on an existing AGENTS.md / CLAUDE.md
+#   - MISSING value: comma-separated bare tool names (gh, python3, git);
+#     same token whether the tool is absent from PATH or fails a runtime
+#     check (so the hook side sees `gh` flagged either way).
+#   - ROUTING_INJECTED is `yes` or `no`. Asymmetric skip semantics: no
+#     AGENTS.md AND no CLAUDE.md → yes; non-git CLAUDE_PROJECT_DIR → yes.
+#   - PROJECT: absolute path of git toplevel when CLAUDE_PROJECT_DIR is
+#     inside a repo, else the path itself.
+#
+# Hermeticity: every scenario sets up its own tmp dirs + stubs. NO
+# scenario depends on host gh credentials, PWD inheritance, or repo state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CHECK_DEPS="${PLUGIN_ROOT}/scripts/check-deps.sh"
+
+if [ ! -f "${CHECK_DEPS}" ]; then
+    printf 'FATAL: %s not found\n' "${CHECK_DEPS}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        printf '    expected: %q\n' "${expected}" >&2
+        printf '    actual:   %q\n' "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_match() {
+    local label="$1"
+    local pattern="$2"
+    local actual="$3"
+    if printf '%s' "${actual}" | grep -qE "${pattern}"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        printf '    pattern:  %s\n' "${pattern}" >&2
+        printf '    actual:   %q\n' "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Helper: write a `gh` stub into <dir>. Reports the given scopes string on
+# `gh auth status` (real gh emits scopes on stderr). Same shape as the
+# stub used by tests/check-deps-exit-codes.sh.
+stub_gh() {
+    local dir="${1:?usage: stub_gh <dir> <scopes>}"
+    local scopes="${2:?usage: stub_gh <dir> <scopes>}"
+    cat > "${dir}/gh" <<STUB
+#!/usr/bin/env bash
+case "\${1:-}" in
+    auth)
+        printf 'github.com\n  Logged in to github.com\n  Token scopes: %s\n' "${scopes}" >&2
+        exit 0
+        ;;
+    *)
+        printf 'stub gh: subcommand %s unsupported\n' "\${1:-}" >&2
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+# Helper: capture (stdout, exit-code) of `check-deps.sh --machine` invoked
+# in a controlled environment. Sets PATH, cwd, CLAUDE_PROJECT_DIR.
+# Args: <stub-dir> <project-dir> <claude-project-dir>
+# Returns stdout via STDOUT_CAPTURE, exit via RC_CAPTURE (globals).
+run_machine() {
+    local stub_dir="${1:?}"
+    local project_dir="${2:?}"
+    local claude_project_dir="${3:?}"
+    local rc=0
+    STDOUT_CAPTURE="$(
+        cd "${project_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="${stub_dir}:/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${claude_project_dir}" \
+            bash "${CHECK_DEPS}" --machine 2>/dev/null
+    )" || rc=$?
+    RC_CAPTURE="${rc}"
+}
+
+# Same, but with a bare PATH (no stub dir) so `gh` is genuinely absent.
+run_machine_no_stub() {
+    local project_dir="${1:?}"
+    local claude_project_dir="${2:?}"
+    local rc=0
+    STDOUT_CAPTURE="$(
+        cd "${project_dir}"
+        env -i \
+            HOME="${HOME}" \
+            PATH="/usr/bin:/bin" \
+            CLAUDE_PROJECT_DIR="${claude_project_dir}" \
+            bash "${CHECK_DEPS}" --machine 2>/dev/null
+    )" || rc=$?
+    RC_CAPTURE="${rc}"
+}
+
+# --- Scenario 1: hermetic happy path ------------------------------------
+# Tmp git repo + routing block + stubbed gh with project scope. Empty
+# stdout, exit 0.
+
+scenario_happy_hermetic() {
+    printf 'Scenario: hermetic happy path → empty stdout, exit 0\n'
+    local tmp project_dir stub_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
+    (
+        cd "${project_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n\nstub.\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    run_machine "${stub_dir}" "${project_dir}" "${project_dir}"
+    assert_eq "happy path → exit 0" "0" "${RC_CAPTURE}"
+    assert_eq "happy path → empty stdout" "" "${STDOUT_CAPTURE}"
+}
+
+# --- Scenario 2: missing dep --------------------------------------------
+# PATH lacks gh; routing block present. → exit 0, three lines emitted with
+# MISSING=gh, ROUTING_INJECTED=yes.
+
+scenario_missing_dep() {
+    printf 'Scenario: missing dep (PATH lacks gh) → MISSING=gh, ROUTING_INJECTED=yes\n'
+    local tmp project_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    mkdir -p "${project_dir}"
+    (
+        cd "${project_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n' > AGENTS.md
+    )
+    run_machine_no_stub "${project_dir}" "${project_dir}"
+    assert_eq "missing dep → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING=gh line" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=yes" "^ROUTING_INJECTED=yes\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has PROJECT=<absolute>" "^PROJECT=/" "${STDOUT_CAPTURE}"
+    # Assert exactly three keyed lines. Bash command substitution strips
+    # the trailing LF from STDOUT_CAPTURE, so a 3-line output becomes a
+    # string with 2 internal LFs. Count by appending a sentinel LF and
+    # using `wc -l`, which then sees exactly 3 newlines.
+    local line_count
+    line_count="$(printf '%s\n' "${STDOUT_CAPTURE}" | wc -l | tr -d ' ')"
+    assert_eq "stdout is exactly 3 lines" "3" "${line_count}"
+}
+
+# --- Scenario 3: missing routing ----------------------------------------
+# AGENTS.md present without heading; deps OK. → exit 0, MISSING= empty,
+# ROUTING_INJECTED=no.
+
+scenario_missing_routing() {
+    printf 'Scenario: AGENTS.md without routing heading → MISSING=, ROUTING_INJECTED=no\n'
+    local tmp project_dir stub_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
+    (
+        cd "${project_dir}"
+        git init -q
+        printf '# Bare project agents file\n\nNo routing block here.\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    run_machine "${stub_dir}" "${project_dir}" "${project_dir}"
+    assert_eq "missing routing → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING= (empty value)" "^MISSING=\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=no" "^ROUTING_INJECTED=no\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has PROJECT=<absolute>" "^PROJECT=/" "${STDOUT_CAPTURE}"
+}
+
+# --- Scenario 4: combined missing dep AND missing routing ----------------
+# PATH lacks gh AND AGENTS.md lacks heading. → MISSING=gh, ROUTING_INJECTED=no.
+
+scenario_combined() {
+    printf 'Scenario: missing dep AND missing routing → MISSING=gh, ROUTING_INJECTED=no\n'
+    local tmp project_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    mkdir -p "${project_dir}"
+    (
+        cd "${project_dir}"
+        git init -q
+        printf '# No routing here\n' > AGENTS.md
+    )
+    run_machine_no_stub "${project_dir}" "${project_dir}"
+    assert_eq "combined → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING=gh" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=no" "^ROUTING_INJECTED=no\$" "${STDOUT_CAPTURE}"
+}
+
+# --- Scenario 5: runtime failure (gh present without project scope) -----
+# gh exists but lacks project scope. Routing block present. The runtime
+# failure → MISSING=gh (same bucket as PATH-absent), ROUTING_INJECTED=yes.
+
+scenario_runtime_failure() {
+    printf 'Scenario: gh without project scope → MISSING=gh, ROUTING_INJECTED=yes\n'
+    local tmp project_dir stub_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    project_dir="${tmp}/project"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${project_dir}" "${stub_dir}"
+    (
+        cd "${project_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'repo'"
+    run_machine "${stub_dir}" "${project_dir}" "${project_dir}"
+    assert_eq "runtime failure → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING=gh" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=yes" "^ROUTING_INJECTED=yes\$" "${STDOUT_CAPTURE}"
+}
+
+# --- Scenario 6: CLAUDE_PROJECT_DIR override ----------------------------
+# cwd is an empty tmp dir; CLAUDE_PROJECT_DIR points at the routing-block
+# repo. → ROUTING_INJECTED=yes; PROJECT is the CLAUDE_PROJECT_DIR's git
+# toplevel.
+
+scenario_claude_project_dir_override() {
+    printf 'Scenario: CLAUDE_PROJECT_DIR override → PROJECT reflects override path\n'
+    local tmp empty_dir routing_dir stub_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    empty_dir="${tmp}/empty"
+    routing_dir="${tmp}/routing"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${empty_dir}" "${routing_dir}" "${stub_dir}"
+    (
+        cd "${routing_dir}"
+        git init -q
+        printf '## board-superpowers session routing\n' > AGENTS.md
+    )
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    # All deps + routing OK against routing_dir → empty stdout expected.
+    run_machine "${stub_dir}" "${empty_dir}" "${routing_dir}"
+    assert_eq "override happy → exit 0" "0" "${RC_CAPTURE}"
+    assert_eq "override happy → empty stdout (everything OK)" "" "${STDOUT_CAPTURE}"
+
+    # Now flip: routing_dir without heading → must surface ROUTING_INJECTED=no
+    # AND PROJECT pointing at routing_dir, not empty_dir.
+    rm "${routing_dir}/AGENTS.md"
+    printf '# No heading\n' > "${routing_dir}/AGENTS.md"
+    run_machine "${stub_dir}" "${empty_dir}" "${routing_dir}"
+    assert_eq "override missing routing → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=no" "^ROUTING_INJECTED=no\$" "${STDOUT_CAPTURE}"
+    # macOS resolves /tmp via /private/tmp, so match the basename suffix.
+    assert_match "stdout PROJECT references routing dir" "^PROJECT=.*/routing\$" "${STDOUT_CAPTURE}"
+}
+
+# --- Scenario 7: non-git CLAUDE_PROJECT_DIR -----------------------------
+# Non-git dir → routing check skipped → ROUTING_INJECTED=yes. With deps
+# all OK, stdout is empty. Verify by also creating a missing-dep variant
+# to confirm PROJECT keeps the literal path (not a git toplevel).
+
+scenario_non_git_project_dir() {
+    printf 'Scenario: non-git CLAUDE_PROJECT_DIR → ROUTING_INJECTED=yes (skip)\n'
+    local tmp non_git_dir stub_dir
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    non_git_dir="${tmp}/not-a-repo"
+    stub_dir="${tmp}/stubs"
+    mkdir -p "${non_git_dir}" "${stub_dir}"
+    stub_gh "${stub_dir}" "'gist', 'project', 'repo'"
+    # Deps OK, non-git project dir → routing skipped → empty stdout.
+    run_machine "${stub_dir}" "${non_git_dir}" "${non_git_dir}"
+    assert_eq "non-git happy → exit 0" "0" "${RC_CAPTURE}"
+    assert_eq "non-git happy → empty stdout" "" "${STDOUT_CAPTURE}"
+
+    # Now drop the gh stub so MISSING=gh trips. Must still emit
+    # ROUTING_INJECTED=yes, plus PROJECT pointing at the non-git dir.
+    run_machine_no_stub "${non_git_dir}" "${non_git_dir}"
+    assert_eq "non-git missing dep → exit 0" "0" "${RC_CAPTURE}"
+    assert_match "stdout has MISSING=gh" "^MISSING=gh\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout has ROUTING_INJECTED=yes" "^ROUTING_INJECTED=yes\$" "${STDOUT_CAPTURE}"
+    assert_match "stdout PROJECT is the non-git path" "^PROJECT=.*/not-a-repo\$" "${STDOUT_CAPTURE}"
+}
+
+# --- Run ----------------------------------------------------------------
+
+scenario_happy_hermetic
+scenario_missing_dep
+scenario_missing_routing
+scenario_combined
+scenario_runtime_failure
+scenario_claude_project_dir_override
+scenario_non_git_project_dir
+
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/tests/common-helpers.sh
+++ b/tests/common-helpers.sh
@@ -78,6 +78,20 @@ capture_helper() {
     set -e
 }
 
+# Capture stdout, stderr, and exit code separately.
+# Sets globals OUT, ERR, RC.
+capture_helper_split() {
+    local code="$1"
+    local err_file
+    err_file="$(mktemp)"
+    set +e
+    OUT="$(bash -c "set -euo pipefail; source '${COMMON_SH}'; ${code}" 2>"${err_file}")"
+    RC=$?
+    set -e
+    ERR="$(cat "${err_file}")"
+    rm -f "${err_file}"
+}
+
 # ---------------------------------------------------------------------------
 # Scenario 1: bsp_normalize_repo_path — happy path
 # ---------------------------------------------------------------------------
@@ -129,6 +143,49 @@ TMP="$(mktemp -d)"
 capture_helper "BOARD_SP_WORKTREE_DIR=/custom/wt bsp_pick_worktree_dir '${TMP}'"
 assert_eq 'env override beats project-local .worktrees' '/custom/wt' "${OUT}"
 rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3b: bsp_pick_worktree_dir — relative env value falls through with warning
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_pick_worktree_dir relative env value rejected (warn + fall-through)\n'
+
+# Relative env, no repo arg → falls through to priority 3 default; stderr
+# carries the warning about the rejected env value.
+capture_helper_split "BOARD_SP_WORKTREE_DIR=relative/path; export BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir"
+assert_eq 'relative env → priority-3 default stdout' \
+    '/test/home/.config/superpowers/worktrees' "${OUT}"
+
+if printf '%s' "${ERR}" | grep -q 'BOARD_SP_WORKTREE_DIR'; then
+    printf '  PASS — relative env emits warning to stderr (mentions BOARD_SP_WORKTREE_DIR)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL — relative env stderr missing warning. stderr=%q\n' "${ERR}" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+if printf '%s' "${ERR}" | grep -q 'not absolute'; then
+    printf '  PASS — warning explains the cause (not absolute)\n'
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL — warning text missing reason. stderr=%q\n' "${ERR}" >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# Relative env should NOT abort the helper (exit 0).
+assert_eq 'relative env exit code is 0 (fall-through, not hard-fail)' '0' "${RC}"
+
+# Bare-word relative value (no slash) is also rejected.
+capture_helper_split "BOARD_SP_WORKTREE_DIR=foo; export BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir"
+assert_eq 'bare-word relative env → priority-3 default' \
+    '/test/home/.config/superpowers/worktrees' "${OUT}"
+
+if printf '%s' "${ERR}" | grep -q 'BOARD_SP_WORKTREE_DIR=foo'; then
+    printf '  PASS — bare-word relative env warning includes the bad value\n'
+    PASS=$((PASS + 1))
+else
+    printf '  FAIL — bare-word warning text. stderr=%q\n' "${ERR}" >&2
+    FAIL=$((FAIL + 1))
+fi
 
 # ---------------------------------------------------------------------------
 # Scenario 4: bsp_pick_worktree_dir — project-local .worktrees/ (priority 2)

--- a/tests/common-helpers.sh
+++ b/tests/common-helpers.sh
@@ -6,7 +6,8 @@
 #   bsp_normalize_repo_path <abs-repo-root> — strip leading "/", replace
 #       remaining "/" with "-"; reject relative paths.
 #   bsp_pick_worktree_dir [repo_root] — 3-priority resolution
-#       (env > config.yml > default) per ADR-0003.
+#       (env > project-local .worktrees/ > default) per ADR-0003 and
+#       docs/architecture/0005-contracts/07-path-conventions.md L51-58.
 #   bsp_host_state_dir <repo_root> — emit
 #       ${HOME}/.board-superpowers/repos/<normalized>
 #       (signature change: was <host> <repo>).
@@ -113,49 +114,57 @@ printf 'Scenario: bsp_pick_worktree_dir env override\n'
 capture_helper 'BOARD_SP_WORKTREE_DIR=/custom/wt bsp_pick_worktree_dir'
 assert_eq 'env override (no repo arg)' '/custom/wt' "${OUT}"
 
-# Even if a repo arg is passed, env wins.
+# Even if a repo arg with a gitignored .worktrees/ is passed, env wins.
 TMP="$(mktemp -d)"
-mkdir -p "${TMP}/.board-superpowers"
-cat > "${TMP}/.board-superpowers/config.yml" <<EOF
-worktree_dir: /per-repo/dir
-EOF
+(
+    cd "${TMP}"
+    git init -q -b main
+    git config user.email test@example.com
+    git config user.name 'Test'
+    mkdir .worktrees
+    printf '.worktrees/\n' > .gitignore
+    git add .gitignore
+    git -c commit.gpgsign=false commit -q -m gitignore
+)
 capture_helper "BOARD_SP_WORKTREE_DIR=/custom/wt bsp_pick_worktree_dir '${TMP}'"
-assert_eq 'env override beats config.yml' '/custom/wt' "${OUT}"
+assert_eq 'env override beats project-local .worktrees' '/custom/wt' "${OUT}"
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
-# Scenario 4: bsp_pick_worktree_dir — config.yml (priority 2)
+# Scenario 4: bsp_pick_worktree_dir — project-local .worktrees/ (priority 2)
 # ---------------------------------------------------------------------------
-printf 'Scenario: bsp_pick_worktree_dir config.yml lookup\n'
+printf 'Scenario: bsp_pick_worktree_dir project-local .worktrees/ lookup\n'
 
+# Happy path: dir exists AND is gitignored → priority 2 fires.
 TMP="$(mktemp -d)"
-mkdir -p "${TMP}/.board-superpowers"
-cat > "${TMP}/.board-superpowers/config.yml" <<EOF
-# project intent
-worktree_dir: /per-repo/dir
-project_owner: PanQiWei
-EOF
-capture_helper "unset BOARD_SP_WORKTREE_DIR; bsp_pick_worktree_dir '${TMP}'"
-assert_eq 'config.yml worktree_dir' '/per-repo/dir' "${OUT}"
+(
+    cd "${TMP}"
+    git init -q -b main
+    git config user.email test@example.com
+    git config user.name 'Test'
+    mkdir .worktrees
+    printf '.worktrees/\n' > .gitignore
+    git add .gitignore
+    git -c commit.gpgsign=false commit -q -m gitignore
+)
+capture_helper "unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'project-local .worktrees (dir exists + gitignored)' "${TMP}/.worktrees" "${OUT}"
 rm -rf "${TMP}"
 
-# Quoted values should also work.
+# Negative: dir exists but NOT gitignored → priority 2 must NOT match,
+# falls through to priority 3 default.
 TMP="$(mktemp -d)"
-mkdir -p "${TMP}/.board-superpowers"
-cat > "${TMP}/.board-superpowers/config.yml" <<EOF
-worktree_dir: "/quoted/dir"
-EOF
-capture_helper "unset BOARD_SP_WORKTREE_DIR; bsp_pick_worktree_dir '${TMP}'"
-assert_eq 'config.yml worktree_dir (double-quoted)' '/quoted/dir' "${OUT}"
-rm -rf "${TMP}"
-
-TMP="$(mktemp -d)"
-mkdir -p "${TMP}/.board-superpowers"
-cat > "${TMP}/.board-superpowers/config.yml" <<EOF
-worktree_dir: '/single/dir'
-EOF
-capture_helper "unset BOARD_SP_WORKTREE_DIR; bsp_pick_worktree_dir '${TMP}'"
-assert_eq 'config.yml worktree_dir (single-quoted)' '/single/dir' "${OUT}"
+(
+    cd "${TMP}"
+    git init -q -b main
+    git config user.email test@example.com
+    git config user.name 'Test'
+    mkdir .worktrees
+    # No .gitignore at all — .worktrees is tracked-eligible.
+)
+capture_helper "unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'project-local .worktrees (dir exists but NOT gitignored) → default' \
+    '/test/home/.config/superpowers/worktrees' "${OUT}"
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
@@ -163,21 +172,23 @@ rm -rf "${TMP}"
 # ---------------------------------------------------------------------------
 printf 'Scenario: bsp_pick_worktree_dir default fallback\n'
 
-TMP="$(mktemp -d)"  # repo without .board-superpowers
+# Repo without any .worktrees dir → default.
+TMP="$(mktemp -d)"
 capture_helper "unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir '${TMP}'"
-assert_eq 'default (no env, no config)' '/test/home/.config/superpowers/worktrees' "${OUT}"
+assert_eq 'default (no env, no .worktrees dir)' '/test/home/.config/superpowers/worktrees' "${OUT}"
 rm -rf "${TMP}"
 
 # No repo_root arg at all → also default.
 capture_helper 'unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir'
 assert_eq 'default (no args at all)' '/test/home/.config/superpowers/worktrees' "${OUT}"
 
-# Repo arg points at a directory without config.yml → default.
+# Path that is not a git repo (mkdir + .worktrees but no `git init`) →
+# `git check-ignore` returns non-zero, falls through to default.
 TMP="$(mktemp -d)"
-mkdir -p "${TMP}/.board-superpowers"
-# no config.yml in there
+mkdir -p "${TMP}/.worktrees"
 capture_helper "unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir '${TMP}'"
-assert_eq 'default (config dir but no file)' '/test/home/.config/superpowers/worktrees' "${OUT}"
+assert_eq 'default (.worktrees dir but not a git repo)' \
+    '/test/home/.config/superpowers/worktrees' "${OUT}"
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------

--- a/tests/common-helpers.sh
+++ b/tests/common-helpers.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# tests/common-helpers.sh — assert scripts/lib/common.sh helper contracts
+# per Card 1 Phase D Slice 4.
+#
+# Contracts under test:
+#   bsp_normalize_repo_path <abs-repo-root> — strip leading "/", replace
+#       remaining "/" with "-"; reject relative paths.
+#   bsp_pick_worktree_dir [repo_root] — 3-priority resolution
+#       (env > config.yml > default) per ADR-0003.
+#   bsp_host_state_dir <repo_root> — emit
+#       ${HOME}/.board-superpowers/repos/<normalized>
+#       (signature change: was <host> <repo>).
+#   bsp_audit_local_path <repo_root> — emit
+#       ${HOME}/.board-superpowers/repos/<normalized>/audit-local.jsonl
+#       (signature change: was <host> <repo>).
+#
+# Hermeticity policy: every scenario sources common.sh in a subshell with
+# a controlled HOME so we never touch the real ~/.board-superpowers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMMON_SH="${PLUGIN_ROOT}/scripts/lib/common.sh"
+
+if [ ! -f "${COMMON_SH}" ]; then
+    printf 'FATAL: %s not found\n' "${COMMON_SH}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_nonzero() {
+    local label="$1"
+    local actual="$2"
+    if [ "${actual}" != "0" ]; then
+        printf '  PASS — %s (exit=%s)\n' "${label}" "${actual}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s: expected non-zero, got %s\n' "${label}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Run a one-liner sourcing common.sh and emitting a single line of stdout.
+# Usage: call_helper "<bash code>"; prints stdout, captures status separately.
+call_helper() {
+    set +e
+    bash -c "set -euo pipefail; source '${COMMON_SH}'; $1" 2>/dev/null
+    local rc=$?
+    set -e
+    return ${rc}
+}
+
+# Capture both stdout and exit code from a helper invocation.
+# Sets globals OUT and RC.
+capture_helper() {
+    local code="$1"
+    set +e
+    OUT="$(bash -c "set -euo pipefail; source '${COMMON_SH}'; ${code}" 2>/dev/null)"
+    RC=$?
+    set -e
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: bsp_normalize_repo_path — happy path
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_normalize_repo_path happy paths\n'
+
+capture_helper 'bsp_normalize_repo_path /Users/foo/bar-baz'
+assert_eq 'normalize /Users/foo/bar-baz' 'Users-foo-bar-baz' "${OUT}"
+
+capture_helper 'bsp_normalize_repo_path /a/b/c'
+assert_eq 'normalize /a/b/c' 'a-b-c' "${OUT}"
+
+capture_helper 'bsp_normalize_repo_path /Users/foo/bar/'
+assert_eq 'normalize trailing slash /Users/foo/bar/' 'Users-foo-bar' "${OUT}"
+
+capture_helper 'bsp_normalize_repo_path /Users/panqiwei/Dev/repos/nemori-ai/board-superpowers'
+assert_eq 'normalize deep path' 'Users-panqiwei-Dev-repos-nemori-ai-board-superpowers' "${OUT}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: bsp_normalize_repo_path — relative path is a usage error
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_normalize_repo_path rejects relative paths\n'
+
+capture_helper 'bsp_normalize_repo_path relative/path'
+assert_nonzero 'relative path → non-zero exit' "${RC}"
+
+capture_helper 'bsp_normalize_repo_path foo'
+assert_nonzero 'bare-word path → non-zero exit' "${RC}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: bsp_pick_worktree_dir — env override (priority 1)
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_pick_worktree_dir env override\n'
+
+capture_helper 'BOARD_SP_WORKTREE_DIR=/custom/wt bsp_pick_worktree_dir'
+assert_eq 'env override (no repo arg)' '/custom/wt' "${OUT}"
+
+# Even if a repo arg is passed, env wins.
+TMP="$(mktemp -d)"
+mkdir -p "${TMP}/.board-superpowers"
+cat > "${TMP}/.board-superpowers/config.yml" <<EOF
+worktree_dir: /per-repo/dir
+EOF
+capture_helper "BOARD_SP_WORKTREE_DIR=/custom/wt bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'env override beats config.yml' '/custom/wt' "${OUT}"
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: bsp_pick_worktree_dir — config.yml (priority 2)
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_pick_worktree_dir config.yml lookup\n'
+
+TMP="$(mktemp -d)"
+mkdir -p "${TMP}/.board-superpowers"
+cat > "${TMP}/.board-superpowers/config.yml" <<EOF
+# project intent
+worktree_dir: /per-repo/dir
+project_owner: PanQiWei
+EOF
+capture_helper "unset BOARD_SP_WORKTREE_DIR; bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'config.yml worktree_dir' '/per-repo/dir' "${OUT}"
+rm -rf "${TMP}"
+
+# Quoted values should also work.
+TMP="$(mktemp -d)"
+mkdir -p "${TMP}/.board-superpowers"
+cat > "${TMP}/.board-superpowers/config.yml" <<EOF
+worktree_dir: "/quoted/dir"
+EOF
+capture_helper "unset BOARD_SP_WORKTREE_DIR; bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'config.yml worktree_dir (double-quoted)' '/quoted/dir' "${OUT}"
+rm -rf "${TMP}"
+
+TMP="$(mktemp -d)"
+mkdir -p "${TMP}/.board-superpowers"
+cat > "${TMP}/.board-superpowers/config.yml" <<EOF
+worktree_dir: '/single/dir'
+EOF
+capture_helper "unset BOARD_SP_WORKTREE_DIR; bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'config.yml worktree_dir (single-quoted)' '/single/dir' "${OUT}"
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: bsp_pick_worktree_dir — default (priority 3)
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_pick_worktree_dir default fallback\n'
+
+TMP="$(mktemp -d)"  # repo without .board-superpowers
+capture_helper "unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'default (no env, no config)' '/test/home/.config/superpowers/worktrees' "${OUT}"
+rm -rf "${TMP}"
+
+# No repo_root arg at all → also default.
+capture_helper 'unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir'
+assert_eq 'default (no args at all)' '/test/home/.config/superpowers/worktrees' "${OUT}"
+
+# Repo arg points at a directory without config.yml → default.
+TMP="$(mktemp -d)"
+mkdir -p "${TMP}/.board-superpowers"
+# no config.yml in there
+capture_helper "unset BOARD_SP_WORKTREE_DIR; HOME=/test/home bsp_pick_worktree_dir '${TMP}'"
+assert_eq 'default (config dir but no file)' '/test/home/.config/superpowers/worktrees' "${OUT}"
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: bsp_host_state_dir new signature
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_host_state_dir <repo_root>\n'
+
+capture_helper 'HOME=/test/home bsp_host_state_dir /Users/foo/bar-baz'
+assert_eq 'host_state_dir new layout' '/test/home/.board-superpowers/repos/Users-foo-bar-baz' "${OUT}"
+
+capture_helper 'HOME=/test/home bsp_host_state_dir /Users/panqiwei/Dev/repos/nemori-ai/board-superpowers'
+assert_eq 'host_state_dir deep path' '/test/home/.board-superpowers/repos/Users-panqiwei-Dev-repos-nemori-ai-board-superpowers' "${OUT}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: bsp_audit_local_path new signature
+# ---------------------------------------------------------------------------
+printf 'Scenario: bsp_audit_local_path <repo_root>\n'
+
+capture_helper 'HOME=/test/home bsp_audit_local_path /Users/foo/bar-baz'
+assert_eq 'audit_local_path new layout' '/test/home/.board-superpowers/repos/Users-foo-bar-baz/audit-local.jsonl' "${OUT}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/fixtures/session-start-v0.1.0.txt
+++ b/tests/fixtures/session-start-v0.1.0.txt
@@ -1,0 +1,1 @@
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.1.0-minimum loaded."}}

--- a/tests/fixtures/session-start-v0.1.0.txt
+++ b/tests/fixtures/session-start-v0.1.0.txt
@@ -1,1 +1,0 @@
-{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.1.0-minimum loaded."}}

--- a/tests/fixtures/session-start-v0.1.1.txt
+++ b/tests/fixtures/session-start-v0.1.1.txt
@@ -1,0 +1,1 @@
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.1.1 loaded."}}

--- a/tests/setup-labels-idempotent.sh
+++ b/tests/setup-labels-idempotent.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# tests/setup-labels-idempotent.sh — assert scripts/setup-labels.sh ships
+# the canonical 13-label set (4 ops + 9 type+size) idempotently per
+# docs/architecture/0005-contracts/05-github-artifact-schemas.md
+# § "Standard label set" and 0005-contracts/01-script-contracts.md.
+#
+# Contract under test:
+#   - Cold start (label list empty) creates all 13 labels exactly once.
+#   - Re-running the script after success creates 0 labels (idempotent).
+#   - Running with 4 ops labels pre-seeded creates exactly the 9 type+size
+#     labels (matches v0.1.0-minimum repo state on this very plugin).
+#
+# Hermeticity policy: every scenario stubs `gh` onto a tmp PATH and keeps
+# all label state in a tmp JSON file. NO scenario calls real GitHub or
+# requires gh auth. Suite passes on a vanilla CI runner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SETUP_LABELS="${PLUGIN_ROOT}/scripts/setup-labels.sh"
+
+if [ ! -f "${SETUP_LABELS}" ]; then
+    printf 'FATAL: %s not found\n' "${SETUP_LABELS}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s: expected %s, got %s\n' "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Helper: write a `gh` stub that maintains a JSON list of label names in
+# ${LABELS_FILE} (path passed via env). Mirrors real gh behavior:
+#   - `gh label list --json name`        → emit current JSON list to stdout
+#   - `gh label create NAME --color X --description D [--repo R]`
+#                                        → append {"name":"NAME"} to the list
+#                                          OR exit 1 with "name already used"
+#                                          if NAME already present
+#   - any other subcommand               → exit 0 silently (not invoked here)
+#
+# Args: <stub-dir> <labels-file>
+stub_gh() {
+    local dir="${1:?usage: stub_gh <dir> <labels-file>}"
+    local labels_file="${2:?usage: stub_gh <dir> <labels-file>}"
+    cat > "${dir}/gh" <<STUB
+#!/usr/bin/env bash
+# Hermetic gh stub — keeps label state in ${labels_file}.
+set -eu
+LABELS_FILE='${labels_file}'
+
+if [ ! -f "\${LABELS_FILE}" ]; then
+    printf '[]\n' > "\${LABELS_FILE}"
+fi
+
+case "\${1:-}" in
+    label)
+        shift
+        case "\${1:-}" in
+            list)
+                cat "\${LABELS_FILE}"
+                exit 0
+                ;;
+            create)
+                shift
+                NAME="\${1:?label create needs NAME}"
+                shift
+                # ignore --color / --description / --repo flags + values
+                EXISTS="\$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print('1' if any(l['name']==sys.argv[2] for l in data) else '0')
+" "\${LABELS_FILE}" "\${NAME}")"
+                if [ "\${EXISTS}" = "1" ]; then
+                    printf 'error: name "%s" already used by another label\n' "\${NAME}" >&2
+                    exit 1
+                fi
+                python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+data.append({'name': sys.argv[2]})
+with open(sys.argv[1], 'w') as f:
+    json.dump(data, f)
+" "\${LABELS_FILE}" "\${NAME}"
+                printf 'label "%s" created\n' "\${NAME}"
+                exit 0
+                ;;
+            *)
+                printf 'stub gh label: subcommand %s unsupported\n' "\${1:-}" >&2
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        # other gh subcommands not invoked by setup-labels.sh
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+# Helper: count labels in the JSON file.
+labels_count() {
+    local file="${1:?}"
+    python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))
+" "${file}"
+}
+
+# Helper: emit sorted label names, one per line.
+labels_list() {
+    local file="${1:?}"
+    python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print('\n'.join(sorted(l['name'] for l in data)))
+" "${file}"
+}
+
+# Canonical 13-label set per spec.
+EXPECTED_LABELS_SORTED='pr-contract-override
+security
+size:L
+size:M
+size:S
+size:XS
+suspended
+type:bug
+type:chore
+type:epic
+type:feature
+type:refactor
+wip-override'
+
+# Helper: run setup-labels.sh in a controlled environment.
+#   - PATH = <stub-dir>:/usr/bin:/bin (stub gh wins; real python3 + bash)
+#   - Working dir is irrelevant (script doesn't read cwd)
+run_setup_labels_in() {
+    local stub_dir="${1:?}"
+    env -i \
+        HOME="${HOME}" \
+        PATH="${stub_dir}:/usr/bin:/bin" \
+        bash "${SETUP_LABELS}" >/dev/null 2>&1
+}
+
+# --- Scenario 1: cold start --------------------------------------------
+# Empty labels file → all 13 labels created on first run.
+
+scenario_cold_start() {
+    printf 'Scenario: cold start (empty label list)\n'
+    local tmp stub_dir labels_file rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    stub_dir="${tmp}/stubs"
+    labels_file="${tmp}/labels.json"
+    mkdir -p "${stub_dir}"
+    printf '[]\n' > "${labels_file}"
+    stub_gh "${stub_dir}" "${labels_file}"
+    run_setup_labels_in "${stub_dir}" || rc=$?
+    assert_eq "cold start exits 0" "0" "${rc}"
+    assert_eq "cold start creates 13 labels" "13" "$(labels_count "${labels_file}")"
+    assert_eq "cold start label set matches spec" \
+        "${EXPECTED_LABELS_SORTED}" \
+        "$(labels_list "${labels_file}")"
+}
+
+# --- Scenario 2: re-run idempotent --------------------------------------
+# After scenario 1's state (13 labels), re-running creates 0 new labels
+# and exits 0.
+
+scenario_rerun_idempotent() {
+    printf 'Scenario: re-run idempotent (13 labels already present)\n'
+    local tmp stub_dir labels_file rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    stub_dir="${tmp}/stubs"
+    labels_file="${tmp}/labels.json"
+    mkdir -p "${stub_dir}"
+    printf '[]\n' > "${labels_file}"
+    stub_gh "${stub_dir}" "${labels_file}"
+    # First run — get to 13 labels.
+    run_setup_labels_in "${stub_dir}" || rc=$?
+    if [ "${rc}" != "0" ]; then
+        printf '  FAIL — pre-condition: first run did not exit 0 (rc=%s)\n' "${rc}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    # Second run — must remain at 13 with exit 0.
+    rc=0
+    run_setup_labels_in "${stub_dir}" || rc=$?
+    assert_eq "re-run exits 0" "0" "${rc}"
+    assert_eq "re-run keeps label count at 13" "13" "$(labels_count "${labels_file}")"
+}
+
+# --- Scenario 3: partial pre-existing -----------------------------------
+# Seed the labels file with the 4 ops labels (mirrors v0.1.0-minimum repo
+# state on this plugin). Run script. Result: 9 type+size labels added,
+# total = 13, exit 0.
+
+scenario_partial_preexisting() {
+    printf 'Scenario: partial pre-existing (4 ops labels seeded)\n'
+    local tmp stub_dir labels_file rc=0
+    tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmp}'" RETURN
+    stub_dir="${tmp}/stubs"
+    labels_file="${tmp}/labels.json"
+    mkdir -p "${stub_dir}"
+    cat > "${labels_file}" <<'JSON'
+[{"name":"wip-override"},{"name":"suspended"},{"name":"security"},{"name":"pr-contract-override"}]
+JSON
+    stub_gh "${stub_dir}" "${labels_file}"
+    run_setup_labels_in "${stub_dir}" || rc=$?
+    assert_eq "partial pre-existing exits 0" "0" "${rc}"
+    assert_eq "partial pre-existing reaches 13 labels" "13" "$(labels_count "${labels_file}")"
+    assert_eq "partial pre-existing final set matches spec" \
+        "${EXPECTED_LABELS_SORTED}" \
+        "$(labels_list "${labels_file}")"
+}
+
+# --- Run ---------------------------------------------------------------
+
+scenario_cold_start
+scenario_rerun_idempotent
+scenario_partial_preexisting
+
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
## Summary

Patch release `v0.1.1` closing accumulated spec drift in v0.1.0-minimum scripts and staging the helpers Card 2 (#25) consumes. No new user-facing skill behavior; the visible surface is the expanded label set + the new `--machine` mode emitter.

Closes #24.

Card body archived in `docs/plans/bootstrap/card-1-plumbing.md` (gitignored). Decomposition rationale in `docs/plans/bootstrap/dependency-rationale.md`.

**Scope (7 numbered Goal items from the card):**

1. `scripts/check-deps.sh` exit codes 0/2/3 per spec (was always exit 1).
2. `scripts/check-deps.sh` `--machine` mode emitting `MISSING=` / `ROUTING_INJECTED=` / `PROJECT=` keys per `01-script-contracts.md` line 93.
3. `scripts/setup-labels.sh` extended from 4 ops labels to 13 (4 ops + 9 spec-mandated `type:*` / `size:*`); idempotent + 100ms inter-create sleep.
4. New helpers in `scripts/lib/common.sh`: `bsp_normalize_repo_path` + `bsp_pick_worktree_dir` (3-priority resolution per ADR-0003).
5. Path convention alignment: `bsp_host_state_dir` / `bsp_audit_local_path` / `bsp_audit_local_write` signatures collapsed from `(host, repo)` → `(repo_root)`. Path moves from `~/.board-superpowers/<host>/<repo>/` → `~/.board-superpowers/repos/<normalized>/`. One-time inline mv migration handles existing audit-local.jsonl.
6. `verify-skill-metadata.sh` gate confirmed clean (no drift).
7. Plugin version bumped to `v0.1.1` in both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`.

**Plus three drive-by fixes** (same-PR contract update doctrine):

- `scripts/check-deps.sh` is now self-contained (does NOT source `lib/common.sh`) per `05-bootstrap-surface.md` lines 36-40.
- `scripts/check-deps.sh` respects `$CLAUDE_PROJECT_DIR` per `01-script-contracts.md` line 82.
- 3 spec doc citation drifts (`07-path-conventions.md` × 2, `08-environment-variables.md` × 1) corrected to point at the canonical `scripts/lib/common.sh` location of `bsp_pick_worktree_dir`.

## Automated Verification

All 5 test suites + 2 verify gates green. shellcheck clean.

```
$ bash tests/check-deps-exit-codes.sh         # 7 passed
$ bash tests/check-deps-machine-mode.sh       # 38 passed
$ bash tests/setup-labels-idempotent.sh       # 8 passed (hermetic gh stub)
$ bash tests/common-helpers.sh                # 22 passed
$ bash tests/audit-local-migration.sh         # 29 passed
$ bash scripts/verify-skill-metadata.sh       # OK (5 skills checked)
$ bash scripts/verify-skill-frontmatter.sh    # OK
$ shellcheck -x scripts/*.sh hooks/*.sh tests/*.sh   # exit 0
```

Total: 104 assertions, 0 failed.

Re-running per Card 1 acceptance line 42: `shellcheck -x scripts/**/*.sh hooks/*.sh tests/*.sh` exits 0.

## Human Verification TODO

- [ ] Post-merge: `gh label list --repo PanQiWei/board-superpowers` shows all 13 labels (4 ops preserved + 9 type+size newly created). Run `bash scripts/setup-labels.sh` once after merge to apply the 9 new labels to the real repo (the script is idempotent, so the existing 4 ops labels are untouched).
- [ ] `bash scripts/check-deps.sh --machine` from any clean checkout: empty stdout when all OK, exactly 3 lines (`MISSING=` / `ROUTING_INJECTED=` / `PROJECT=`) with absolute path values when something's wrong. Already eyeballed at `/private/tmp` synthetic-missing-dep — output matches spec line format.
- [ ] Audit-local migration: this Manager session's existing audit log at `~/.board-superpowers/panqiweideMacBook-Pro/PanQiWei/board-superpowers/audit-local.jsonl` will migrate to `~/.board-superpowers/repos/Users-panqiwei-Dev-repos-nemori-ai-board-superpowers/audit-local.jsonl` on the next `bsp_audit_local_write` call. Verify by running `bsp_audit_local_write` from any consuming script and confirming the legacy file disappears.

## Retro Notes

Reusable lessons captured during the 14-commit TDD cadence (Phase A through Phase E plus 3 fix-up rounds):

1. **Spec-vs-card precedence**. Card 1's body had two drafting bugs in its description of `--machine` mode (`<true|false>` enum, always-emit). The authoritative spec at `01-script-contracts.md` line 93 disagreed (`<yes|no>` enum, empty-when-OK). The orchestrator adjudicated **spec wins**. The card body in `docs/plans/` is gitignored scaffolding; only `docs/architecture/` is durable contract. Future card decompositions should cross-check spec docs before writing card-body acceptance language.

2. **Self-contained scripts at the dep-check layer**. Both `scripts/check-deps.sh` and `hooks/session-start.sh` MUST NOT source `scripts/lib/common.sh` (per `05-bootstrap-surface.md` lines 36-40). v0.1.0-minimum's `check-deps.sh` violated this — Codex caught it during review. Future scripts at the boot-critical layer should be audited against this rule.

3. **Atomic-append concurrency on POSIX**. `bsp_audit_local_write` uses Python `open(path, 'a').write(line)` which on POSIX uses `O_APPEND`. Single-line writes under `PIPE_BUF` (4096 bytes; audit lines are ~200) are atomic at kernel level — multiple concurrent writers cannot interleave. Migration `mv` is race-tolerant via the existence-recheck branch. Documented in the function header comment.

4. **shellcheck SC1091 information-level still produces exit 1**. Easy to miss because diagnostic severity is "info". Companion directive `# shellcheck source-path=SCRIPTDIR` paired with `# shellcheck source=lib/common.sh` resolves it cleanly. Applied to 6 scripts in this PR.

5. **Hermetic test design pays off**. Phase A's first review pass (Codex) flagged the original happy-path test as depending on real `gh` auth — would have failed CI. Switching to stubbed-`gh` + `env -i` PATH scrub made all 104 assertions deterministic. Future tests should assume CI has zero external auth.

6. **Two parallel reviewers is the right number**. Opus and Codex disagreed on 4 of 5 review rounds (Opus tended toward APPROVE, Codex toward REQUEST_CHANGES with concrete reproductions). Each round, Codex caught at least one defect Opus missed. The cost of running both is small relative to the catch rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)