### PR TITLE
[Card 2] Full bootstrap mechanism (F-B1 + F-B2 + intent injection + bootstrapping-repo skill); ships v0.2.0 (closes #25)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "board-superpowers",
       "source": "./",
       "description": "Agile scheduling layer for Claude Code: turn GitHub Projects into the central dispatcher, one session = one PR. Depends on superpowers and gstack.",
-      "version": "0.1.1"
+      "version": "0.2.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "board-superpowers",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Agile scheduling layer for Claude Code: turn GitHub Projects into the central dispatcher, turn one session into one deliverable milestone (one PR). Depends on superpowers and gstack.",
   "author": {
     "name": "board-superpowers contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "board-superpowers",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Agile scheduling layer for Codex CLI: turn GitHub Projects into the central dispatcher, one session = one PR. Depends on superpowers and gstack.",
   "author": "board-superpowers contributors",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "interface": {
     "displayName": "board-superpowers",
     "shortDescription": "GitHub-Project-driven scheduling for AI coding sessions",
-    "longDescription": "board-superpowers turns a GitHub Project into the central dispatcher for AI-driven coding sessions. Routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode. Delegates real work — TDD, debugging, review, QA, security — to superpowers and gstack. v0.1.1 ships 5 of 10 v1 skills.",
+    "longDescription": "board-superpowers turns a GitHub Project into the central dispatcher for AI-driven coding sessions. Routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode. Delegates real work — TDD, debugging, review, QA, security — to superpowers and gstack. v0.2.0 ships 6 of 10 v1 skills.",
     "developerName": "board-superpowers contributors",
     "category": "developer-tools",
     "websiteURL": "https://github.com/PanQiWei/board-superpowers"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,19 +10,18 @@ user-facing overview.
 
 > **The plugin is now loadable at runtime.** `hooks/`,
 > `scripts/`, and `skills/` directories exist at the repo root.
-> `SessionStart` fires. The 5 v1-minimum skills auto-match.
+> `SessionStart` fires. The 6 v1-minimum skills auto-match.
 > The plugin dogfoods itself for any new skill / script / hook.
 
-**v1-minimum = 5 of 10 skills shipped** (per
+**v1-minimum = 6 of 10 skills shipped** (per
 [`SKILLS.md`](./SKILLS.md) § "v1 minimum vs v1 complete"):
 
 - **Shipped**: `using-board-superpowers` (entry),
-  `managing-board` + `consuming-card` (molecular),
-  `board-canon` + `enforcing-pr-contract` (atomic).
+  `managing-board` + `consuming-card` + `bootstrapping-repo`
+  (molecular), `board-canon` + `enforcing-pr-contract` (atomic).
 - **Deferred to v1-complete**: `decomposing-into-milestones`,
-  `bootstrapping-repo`, `migrating-repo-version`,
-  `classifying-actions`, `auditing-actions`. Reasons live in
-  the SKILLS.md table.
+  `migrating-repo-version`, `classifying-actions`,
+  `auditing-actions`. Reasons live in the SKILLS.md table.
 
 **v1-minimum degraded behaviors** (designed-in, removed when
 deferred atomics ship):
@@ -34,14 +33,10 @@ deferred atomics ship):
 - All audit entries write to a **local jsonl trace file** at
   `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`. The
   full BYO RDBMS schema from `auditing-actions` is deferred.
-- **No `bootstrapping-repo` skill yet** — the plugin assumes
-  the repo's GitHub Project + standard labels are already set
-  up manually. The hook never injects `INVOKE: bootstrapping-repo`
-  in v1-minimum.
 - **No `migrating-repo-version` skill yet** — current plugin
-  version is `v0.1.1`; nothing to migrate from. The
-  hook never injects `INVOKE: migrating-repo-version` in
-  v1-minimum.
+  version is `v0.2.0`; the schema-aware migration runner lands
+  starting from the v0.2.x → v0.3.x transition. The hook never
+  injects `INVOKE: migrating-repo-version` in v0.2.0.
 
 The single source of truth for v1 design remains
 [`docs/architecture/`](./docs/architecture/) — read
@@ -526,7 +521,7 @@ The v1-minimum plugin is loadable. The operational checklist:
 - `scripts/verify-skill-frontmatter.sh` — Tier 1 + Tier 2 +
   no-Tier-3 compliance per SKILL.md.
 - `shellcheck -x scripts/**/*.sh hooks/*.sh` — full pass.
-- Manual smoke: open a fresh CC session, type each of the 5
+- Manual smoke: open a fresh CC session, type each of the 6
   v1-minimum skills' trigger phrases, verify auto-trigger.
 
 ### Release flow
@@ -555,7 +550,7 @@ ls docs/architecture/adr/                      # what's decided
 <!-- board-superpowers:routing -->
 ## board-superpowers session routing
 
-This project uses the `board-superpowers` plugin (v0.1.1).
+This project uses the `board-superpowers` plugin (v0.2.0).
 Any Claude Code session in this project plays one of two roles:
 
 - **Board Consumer** — if the first message contains `[board-card:#N]`,

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,4 +1,4 @@
-# Skills system — board-superpowers v1 catalog (10 skills total: 5 v1-minimum + 5 deferred to v1-complete, 3 layers)
+# Skills system — board-superpowers v1 catalog (10 skills total: 6 v1-minimum + 4 deferred to v1-complete, 3 layers)
 
 > **Always loaded.** This document is referenced from
 > [`AGENTS.md`](./AGENTS.md) via `@SKILLS.md` and rides into
@@ -76,11 +76,11 @@ A9).
 
 ## v1 minimum vs v1 complete
 
-The full v1 catalog defines **10 skills**. The first PR that
-ships skill content lands a deliberate subset — **5 v1-minimum
-skills** — whose purpose is to make the plugin **self-hostable
-on this very repo**. The other 5 are **deferred to v1-complete**
-and ship in a follow-up PR once the dogfood loop is validated.
+The full v1 catalog defines **10 skills**. As of `v0.2.0`,
+**6 v1-minimum skills** ship — enough to make the plugin
+**self-hostable on this very repo** AND to bootstrap a fresh
+consuming repo from zero. The remaining **4 are deferred to
+v1-complete** and ship in follow-up PRs once each is unblocked.
 
 | Skill | Layer | v1 status | Why this scoping |
 |-------|-------|-----------|-------------------|
@@ -88,8 +88,8 @@ and ship in a follow-up PR once the dogfood loop is validated.
 | `managing-board` | Molecular | **v1-minimum** | Producer surface — required for "what should I work on" / Review Queue / intake on this repo. |
 | `consuming-card` | Molecular | **v1-minimum** | Consumer surface — required for the F-C0..F-C14 lifecycle that delivers each card's PR. |
 | `decomposing-into-milestones` | Molecular | deferred to v1-complete | Initial cards on this repo's board are hand-crafted by the architect; automatic decomposition is a v1-complete enhancement. |
-| `bootstrapping-repo` | Molecular | deferred to v1-complete | This repo is already manually bootstrapped (GitHub Project + standard labels exist). The skill is required for **other** repos' first-time setup, not for our own dogfood. |
-| `migrating-repo-version` | Molecular | deferred to v1-complete | No prior version exists; migration only becomes meaningful starting from v0.2.x → v0.3.x transitions. |
+| `bootstrapping-repo` | Molecular | **v1-minimum** (shipped in v0.2.0) | F-B1 (host bootstrap) + F-B2 (per-repo bootstrap, including step 4 routing-block injection) — the entry-skill state probe routes here on first session. |
+| `migrating-repo-version` | Molecular | deferred to v1-complete | Migration becomes meaningful starting from v0.2.x → v0.3.x transitions; the v0.2.0 ship establishes the baseline. |
 | `board-canon` | Atomic | **v1-minimum** | True SPOT — every other v1-minimum skill consumes its state machine + schema + WIP rules. |
 | `enforcing-pr-contract` | Atomic | **v1-minimum** | True SPOT — Consumer's F-C12 PR submit + Manager's F-02 Review Queue both depend on it. |
 | `classifying-actions` | Atomic | deferred to v1-complete | D-AUTONOMY-1 matrix lives inline in v1-minimum skills as "ask-architect-on-every-mutation" (degraded R-class default). Atomic SPOT extraction lands in v1-complete with `auditing-actions`. |
@@ -144,7 +144,7 @@ means for board-superpowers" #3 for the full rationale.
 - **Tier 2 frontmatter**: `when_to_use` (extended trigger
   vocabulary outside the primary `description`).
 
-### Molecular layer (5 skills: 2 v1-minimum + 3 deferred)
+### Molecular layer (5 skills: 3 v1-minimum + 2 deferred)
 
 #### `managing-board` (v1-minimum)
 
@@ -202,24 +202,18 @@ means for board-superpowers" #3 for the full rationale.
   `classifying-actions`, `auditing-actions`.
 - **Composes (cross-plugin)**: see § "Cross-plugin edges" below.
 
-#### `bootstrapping-repo` (landing in v0.2.0)
+#### `bootstrapping-repo` (v1-minimum, shipped v0.2.0)
 
-> **Status**: skill body + references shipped in v0.2.0 (this PR's
-> Card 2). Slice 7 of that card promotes this entry to v1-minimum
-> (5 of 10 → 6 of 10) and refines the catalog text. The minimal
-> "landing in v0.2.0" wording here lets `verify-skill-metadata.sh`
-> recognize the skill ahead of slice 7's full SKILLS.md restructure.
-
-- **Role**: F-B1 (host bootstrap) + F-B2 (per-repo bootstrap, with
-  5 sub-capabilities: standard labels, Status validation,
+- **Role**: F-B1 (host bootstrap) + F-B2 (per-repo bootstrap with
+  5 sub-capabilities — standard labels, Status validation,
   `config.yml` write, `.gitignore` entry, BYO-RDBMS credential
-  setup) + step 4 routing-block injection into `CLAUDE.md` +
-  `AGENTS.md` + initial host-local `state.yml` write.
+  setup) + step 4 routing-block injection into `AGENTS.md` +
+  `CLAUDE.md` + initial host-local `state.yml` write. Drives
+  `scripts/bootstrap-host.sh` and `scripts/bootstrap-project.sh`
+  end-to-end and orchestrates the architect's first-session UX.
 - **Body target**: 250-450 lines (molecular budget).
 - **References folder**: `references/{intro,first-time-user-guide}.md`
-  + `references/changelog/v0.2.0.md`. (Additional reference files —
-  `byo-rdbms-setup`, `project-creation-walkthrough` — land in slice
-  7's polish pass per the card body's slice 7 scope.)
+  + `references/changelog/v0.2.0.md`.
 - **Composes (atomic)**: `board-canon` (read schema invariants for
   Status validation; static reference at v1-minimum). The deferred
   atomic `auditing-actions` is inlined as the v1-minimum-degraded

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -202,26 +202,40 @@ means for board-superpowers" #3 for the full rationale.
   `classifying-actions`, `auditing-actions`.
 - **Composes (cross-plugin)**: see § "Cross-plugin edges" below.
 
-#### `bootstrapping-repo` (deferred to v1-complete)
+#### `bootstrapping-repo` (landing in v0.2.0)
 
-- **Role**: §1.5.0 dep check + F-B1 (host bootstrap) + F-B2
-  (per-repo bootstrap, with 5 sub-capabilities: standard
-  labels, Status validation, `config.yml` write, `.gitignore`
-  entry, BYO-RDBMS credential setup).
-- **Body target**: 300-400 lines.
-- **References folder**:
-  `references/{intro,first-time-user-guide,byo-rdbms-setup,project-creation-walkthrough}.md`.
-- **Composes (atomic)**: `board-canon` (read schema invariants
-  for Status validation), `auditing-actions`.
+> **Status**: skill body + references shipped in v0.2.0 (this PR's
+> Card 2). Slice 7 of that card promotes this entry to v1-minimum
+> (5 of 10 → 6 of 10) and refines the catalog text. The minimal
+> "landing in v0.2.0" wording here lets `verify-skill-metadata.sh`
+> recognize the skill ahead of slice 7's full SKILLS.md restructure.
+
+- **Role**: F-B1 (host bootstrap) + F-B2 (per-repo bootstrap, with
+  5 sub-capabilities: standard labels, Status validation,
+  `config.yml` write, `.gitignore` entry, BYO-RDBMS credential
+  setup) + step 4 routing-block injection into `CLAUDE.md` +
+  `AGENTS.md` + initial host-local `state.yml` write.
+- **Body target**: 250-450 lines (molecular budget).
+- **References folder**: `references/{intro,first-time-user-guide}.md`
+  + `references/changelog/v0.2.0.md`. (Additional reference files —
+  `byo-rdbms-setup`, `project-creation-walkthrough` — land in slice
+  7's polish pass per the card body's slice 7 scope.)
+- **Composes (atomic)**: `board-canon` (read schema invariants for
+  Status validation; static reference at v1-minimum). The deferred
+  atomic `auditing-actions` is inlined as the v1-minimum-degraded
+  jsonl audit trace via `bsp_audit_local_write`.
 - **Composes (cross-plugin)**: none (bootstrap is
   board-superpowers-internal).
-- **Trigger model**: `INVOKE: bootstrapping-repo` marker
-  injected by the `SessionStart` hook when `manifest.yml` or
-  `state.yml` is absent (fast path), OR architect explicitly
-  says "set up board-superpowers" (fallback path). Per the hook
-  intent injection pattern in
-  [`docs/architecture/0004-component-architecture.md`](./docs/architecture/0004-component-architecture.md)
+- **Trigger model**: `INVOKE: bootstrapping-repo` marker injected
+  by the `SessionStart` hook when `manifest.yml` or per-repo
+  `state.yml` is absent (fast path), OR architect explicitly says
+  "set up board-superpowers" / "first time on this repo" /
+  "bootstrap this repo" (fallback path). Per the hook intent
+  injection pattern in [`docs/architecture/0004-component-architecture.md`](./docs/architecture/0004-component-architecture.md)
   § "Hook intent injection pattern".
+- **Tier 2 frontmatter**: `when_to_use` (extended trigger
+  vocabulary covering the architect-spoken fallback phrases plus
+  the entry-skill state-probe trigger).
 
 #### `migrating-repo-version` (deferred to v1-complete)
 

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
@@ -370,7 +370,7 @@ needs its config.
   4. **Dual-file routing injection** — append the canonical
      routing block to **both** `CLAUDE.md` AND `AGENTS.md`. The
      block content is mirrored verbatim from
-     `skills/using-board-superpowers/references/claudemd-routing.md`
+     `skills/using-board-superpowers/references/agentsmd-routing.md`
      between the marker pair `<!-- board-superpowers:routing -->`
      / `<!-- /board-superpowers:routing -->`. If either file
      exists already with content, the block is appended (with one
@@ -512,7 +512,7 @@ needs its config.
        `state.yml:routing_blocks` and compare to its `block_hash`.
      - **If hashes match** (block is plugin-pristine): re-inject
        the new source-of-truth block content from
-       `references/claudemd-routing.md`, update `block_hash` in
+       `references/agentsmd-routing.md`, update `block_hash` in
        `state.yml`, log an audit entry. Auto-update; no architect
        prompt.
      - **If hashes differ** (architect modified the block since
@@ -535,7 +535,7 @@ needs its config.
      every subsequent session for this version.
 - **Composes**: §1.5.0 dep check + `state.yml` parse + SHA256
   + diff (line-based diff for the user-modified surface
-  prompt) + `references/claudemd-routing.md` source-of-truth
+  prompt) + `references/agentsmd-routing.md` source-of-truth
   read + migration-script execution.
 - **Maps to (canonical)**: chezmoi `apply` 3-way prompt for
   modified targets; Debian `dpkg --force-confdef` /

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
@@ -346,12 +346,17 @@ needs its config.
         no longer needed: `state.yml` does not live in the repo at
         all.
      5. **BYO RDBMS audit-log credential setup** (per ADR-0006
-        §5) — checks for `BOARD_SP_AUDIT_DB_URL` env var OR
-        `~/.board-superpowers/credentials.yml` (chmod 600) with
-        an `audit_db_url:` field. **Postgres or MySQL only**;
-        SQLite, local file paths, and any public destination
-        (card comments, audit issue) are explicitly forbidden.
-        If no DB is configured, surface the trade-off: every
+        §5 + ADR-0009) — checks for `BOARD_SP_AUDIT_DB_URL` env
+        var OR `~/.board-superpowers/credentials.yml` (chmod
+        600) with an `audit_db_url:` field. **6-scheme
+        allowlist**: `postgresql://`, `postgres://`, `mysql://`,
+        `mysql+pymysql://`, `sqlite://`, `sqlite3://` (per
+        ADR-0009). SQLite is acceptable when host-local under
+        `~/.board-superpowers/repos/<normalized>/audit.db`;
+        SQLite inside the project tree, bare file paths, and any
+        public destination (card comments, audit issue) remain
+        forbidden. If no DB is configured, surface the trade-off:
+        every
         D-AUTONOMY-1 A-class action degrades to R-class
         (architect prompt required for everything Producer
         would otherwise auto-do) until the architect provisions

--- a/docs/architecture/0002-product-features-and-flows/07-cross-cutting-invariants.md
+++ b/docs/architecture/0002-product-features-and-flows/07-cross-cutting-invariants.md
@@ -163,7 +163,7 @@ attention).
 **I-10. Routing-block mirror rule.** The routing block
 injected into downstream `CLAUDE.md` and `AGENTS.md` is
 byte-identical to the fenced block in
-`skills/using-board-superpowers/references/claudemd-routing.md`
+`skills/using-board-superpowers/references/agentsmd-routing.md`
 between the marker pair. Edits to one MUST land in the other
 in the same commit. Cited by: F-B2, F-B4, `CLAUDE.md`
 change-impact matrix, the `<!-- board-superpowers:routing -->`

--- a/docs/architecture/0002-product-features-and-flows/20-user-flows.md
+++ b/docs/architecture/0002-product-features-and-flows/20-user-flows.md
@@ -293,10 +293,14 @@ sub-step. Common failure modes worth narrating in detail:
        (per ADR-0006 §5's "trade-off explicitly registered"
        note). Audit-log writes buffer in memory until the DB
        is back; on persistent failure, Producer surfaces and
-       suspends. There is no on-disk audit-log fallback —
-       SQLite / local files are explicitly forbidden per
-       ADR-0006 §5 because the BYO-RDBMS contract is the
-       enforcement mechanism.
+       suspends. SQLite (host-local under
+       `~/.board-superpowers/repos/<normalized>/audit.db`) is
+       acceptable as a primary backend per ADR-0009, but it is
+       still chosen at bootstrap, not silently fallen back to —
+       there is no automatic on-disk fallback when the configured
+       DB is unreachable. Project-tree SQLite and bare file
+       paths remain forbidden per ADR-0006 §5; the BYO contract
+       is the enforcement mechanism either way.
 
 **4. Initial `state.yml` write** (per §1.5.2 F-B2 step 3). Skill
 writes to

--- a/docs/architecture/0002-product-features-and-flows/20-user-flows.md
+++ b/docs/architecture/0002-product-features-and-flows/20-user-flows.md
@@ -315,7 +315,7 @@ routing_blocks: []    # filled in step 5
 
 **5. Dual-file routing block injection** (per §1.5.2 F-B2
 step 4). Skill reads
-`skills/using-board-superpowers/references/claudemd-routing.md`,
+`skills/using-board-superpowers/references/agentsmd-routing.md`,
 extracts the fenced block, and appends it to both `CLAUDE.md`
 AND `AGENTS.md`. If a file does not exist, it is created with
 just the routing block. After injection, the skill computes
@@ -335,7 +335,7 @@ routing_blocks:
 
 - **Why `block_hash` exists.** Plugin upgrades may want to
   re-inject an updated routing block when the source-of-truth
-  in `claudemd-routing.md` evolves (F-B4). The plugin has to
+  in `agentsmd-routing.md` evolves (F-B4). The plugin has to
   decide: "did the architect modify the on-disk block since I
   last wrote it?" The `block_hash` is the answer — at F-B4
   time, recompute SHA256 of the on-disk block and compare. If
@@ -546,7 +546,7 @@ F-B4 step 4. For each of `CLAUDE.md` and `AGENTS.md`:
 
 **Case 1: hashes match (block is plugin-pristine).** Skill
 auto-re-injects the new source-of-truth block content from
-`references/claudemd-routing.md`, updates `block_hash` in
+`references/agentsmd-routing.md`, updates `block_hash` in
 `state.yml`, writes an audit-log entry. Architect sees:
 
 ```

--- a/docs/architecture/0002-product-features-and-flows/30-cross-references.md
+++ b/docs/architecture/0002-product-features-and-flows/30-cross-references.md
@@ -54,7 +54,7 @@ feature, all are listed.
 |---------|---------------------|
 | 1.5.0 Dependency check (shared primitive) | `scripts/check-deps.sh`; `hooks/session-start.sh` (Layer 1); `skills/using-board-superpowers/SKILL.md` Step 1 (Layer 2); just-in-time calls in `skills/managing-board/SKILL.md` + `skills/consuming-card/SKILL.md` (Layer 3) |
 | F-B1 Host bootstrap | `skills/using-board-superpowers/SKILL.md` (manifest write + intro routing); `skills/using-board-superpowers/references/intro.md` (intro narrative — planned) |
-| F-B2 Per-repo bootstrap | `scripts/bootstrap-project.sh`; `skills/using-board-superpowers/SKILL.md` Step 3 + `references/claudemd-routing.md` (routing source-of-truth) + `references/first-time-user-guide.md` (post-bootstrap pointer) |
+| F-B2 Per-repo bootstrap | `scripts/bootstrap-project.sh`; `skills/using-board-superpowers/SKILL.md` Step 3 + `references/agentsmd-routing.md` (routing source-of-truth) + `references/first-time-user-guide.md` (post-bootstrap pointer) |
 | F-B3 Host version transition | `skills/using-board-superpowers/SKILL.md` (manifest version compare + changelog routing); `skills/using-board-superpowers/references/changelog/v<X>.md` (per-version highlights file — planned) |
 | F-B4 Per-repo version transition | `skills/using-board-superpowers/SKILL.md` (state.yml compare + new-features list + routing-block hash + 3-way prompt); `${CLAUDE_PLUGIN_ROOT}/scripts/migrations/state-v<N>-to-v<N+1>.sh` (per-version state migrations — planned) |
 | 1.6.1 INVEST criteria | `skills/decomposing-into-milestones/SKILL.md` ("The INVEST gate") |
@@ -185,7 +185,7 @@ delta as of this writing.
 | 1.7 I-7 | Implemented | `claim-card.sh` enforces |
 | 1.7 I-8 | Planned | Audit-log uniformity is contract; persistence target (BYO RDBMS) per ADR-0006 not yet implemented |
 | 1.7 I-9 | Partial | Card schema supports thin-pointer convention; in-repo `docs/` resolution implemented; third-party storage adapter planned |
-| 1.7 I-10 | Implemented | Routing block exists in both `references/claudemd-routing.md` source-of-truth and the appendix block at the bottom of `AGENTS.md` |
+| 1.7 I-10 | Implemented | Routing block exists in both `references/agentsmd-routing.md` source-of-truth and the appendix block at the bottom of `AGENTS.md` |
 | 1.7 I-11 | Planned | Plugin-owned vs user-owned region split is contract; `block_hash` enforcement (F-B2 + F-B4) not yet implemented |
 | 1.7 I-12 | Planned | `schema_version` field convention defined; migration runner at `${CLAUDE_PLUGIN_ROOT}/scripts/migrations/` not yet implemented; lazy-on-read invariant is spec |
 | 1.7 I-13 | Partial | `claims/` gitignore entry implemented; `state.yml` does not exist yet (planned with F-B2); `config.yml` tracked correctly today |

--- a/docs/architecture/0003-domain-model/01-ubiquitous-language.md
+++ b/docs/architecture/0003-domain-model/01-ubiquitous-language.md
@@ -322,9 +322,12 @@ Mode topology, `MULTI_AGENT_DEVELOPMENT.md`.
 
 **Negative invariant.** A fact about what must NEVER hold.
 Examples: "ClaimMarker MUST NOT carry an absolute local
-path" (regression-tested), "audit-log MUST NOT persist to
-SQLite or local file" (ADR-0006). Source: invariant list +
-ADR consequences sections.
+path" (regression-tested), "audit-log MUST NOT persist to a
+project-tree SQLite file or to bare local files outside the
+6-scheme `audit_db_url` allowlist" (ADR-0006 §5 + ADR-0009 —
+SQLite under `~/.board-superpowers/repos/<normalized>/audit.db`
+IS acceptable; project-tree SQLite is the negative invariant).
+Source: invariant list + ADR consequences sections.
 
 ### O
 

--- a/docs/architecture/0003-domain-model/01-ubiquitous-language.md
+++ b/docs/architecture/0003-domain-model/01-ubiquitous-language.md
@@ -299,7 +299,7 @@ unknown label → `schema_mismatch` error (ADR-0005). Source:
 routing block). Each is a machine-readable identifier that
 distinguishes board-superpowers artifacts from generic
 content. Source: `card-schema.md`, `pr-template.md`,
-`claudemd-routing.md`, I-10. Expanded across multiple
+`agentsmd-routing.md`, I-10. Expanded across multiple
 aggregates in `03-aggregates-and-entities.md`.
 
 **Milestone.** Outcome bucket on the **outcome axis** of work
@@ -440,7 +440,7 @@ Producer's F-12 retro routine. Source: §1.8.3.
 `AGENTS.md`. Plugin-owned within the marker pair
 (I-11); user-owned outside. Source-of-truth content lives
 at
-`skills/using-board-superpowers/references/claudemd-routing.md`
+`skills/using-board-superpowers/references/agentsmd-routing.md`
 (I-10 mirror rule). Source: §1.5.2 (F-B2), §1.5.4 (F-B4),
 I-10, I-11. Expanded in:
 `03-aggregates-and-entities.md` § RepoBootstrap.

--- a/docs/architecture/0003-domain-model/02-bounded-contexts.md
+++ b/docs/architecture/0003-domain-model/02-bounded-contexts.md
@@ -178,7 +178,7 @@ files at
   user spec docs.)
 
 **Invariants applying here:** I-10 (routing-block mirror rule
-between source-of-truth `claudemd-routing.md` and downstream
+between source-of-truth `agentsmd-routing.md` and downstream
 files), I-11 (plugin-owned vs user-owned region split, with
 `block_hash` as the boundary enforcer), I-12 (schema
 versioning + lazy migration), I-13 (state files in git,

--- a/docs/architecture/0003-domain-model/02-bounded-contexts.md
+++ b/docs/architecture/0003-domain-model/02-bounded-contexts.md
@@ -199,9 +199,13 @@ and Consumer action.
   scoping TBD in `0005-contracts.md`).
 
 **Physical substrate.** A relational database the architect
-provides — Postgres or MySQL only (ADR-0006 §5 backend
-constraint). SQLite, local files, card comments, dedicated
-audit issues are all explicitly forbidden. Connection details
+provides — the 6-scheme allowlist is `postgresql://`,
+`postgres://`, `mysql://`, `mysql+pymysql://`, `sqlite://`,
+`sqlite3://` (ADR-0006 §5 + ADR-0009). SQLite is acceptable
+when host-local under
+`~/.board-superpowers/repos/<normalized>/audit.db`; SQLite
+inside the project tree, bare file paths, card comments, and
+dedicated audit issues remain forbidden. Connection details
 via `~/.board-superpowers/credentials.yml` (chmod 600) or
 `BOARD_SP_AUDIT_DB_URL` env var.
 

--- a/docs/architecture/0003-domain-model/03-aggregates-and-entities.md
+++ b/docs/architecture/0003-domain-model/03-aggregates-and-entities.md
@@ -457,7 +457,7 @@ Path normalization rule pinned at
 - **I-10 routing-block mirror rule** — the block content
   injected into `CLAUDE.md` / `AGENTS.md` is byte-identical
   to the source-of-truth block at
-  `skills/using-board-superpowers/references/claudemd-routing.md`.
+  `skills/using-board-superpowers/references/agentsmd-routing.md`.
 - **I-11 plugin-owned vs user-owned region split** — the
   routing block within marker pair is plugin-owned;
   everything outside is user-owned. `BlockHash` is the

--- a/docs/architecture/0003-domain-model/03-aggregates-and-entities.md
+++ b/docs/architecture/0003-domain-model/03-aggregates-and-entities.md
@@ -572,18 +572,23 @@ immutable AuditEntry value objects.
   unreachable, every A-class action degrades to R-class
   (architect prompted). The AuditTrail aggregate is what
   the degradation guards: no write → no autonomy.
-- **Persistence target constraints (ADR-0006 §5):**
-  Postgres OR MySQL (no SQLite); never local files; never
-  in-repo paths; never public destinations (no card
-  comments, no audit issues, no GitHub Discussions).
+- **Persistence target constraints (ADR-0006 §5 + ADR-0009):**
+  6-scheme allowlist — `postgresql://`, `postgres://`,
+  `mysql://`, `mysql+pymysql://`, `sqlite://`, `sqlite3://`.
+  SQLite is acceptable when host-local under
+  `~/.board-superpowers/repos/<normalized>/audit.db`; SQLite
+  inside the project tree, bare file paths, and public
+  destinations (card comments, audit issues, GitHub
+  Discussions) remain forbidden.
 - **Credentials sourced from user layer, never repo layer.**
   Either `~/.board-superpowers/credentials.yml` (chmod 600;
   `audit_db_url:` field) or `BOARD_SP_AUDIT_DB_URL` env
   var. Final mechanism choice TBD in `0005-contracts.md`.
 
-**Physical location.** A user-provided Postgres or MySQL
-database. The plugin owns the schema definition (lives in
-TBD-4) but does NOT own the database itself.
+**Physical location.** A user-provided Postgres, MySQL, or
+SQLite database (per ADR-0009). The plugin owns the schema
+definition (lives in TBD-4) but does NOT own the database
+itself.
 
 **TBD-3.** Per-`action_id` payload shape hardening. ADR-0006 §5
 notes payload is loose JSONB at v1; once Producer features

--- a/docs/architecture/0005-contracts/03-config-schemas.md
+++ b/docs/architecture/0005-contracts/03-config-schemas.md
@@ -341,8 +341,19 @@ allowlist with `sqlite://` / `sqlite3://`):
 | `postgres://` | Postgres (alias; same as above) | `postgres://user:pwd@host:5432/db` |
 | `mysql://` | MySQL (canonical) | `mysql://user:pwd@host:3306/db` |
 | `mysql+pymysql://` | MySQL via PyMySQL driver hint (SQLAlchemy-compatible) | `mysql+pymysql://user:pwd@host/db` |
-| `sqlite://` | SQLite (canonical) | `sqlite:///Users/alice/.board-superpowers/repos/Users-alice-projects-foo/audit.db` |
-| `sqlite3://` | SQLite (alias; same as above) | `sqlite3:///Users/alice/.board-superpowers/repos/Users-alice-projects-foo/audit.db` |
+| `sqlite://` | SQLite (canonical) | `sqlite:////Users/alice/.board-superpowers/repos/Users-alice-projects-foo/audit.db` |
+| `sqlite3://` | SQLite (alias; same as above) | `sqlite3:////Users/alice/.board-superpowers/repos/Users-alice-projects-foo/audit.db` |
+
+**SQLite uses 4 slashes for absolute paths** (`sqlite:////` then
+`/Users/...`). The 3-slash form (`sqlite:///relative/path`) is
+interpreted relative to `cwd` per SQLAlchemy convention and would
+silently write the file to the wrong location. Because the
+default path under
+`~/.board-superpowers/repos/<normalized>/audit.db` is always
+absolute, every `sqlite://` / `sqlite3://` DSN this plugin emits
+or accepts MUST use the 4-slash form. Verifiable via
+`from sqlalchemy.engine import make_url;
+make_url('sqlite:////abs/path').database == '/abs/path'`.
 
 A second-driver author who lands a new RDBMS adapter MUST add its
 scheme prefix to this table in the same PR; no implicit driver

--- a/docs/architecture/0005-contracts/03-config-schemas.md
+++ b/docs/architecture/0005-contracts/03-config-schemas.md
@@ -155,7 +155,7 @@ The hash is computed over **bytes between** the marker pair,
 `<!-- /board-superpowers:routing -->` themselves. Trailing newline
 inclusion: include the final `\n` before the closing marker (so
 "block content" matches what the SoT file at
-`skills/using-board-superpowers/references/claudemd-routing.md`
+`skills/using-board-superpowers/references/agentsmd-routing.md`
 emits). Whitespace between the markers and the block content is
 also part of the hashed region — re-injection writes a deterministic
 form (one blank line above and below the block within the markers).
@@ -329,9 +329,11 @@ audit_db_url: "postgresql://user:password@host:5432/dbname"
 
 | Field | Type | Required? | Notes |
 |-------|------|-----------|-------|
-| `audit_db_url` | string DSN with one of the accepted URL schemes below | yes if file is present | Connection string. SQLite, file paths, GitHub URLs, and any public destination are forbidden per ADR-0006 §5 |
+| `audit_db_url` | string DSN with one of the accepted URL schemes below | yes if file is present | Connection string. Bare file paths, GitHub URLs, and any public destination are forbidden per ADR-0006 §5. SQLite IS allowed per ADR-0009 (6-scheme allowlist below) but only via the explicit `sqlite://` / `sqlite3://` schemes, and only outside the project tree. |
 
-**Accepted URL schemes** (the prefix is the driver discriminator):
+**Accepted URL schemes** (the prefix is the driver discriminator).
+Per ADR-0006 §5 + ADR-0009 (which extended the original 4-scheme
+allowlist with `sqlite://` / `sqlite3://`):
 
 | Scheme | Driver | Example |
 |--------|--------|---------|
@@ -339,10 +341,29 @@ audit_db_url: "postgresql://user:password@host:5432/dbname"
 | `postgres://` | Postgres (alias; same as above) | `postgres://user:pwd@host:5432/db` |
 | `mysql://` | MySQL (canonical) | `mysql://user:pwd@host:3306/db` |
 | `mysql+pymysql://` | MySQL via PyMySQL driver hint (SQLAlchemy-compatible) | `mysql+pymysql://user:pwd@host/db` |
+| `sqlite://` | SQLite (canonical) | `sqlite:///Users/alice/.board-superpowers/repos/Users-alice-projects-foo/audit.db` |
+| `sqlite3://` | SQLite (alias; same as above) | `sqlite3:///Users/alice/.board-superpowers/repos/Users-alice-projects-foo/audit.db` |
 
 A second-driver author who lands a new RDBMS adapter MUST add its
 scheme prefix to this table in the same PR; no implicit driver
 discovery.
+
+**SQLite default path suggestion.** When the architect picks
+SQLite during F-B2 step 2e interactive UX,
+`bootstrap-project.sh` suggests:
+
+```
+~/.board-superpowers/repos/<normalized>/audit.db
+```
+
+Co-locating with `state.yml` keeps every per-`(host, repo)`
+artifact under the same `0700` parent. Other locations under
+`~/.board-superpowers/` are accepted; SQLite paths INSIDE the
+project tree (e.g., `<repo>/.board-superpowers/audit.db`)
+remain forbidden — the default suggestion deliberately steers
+the architect away from project-tree files. Per ADR-0009 +
+[`07-path-conventions.md`](./07-path-conventions.md) "Per-repo
+layout — `~/.board-superpowers/repos/<normalized-repo-path>/`".
 
 ### Resolution priority (env var vs file)
 
@@ -357,10 +378,14 @@ can override per-process without editing files.
 
 ### Forbidden destinations
 
-Per ADR-0006 §5 — repeated here because it is a security contract:
+Per ADR-0006 §5 + ADR-0009 — repeated here because it is a
+security contract:
 
-- **No SQLite** (file-based; re-introduces local-persistence anti-
-  pattern).
+- **No SQLite under the project tree.** `<repo>/.board-superpowers/audit.db`
+  and any other path inside the repo working tree is forbidden.
+  SQLite under `~/.board-superpowers/` IS allowed per ADR-0009
+  (typically the default-suggested
+  `~/.board-superpowers/repos/<normalized>/audit.db`).
 - **No local `.log` file** under the project tree or
   `~/.board-superpowers/`.
 - **No card comment / dedicated audit issue / GitHub Discussion**
@@ -377,6 +402,9 @@ hints). Not landed at v1.
 - ADR-0006 §5 (BYO RDBMS, persistence rules, backend constraint,
   credential mechanism) — finalization deferred to 0005, landing
   here.
+- ADR-0009 (allow SQLite as a 6th scheme; default path under
+  `~/.board-superpowers/repos/<normalized>/audit.db`) —
+  partially supersedes ADR-0006 §5's backend constraint.
 - I-13 (state files in git, machine-state files not).
 - 0003 § 3.3.8 AuditTrail aggregate (credentials value object,
   invariant block).

--- a/docs/architecture/0005-contracts/05-github-artifact-schemas.md
+++ b/docs/architecture/0005-contracts/05-github-artifact-schemas.md
@@ -5,7 +5,7 @@
 > fields, PR mandatory-section header strings, routing-block marker
 > pair + `block_hash` format, Project v2 Status enum, and the
 > standard label set. Where canonical bodies live elsewhere
-> (`card-schema.md`, `pr-template.md`, `claudemd-routing.md`), 0005
+> (`card-schema.md`, `pr-template.md`, `agentsmd-routing.md`), 0005
 > surfaces only the parsing contract and links.
 
 ---
@@ -242,7 +242,7 @@ routing markers".
 ### Block content
 
 The bytes between the marker pair are the **plugin-owned region**
-(per I-11). Source of truth: `skills/using-board-superpowers/references/claudemd-routing.md`.
+(per I-11). Source of truth: `skills/using-board-superpowers/references/agentsmd-routing.md`.
 Per I-10, the block injected into downstream `CLAUDE.md` /
 `AGENTS.md` is byte-identical to the SoT block.
 
@@ -264,7 +264,7 @@ blank line above and below the block content within the markers)
 so the hash is stable across reads.
 
 **Source-of-truth file shape.** The SoT body at
-`skills/using-board-superpowers/references/claudemd-routing.md` is
+`skills/using-board-superpowers/references/agentsmd-routing.md` is
 the **injectable region only — the SoT file itself contains no
 markers**. Injection wraps the SoT body as:
 
@@ -299,7 +299,7 @@ compares its `block_hash`:
 - I-10 (mirror rule), I-11 (plugin-owned vs user-owned).
 - §1.5.2 F-B2 (initial injection + initial hash).
 - §1.5.4 F-B4 (re-check + 3-way prompt).
-- `claudemd-routing.md` (canonical block body).
+- `agentsmd-routing.md` (canonical block body).
 - `AGENTS.md` Protocol invariants → routing-marker entry.
 
 ---

--- a/docs/architecture/0005-contracts/07-path-conventions.md
+++ b/docs/architecture/0005-contracts/07-path-conventions.md
@@ -139,9 +139,11 @@ design — none of these files are tracked in git (per I-13).
 | `~/.board-superpowers/manifest.yml` | no | inherits umask (typically `0644`) | HostBootstrap | Plugin-managed `HostManifest` (per [`03-config-schemas.md`](./03-config-schemas.md)) |
 | `~/.board-superpowers/overrides.yml` | no | inherits umask | RepoConfig (user-layer) | User-level autonomy overrides (per [`03-config-schemas.md`](./03-config-schemas.md)) |
 | `~/.board-superpowers/credentials.yml` | no | **`0600` strict** | AuditTrail | Audit-DB connection string (per [`03-config-schemas.md`](./03-config-schemas.md) + ADR-0006 §5) |
-| `~/.board-superpowers/repos/` | n/a | inherits `0700` | RepoBootstrap | Container for all per-repo `state.yml` files this host has bootstrapped |
-| `~/.board-superpowers/repos/<normalized-repo-path>/` | n/a | inherits | RepoBootstrap | One sub-directory per repo bootstrapped on this host; name is the repo's absolute path with leading `/` stripped and remaining `/` replaced by `-` |
+| `~/.board-superpowers/repos/` | n/a | inherits `0700` | RepoBootstrap | Container for every per-`(host, repo)` directory this host has bootstrapped |
+| `~/.board-superpowers/repos/<normalized-repo-path>/` | n/a | inherits | RepoBootstrap | One sub-directory per repo bootstrapped on this host; name is the repo's absolute path with leading `/` stripped and remaining `/` replaced by `-`. Houses the three per-`(host, repo)` siblings below |
 | `~/.board-superpowers/repos/<normalized-repo-path>/state.yml` | no | inherits | RepoBootstrap | Plugin-managed `RepoState` for this (host, repo) pair (per [`03-config-schemas.md`](./03-config-schemas.md)) |
+| `~/.board-superpowers/repos/<normalized-repo-path>/audit-local.jsonl` | no | inherits | AuditTrail (degraded mode) | Per-`(host, repo)` jsonl trace written when audit DB is unavailable. **Legacy v0.1.0-minimum** wrote this at `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`; Card 1's plumbing migrates the legacy path into the canonical normalized location |
+| `~/.board-superpowers/repos/<normalized-repo-path>/audit.db` | no | inherits | AuditTrail (SQLite scheme) | **Optional.** Default SQLite database path suggested by `bootstrap-project.sh` step 2e when the architect picks `sqlite://` / `sqlite3://` (per ADR-0009). Absent when BYO scheme is Postgres / MySQL or audit DB is not configured |
 
 ### Path-normalization rule for the per-repo sub-directory
 
@@ -168,6 +170,34 @@ from Claude Code's leading-`-` form (`-Users-panqiwei-...`); the
 absence of the leading dash makes the directory listing read more
 naturally with no semantic loss.
 
+### Per-`(host, repo)` directory contents — three siblings
+
+Each `~/.board-superpowers/repos/<normalized-repo-path>/` directory
+houses up to three sibling files, one per concern, all owned by
+distinct aggregates but co-located so a single `(host, repo)` pair
+has exactly one canonical filesystem footprint:
+
+| Sibling | Always present? | Owner | Lifecycle |
+|---------|-----------------|-------|-----------|
+| `state.yml` | Yes (after F-B2) | RepoBootstrap | Created at F-B2 first run; updated by F-B4 on version transitions; schema-versioned per I-12 |
+| `audit-local.jsonl` | Yes during R-class degradation; absent once a BYO audit DB is configured AND reachable | AuditTrail (degraded mode) | Append-only jsonl trace written when `audit_db_url` is unset OR the configured DB is unreachable. **Legacy v0.1.0-minimum location** was `~/.board-superpowers/<host>/<repo>/audit-local.jsonl`; Card 1's plumbing migrates that path forward into the canonical normalized location |
+| `audit.db` | Only when BYO scheme is `sqlite://` / `sqlite3://` AND the architect accepted the default path suggestion | AuditTrail (SQLite scheme) | Created on the first audit write after F-B2 step 2e selects SQLite; lives for the project's lifetime (no rollover); WAL mode enabled on first connection |
+
+**One normalized dir per `(host, repo)` pair.** The directory name
+is fully determined by the host's view of the repo's absolute path
+(per the normalization rule above); no two distinct
+`(host, repo)` pairs share a directory under any architect's `$HOME`.
+The three siblings stay in lockstep — when the architect runs the
+deferred `bootstrap-rollback.sh`, every sibling under this directory
+gets cleaned up symmetrically.
+
+The `audit.db` sibling is **forbidden inside the project tree**
+(e.g., `<repo>/.board-superpowers/audit.db`). Per ADR-0009 the
+default suggestion deliberately steers the architect to this
+host-local location; if they override to a different host-local
+path under `~/.board-superpowers/` that is acceptable, but a
+project-tree location is rejected.
+
 ### Why `~/.board-superpowers/` and not `~/.config/board-superpowers/`
 
 ADR-0003 already places the global-default worktree dir under
@@ -193,6 +223,9 @@ parent dir guards anything new by default.
 - 0003 § 3.3.8 AuditTrail aggregate — `credentials.yml` location +
   permission rules.
 - ADR-0006 §5 (BYO RDBMS — credential-file location finalization).
+- ADR-0009 — `audit.db` sibling location finalization for the
+  SQLite scheme; default path suggestion under
+  `~/.board-superpowers/repos/<normalized-repo-path>/audit.db`.
 - I-13 (state files in git, machine-state files not).
 - [`03-config-schemas.md`](./03-config-schemas.md) — schemas for
   every file in this table.
@@ -470,6 +503,8 @@ project. Out-of-scope per P3.
 - ADR-0002 (atomic claim — claim marker is the lock payload).
 - ADR-0003 (worktree path priority — canonical home).
 - ADR-0006 §5 (BYO RDBMS — `credentials.yml` location).
+- ADR-0009 (allow SQLite as a BYO audit DB scheme — `audit.db`
+  sibling default path).
 - ADR-0007 C-PLUGIN-2 (no daemon — session-log paths are read,
   never written).
 - `MULTI_AGENT_DEVELOPMENT.md` — session-log path canonical home

--- a/docs/architecture/0005-contracts/README.md
+++ b/docs/architecture/0005-contracts/README.md
@@ -54,7 +54,7 @@ cited ADR or feature spec.**
   §1.5 cross-cutting principles. Anything not in v1 spec is either
   marked TBD with a one-line rationale + destination, or omitted.
 - ❌ A duplicate of `card-schema.md`, `pr-template.md`, or
-  `claudemd-routing.md`. Those are the canonical source of their
+  `agentsmd-routing.md`. Those are the canonical source of their
   respective bodies; 0005 surfaces the **section list / parsing
   contract / marker-string** and links to the canonical body.
 - ❌ A regression-test catalog. That's `0008-test-architecture.md`.

--- a/docs/architecture/adr/0004-composition-over-reimplementation.md
+++ b/docs/architecture/adr/0004-composition-over-reimplementation.md
@@ -80,7 +80,7 @@ reimplemented.
   using-board-superpowers SKILL Step 1 + just-in-time re-checks).
 - Routing decisions become first-class architecture. The
   CLAUDE.md routing block injected during bootstrap (see
-  `skills/using-board-superpowers/references/claudemd-routing.md`)
+  `skills/using-board-superpowers/references/agentsmd-routing.md`)
   has to encode phase-by-phase composition (gstack bookends +
   superpowers middle).
 - We are exposed to upstream breakage. If `superpowers` ships a
@@ -134,7 +134,7 @@ a discipline-plugin ecosystem.
   commitment; both define what board-superpowers refuses to own)
 - `0001-positioning.md` P4b — composition is permanent (premise this
   ADR anchors)
-- `skills/using-board-superpowers/references/claudemd-routing.md`
+- `skills/using-board-superpowers/references/agentsmd-routing.md`
   — the runtime encoding of this composition (gets injected into
   every downstream CLAUDE.md at bootstrap)
 - `0006-failure-modes.md` (stub) — F-06 mid-session dep removal is the

--- a/docs/architecture/adr/0006-producer-autonomy-boundary.md
+++ b/docs/architecture/adr/0006-producer-autonomy-boundary.md
@@ -1,6 +1,6 @@
 # ADR 0006: Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix
 
-**Status:** proposed
+**Status:** accepted (§5 partially superseded by ADR-0009)
 **Date:** 2026-04-26
 **Deciders:** PanQiWei (maintainer)
 
@@ -137,6 +137,18 @@ database (the **infrastructure**).
 **Backend constraint:** Postgres or MySQL. SQLite is **not
 acceptable** because it's file-based and would re-introduce the
 "local persistence" anti-pattern under a different name.
+
+> **Partially superseded by ADR-0009.** ADR-0009 (2026-04-27)
+> reverses this paragraph's no-SQLite stance and adds
+> `sqlite://` + `sqlite3://` to the allowlist (6 schemes total),
+> with a default path suggestion under
+> `~/.board-superpowers/repos/<normalized>/audit.db`. The rest
+> of §5 — BYO opt-in, no auto-default, R-class degradation when
+> the DB is unavailable, the no-public-destinations rule, the
+> propose-and-resolve two-entry rule for R-class actions — is
+> preserved and not affected by ADR-0009. See
+> [`0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+> for the live 6-scheme allowlist.
 
 **Credentials.** Connection details live in user-level config.
 Two candidate mechanisms (final choice deferred to
@@ -288,6 +300,8 @@ explicitly.
 
 ## Related
 
+- ADR-0009 — partially supersedes §5 by allowing SQLite as a 6th
+  scheme; the rest of §5 stands.
 - ADR-0005 — v1 BoardAdapter contract surface (the audit-log DB
   config integration point lands in `0005-contracts.md`, alongside
   the BoardAdapter contract)

--- a/docs/architecture/adr/0006-producer-autonomy-boundary.md
+++ b/docs/architecture/adr/0006-producer-autonomy-boundary.md
@@ -1,6 +1,6 @@
 # ADR 0006: Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix
 
-**Status:** accepted (§5 partially superseded by ADR-0009)
+**Status:** accepted
 **Date:** 2026-04-26
 **Deciders:** PanQiWei (maintainer)
 

--- a/docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md
+++ b/docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md
@@ -1,0 +1,190 @@
+# ADR 0009: Allow SQLite as a BYO audit DB scheme (supersedes ADR-0006 §5 partial)
+
+**Status:** accepted
+**Date:** 2026-04-27
+**Deciders:** PanQiWei (maintainer)
+
+## Context
+
+ADR-0006 §5 set the persistence target for the audit log: a
+relational database the architect provides (BYO RDBMS). At v1
+the §5 backend constraint named **Postgres or MySQL only** and
+explicitly rejected SQLite as "file-based; re-introduces the
+local-persistence anti-pattern under a different name."
+
+Six months of dogfood reality on this very repo, plus solo /
+small-team usage feedback, surface a friction the original
+constraint did not anticipate:
+
+- The typical board-superpowers user is **one architect on one
+  repo**. The `(host, repo) → 1 architect` mapping is the modal
+  case, not the exception. Producer and Consumer sessions on a
+  single host serialize through the architect's prompt cadence —
+  there is exactly one writer to the audit log at any given
+  moment.
+- Provisioning Postgres or MySQL **just to write a few audit
+  lines per day** is ergonomically heavy. Container setup,
+  credential rotation, port management, backup story — all
+  upfront cost paid before the first `manifest.yml` lands.
+- Architects respond rationally: they skip the DB, accept the
+  R-class degradation indefinitely, and the audit log never
+  comes online. The `audit_db_url` field stays empty across
+  hundreds of A-class actions, defeating the point of having an
+  audit log schema at all.
+
+SQLite's actual disqualifier in ADR-0006 §5 was **multi-writer
+contention** plus the *local-persistence anti-pattern*. The
+multi-writer worry does not apply to the modal `(host, repo) →
+1 architect` deployment. The local-persistence worry is
+addressable: a SQLite file under `~/.board-superpowers/` is
+already in the same host-local territory as `manifest.yml`,
+`state.yml`, and `credentials.yml` — none of which are in the
+project tree, none in git, all under user-mode `0700`.
+
+The solo-developer reality requires re-evaluating the §5
+backend constraint without re-litigating the rest of §5
+(propose-and-resolve two-entry rule, BYO opt-in, R-class
+degradation, no public destinations). Hence: a partial
+supersession.
+
+## Decision
+
+Allow `sqlite://` and `sqlite3://` URI schemes alongside the
+existing four. The full `audit_db_url` allowlist is now **6
+schemes**:
+
+| Scheme | Driver |
+|--------|--------|
+| `postgresql://` | Postgres (canonical) |
+| `postgres://` | Postgres (alias) |
+| `mysql://` | MySQL (canonical) |
+| `mysql+pymysql://` | MySQL via PyMySQL driver hint |
+| `sqlite://` | SQLite (canonical) |
+| `sqlite3://` | SQLite (alias) |
+
+The default SQLite path suggested by `bootstrap-project.sh`
+step 2e is:
+
+```
+~/.board-superpowers/repos/<normalized>/audit.db
+```
+
+Co-locating `audit.db` with `state.yml` keeps every per-`(host,
+repo)` artifact under the same `0700` parent, with one
+normalized-name sub-directory per pair (per `07-path-conventions.md`).
+
+### Forces preserved (not relaxed by this ADR)
+
+- **BYO opt-in.** No auto-default audit DB. The architect must
+  still explicitly choose to provision (any scheme) — declining
+  produces the R-class degradation notice.
+- **R-class degradation when DB unavailable.** ADR-0006 §5's
+  fallback rule stands: missing `audit_db_url` → A-class actions
+  degrade to R-class.
+- **No public destinations.** Card comments, dedicated audit
+  issue, GitHub Discussions remain forbidden.
+- **No project-tree files.** SQLite under the repo's own tree
+  (`<repo>/.board-superpowers/audit.db`) remains forbidden — the
+  default suggestion deliberately steers the architect to
+  `~/.board-superpowers/`.
+- **Two-entry rule for R-class.** Propose + resolve writes
+  unchanged.
+- **Friction-as-feature.** The architect still makes an explicit
+  decision; SQLite picker is a prompt, not a silent default.
+
+### Forces relaxed by this ADR
+
+- The previous **"no SQLite"** stance in ADR-0006 §5
+  ("Alternatives considered → Allow SQLite as a BYO option →
+  Rejected") is reversed. SQLite is now a first-class scheme,
+  not a rejected alternative.
+
+## Consequences
+
+**What this enables:**
+
+- **`bootstrap-project.sh` step 2e gains a SQLite branch.** The
+  interactive UX presents the 6-scheme allowlist; if the
+  architect picks SQLite, the script suggests
+  `~/.board-superpowers/repos/<normalized>/audit.db` as the
+  default path. Parent directory writability is verified
+  before `credentials.yml` is written.
+- **Solo-developer audit log adoption becomes realistic.** The
+  zero-infra option means architects can flip the audit log on
+  during initial bootstrap rather than deferring "until I set
+  up Postgres later."
+- **Future `auditing-actions` skill must support SQLite
+  client.** Python's `sqlite3` stdlib module is sufficient — no
+  new runtime dependency. The skill's DB-write helper script
+  branches on URL scheme.
+- **`03-config-schemas.md` `audit_db_url` schemes table grows
+  from 4 rows to 6.** Same shape; same forbidden-destinations
+  list; SQLite under the project tree is still forbidden.
+
+**What this constrains:**
+
+- **SQLite picker MUST verify parent dir writability** before
+  writing `credentials.yml`. Otherwise the next audit write
+  fails opaquely. `bootstrap-project.sh` step 2e aborts with a
+  clear error if the directory is non-writable.
+- **No multi-architect concurrent writers on one SQLite file.**
+  The modal deployment makes this moot; if a future deployment
+  needs multi-writer (shared host with two architects on the
+  same repo), the architect picks Postgres or MySQL — the choice
+  is theirs.
+
+**What this rules out:**
+
+- A SQLite file inside the project tree (e.g.,
+  `<repo>/.board-superpowers/audit.db`). The default suggestion
+  is host-local on purpose; if the architect overrides to a
+  project-tree path, `bootstrap-project.sh` rejects it (same
+  rule that forbids `.log` files in the project tree).
+
+## Alternatives considered
+
+**Keep the v1 "Postgres or MySQL only" constraint.** Rejected:
+the friction is high enough that adoption stalls; architects
+defer DB provisioning indefinitely and never benefit from the
+audit log they implicitly opted into by using the plugin.
+
+**Allow SQLite only when explicitly enabled by an env-var
+escape hatch.** Rejected: adds ceremony without addressing the
+core force (solo-developer ergonomics). The escape hatch becomes
+the path everyone takes; might as well bless it as a first-class
+scheme.
+
+**Allow SQLite but make Postgres / MySQL the bootstrap
+default suggestion.** Rejected: surveys real usage upside-down.
+The modal architect is solo; the modal default should be the
+zero-infra option. Multi-architect setups are the minority case
+and the architect picks accordingly.
+
+## Notes
+
+- SQLite's WAL mode is recommended for any architect who anticipates
+  brief overlap between Producer (writing audit entries) and a
+  retro / weekly-report query. The `auditing-actions` skill's
+  DB-write helper enables WAL on first connection.
+- The ADR-0006 §5 paragraph "Alternatives considered → Allow
+  SQLite as a BYO option" is now stale. ADR-0006 §5 receives a
+  cross-reference paragraph noting the partial supersession by
+  this ADR; the alternatives-considered text stays for history.
+
+## Related
+
+- ADR-0006 §5 — partially superseded by this ADR (SQLite scheme
+  allowance only). The rest of §5 (BYO opt-in, no auto-default,
+  R-class degradation, no public destinations, propose-and-
+  resolve two-entry rule) stands.
+- `0005-contracts/03-config-schemas.md` — `audit_db_url` schemes
+  table extends from 4 to 6 rows.
+- `0005-contracts/07-path-conventions.md` — `~/.board-superpowers/repos/<normalized>/`
+  per-repo directory now houses three siblings (`state.yml`,
+  `audit-local.jsonl`, optional `audit.db`).
+- `0002-product-features-and-flows/05-bootstrap-surface.md`
+  F-B2 step 2e — interactive picker presents 6 schemes;
+  SQLite path suggestion lives here.
+- `0001-positioning.md` P3 (solo / small-team scale) — the
+  premise that justifies treating the modal `(host, repo) → 1
+  architect` mapping as the design center, not an edge case.

--- a/docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md
+++ b/docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md
@@ -69,9 +69,22 @@ step 2e is:
 ~/.board-superpowers/repos/<normalized>/audit.db
 ```
 
-Co-locating `audit.db` with `state.yml` keeps every per-`(host,
-repo)` artifact under the same `0700` parent, with one
-normalized-name sub-directory per pair (per `07-path-conventions.md`).
+Rendered as a SQLAlchemy DSN this becomes (note **4 slashes**
+between scheme and absolute path):
+
+```
+sqlite:////Users/<user>/.board-superpowers/repos/<normalized>/audit.db
+```
+
+**SQLite uses 4 slashes for absolute paths** (`sqlite:////` then
+`/Users/...`); the 3-slash form is interpreted relative to
+`cwd` per SQLAlchemy convention and would silently write to the
+wrong location. Because the suggested path is always absolute,
+every DSN this plugin emits or accepts MUST use the 4-slash
+form. Co-locating `audit.db` with `state.yml` keeps every
+per-`(host, repo)` artifact under the same `0700` parent, with
+one normalized-name sub-directory per pair (per
+`07-path-conventions.md`).
 
 ### Forces preserved (not relaxed by this ADR)
 

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -72,6 +72,7 @@ Omit if no such notes apply.
 | [0003](./0003-worktree-per-consumer.md) | One worktree per Consumer session | accepted |
 | [0004](./0004-composition-over-reimplementation.md) | Composition over reimplementation of TDD/QA | accepted |
 | [0005](./0005-board-adapter-contract.md) | v1 BoardAdapter contract surface | accepted |
-| [0006](./0006-producer-autonomy-boundary.md) | Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix | proposed |
+| [0006](./0006-producer-autonomy-boundary.md) | Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix | accepted (§5 partially superseded by ADR-0009) |
 | [0007](./0007-plugin-runtime-derived-constraints.md) | Plugin-runtime-derived constraints — three constraints arising from CC / Codex plugin physics | proposed |
 | [0008](./0008-plugin-to-plugin-skill-invocation.md) | Plugin-to-plugin composition via SKILL invocation (vs subagent spawn / MCP / direct import) | accepted |
+| [0009](./0009-allow-sqlite-as-byo-audit-db.md) | Allow SQLite as a BYO audit DB scheme (supersedes ADR-0006 §5 partial) | accepted |

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -72,7 +72,7 @@ Omit if no such notes apply.
 | [0003](./0003-worktree-per-consumer.md) | One worktree per Consumer session | accepted |
 | [0004](./0004-composition-over-reimplementation.md) | Composition over reimplementation of TDD/QA | accepted |
 | [0005](./0005-board-adapter-contract.md) | v1 BoardAdapter contract surface | accepted |
-| [0006](./0006-producer-autonomy-boundary.md) | Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix | accepted (§5 partially superseded by ADR-0009) |
+| [0006](./0006-producer-autonomy-boundary.md) | Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix | accepted |
 | [0007](./0007-plugin-runtime-derived-constraints.md) | Plugin-runtime-derived constraints — three constraints arising from CC / Codex plugin physics | proposed |
 | [0008](./0008-plugin-to-plugin-skill-invocation.md) | Plugin-to-plugin composition via SKILL invocation (vs subagent spawn / MCP / direct import) | accepted |
 | [0009](./0009-allow-sqlite-as-byo-audit-db.md) | Allow SQLite as a BYO audit DB scheme (supersedes ADR-0006 §5 partial) | accepted |

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,87 +1,235 @@
 #!/usr/bin/env bash
-# hooks/session-start.sh — board-superpowers SessionStart hook.
+# hooks/session-start.sh — board-superpowers SessionStart hook (Layer 1).
 #
-# Fires once per CC session at startup. Performs:
-#   1. Dependency check (delegated to scripts/check-deps.sh).
-#   2. State inspection (host-local state.yml + per-repo config.yml).
-#   3. Optional intent injection — emits one of the legal INVOKE markers
-#      per docs/architecture/0005-contracts/02-hook-contracts.md
-#      § "Intent-injection markers".
+# Fires once per CC / Codex session at startup. Per
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § "three-layer alert + intent-injection strategy" the hook performs
+# TWO roles:
+#   (a) dep alert — surface a banner when a dependency is missing or
+#       the consuming repo's AGENTS.md / CLAUDE.md lacks the routing block.
+#   (b) intent injection — when on-disk state implies a specific
+#       skill should be invoked, emit one of the legal markers per
+#       docs/architecture/0005-contracts/02-hook-contracts.md
+#       § "Intent-injection markers". v0.2.0 emits only
+#       INVOKE: bootstrapping-repo (manifest.yml or per-repo state.yml
+#       absent). INVOKE: migrating-repo-version is reserved for a future
+#       slice once schema-aware version comparison ships.
 #
-# In v1-minimum, intent injection is INTENTIONALLY DEGRADED:
-#   - bootstrapping-repo / migrating-repo-version markers are NOT emitted
-#     because those skills are deferred to v1-complete. Instead, the hook
-#     emits a friendly comment for first-time users so they aren't left
-#     wondering what to do.
-#
-# Output protocol: JSON to stdout per
+# Output protocol: ONE JSON object on stdout per
 # https://code.claude.com/docs/en/hooks (additionalContext rides as
 # extra system prompt for the session).
 #
-# The hook MUST exit 0 even when checks fail — non-zero exit blocks the
-# session, which is a worse failure mode than an unconfigured plugin.
+# The hook MUST exit 0 even when checks fail — non-zero exit blocks
+# the session, which is a worse failure mode than an unconfigured
+# plugin. Per 02-hook-contracts.md § "Exit codes": "board-superpowers'
+# invariant: hook failures MUST NEVER block session start."
+#
+# SELF-CONTAINED: this script MUST NOT source scripts/lib/common.sh,
+# per 02-hook-contracts.md § "Self-containment" (line 297-298) and
+# 05-bootstrap-surface.md § "Cross-cutting principles". A broken or
+# missing lib must never prevent session startup. The path
+# normalization helper bsp_normalize_repo_path (defined in
+# scripts/lib/common.sh) is duplicated INLINE below as
+# normalize_repo_path. Keep the two implementations in lockstep —
+# DO NOT deduplicate by sourcing.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
-# --- Dep check (best-effort) --------------------------------------------
-DEP_OUTPUT=""
-if bash "${PLUGIN_ROOT}/scripts/check-deps.sh" >/tmp/bsp-deps-$$.txt 2>&1; then
-    DEP_OUTPUT="$(cat /tmp/bsp-deps-$$.txt)"
-    DEP_OK="yes"
-else
-    DEP_OUTPUT="$(cat /tmp/bsp-deps-$$.txt)"
-    DEP_OK="no"
+# --- Inline helpers (intentionally NOT sourced from scripts/lib/common.sh)
+
+# normalize_repo_path — duplicate of bsp_normalize_repo_path in
+# scripts/lib/common.sh. Per spec the hook is self-contained; do not
+# refactor by sourcing common.sh. Strip leading "/", replace remaining
+# "/" with "-". Defensive trailing-slash strip.
+normalize_repo_path() {
+    local p="${1:-}"
+    [ -n "${p}" ] || return 1
+    case "${p}" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    p="${p%/}"
+    p="${p#/}"
+    printf '%s\n' "${p//\//-}"
+}
+
+# sanitize_dep_name — per 02-hook-contracts.md § "Sanitization
+# expectation". Replace any char outside [a-zA-Z0-9_-] with `-`,
+# truncate to 32 chars, drop the value entirely if it has no
+# alphanumeric content.
+sanitize_dep_name() {
+    local raw="${1:-}"
+    # Replace non-allowed chars with `-`.
+    local cleaned
+    cleaned="$(printf '%s' "${raw}" | LC_ALL=C tr -c 'a-zA-Z0-9_-' '-')"
+    # Truncate to 32 chars.
+    cleaned="${cleaned:0:32}"
+    # Drop if no alphanumeric content.
+    case "${cleaned}" in
+        *[a-zA-Z0-9]*) printf '%s' "${cleaned}" ;;
+        *) return 1 ;;
+    esac
+}
+
+# NOTE: 02-hook-contracts.md § "Sanitization expectation" cites a
+# pure-bash json_escape_string helper. We delegate JSON shaping to
+# Python's json.dumps below (which handles RFC 8259 §7 quoting,
+# control-char escaping, and \uXXXX for non-ASCII automatically), so
+# no shell-side escaper is needed. The sanitize_dep_name helper
+# above guards against control chars / markup leaking into
+# additionalContext at the value-extraction layer; json.dumps then
+# serializes the resulting string safely.
+
+# --- Plugin version (read from plugin.json; default to "unknown") ------
+PLUGIN_VERSION="unknown"
+PLUGIN_JSON="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+if [ -r "${PLUGIN_JSON}" ] && command -v python3 >/dev/null 2>&1; then
+    PLUGIN_VERSION="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get("version", "unknown"))
+except Exception:
+    print("unknown")
+' "${PLUGIN_JSON}" 2>/dev/null || printf 'unknown')"
 fi
-rm -f /tmp/bsp-deps-$$.txt
 
-# --- State inspection ---------------------------------------------------
-# v1-minimum: we don't yet have a manifest.yml convention; the deferred
-# bootstrapping-repo skill defines that. Instead we look for the
-# per-repo config.yml as a presence signal.
-REPO_ROOT="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || true)"
-HAS_CONFIG="no"
-if [ -n "${REPO_ROOT}" ] && [ -f "${REPO_ROOT}/.board-superpowers/config.yml" ]; then
-    HAS_CONFIG="yes"
+# --- Layer 1a: dep check (best-effort) ---------------------------------
+# Use --machine mode per 01-script-contracts.md so we get structured
+# output. Exit code is always 0 in machine mode; stdout is empty when
+# all is well, three lines (MISSING= / ROUTING_INJECTED= / PROJECT=)
+# when something is wrong.
+DEP_RAW=""
+DEP_SCRIPT="${PLUGIN_ROOT}/scripts/check-deps.sh"
+if [ -x "${DEP_SCRIPT}" ] || [ -r "${DEP_SCRIPT}" ]; then
+    DEP_RAW="$(bash "${DEP_SCRIPT}" --machine 2>/dev/null || true)"
+fi
+
+DEP_MISSING=""
+DEP_ROUTING="yes"
+if [ -n "${DEP_RAW}" ]; then
+    while IFS= read -r line; do
+        case "${line}" in
+            MISSING=*) DEP_MISSING="${line#MISSING=}" ;;
+            ROUTING_INJECTED=*) DEP_ROUTING="${line#ROUTING_INJECTED=}" ;;
+            PROJECT=*) ;;
+        esac
+    done <<< "${DEP_RAW}"
+fi
+
+# --- Layer 1b: state probe ---------------------------------------------
+# Per 05-bootstrap-surface.md § "State files":
+#   ~/.board-superpowers/manifest.yml             → manifest_present
+#   ~/.board-superpowers/repos/<normalized>/state.yml → state_present
+#
+# <normalized> derives from the repo root via the inline helper above.
+# A non-git working directory yields no state probe (state_present=yes
+# defensively — the hook only INVOKEs bootstrapping-repo when we are
+# certain a repo bootstrap is missing).
+
+REPO_ROOT=""
+if command -v git >/dev/null 2>&1; then
+    REPO_ROOT="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+
+MANIFEST_PRESENT="no"
+if [ -f "${HOME}/.board-superpowers/manifest.yml" ]; then
+    MANIFEST_PRESENT="yes"
+fi
+
+STATE_PRESENT="yes"
+NORMALIZED=""
+if [ -n "${REPO_ROOT}" ]; then
+    if NORMALIZED="$(normalize_repo_path "${REPO_ROOT}" 2>/dev/null)"; then
+        if [ -f "${HOME}/.board-superpowers/repos/${NORMALIZED}/state.yml" ]; then
+            STATE_PRESENT="yes"
+        else
+            STATE_PRESENT="no"
+        fi
+    fi
 fi
 
 # --- Build the additionalContext payload --------------------------------
-# Use a heredoc + python escape to avoid jq dependency.
-python3 - <<PY
-import json
-dep_ok = "${DEP_OK}"
-has_config = "${HAS_CONFIG}"
-dep_output = """${DEP_OUTPUT}"""
+# Order, per 02-hook-contracts.md "additionalContext body":
+#   1. Version banner (always).
+#   2. Dep / routing alert (when something is wrong) — most urgent.
+#   3. Intent-injection marker (when state files absent) — at most one.
+LINES=()
+LINES+=("board-superpowers v${PLUGIN_VERSION} loaded.")
 
-lines = ["board-superpowers v0.1.1 loaded."]
-if dep_ok != "yes":
-    lines.append("⚠️  Dependency check failed:")
-    lines.append(dep_output)
-    lines.append("Run scripts/check-deps.sh to see what to install.")
+if [ -n "${DEP_MISSING}" ] || [ "${DEP_ROUTING}" = "no" ]; then
+    LINES+=("")
+    LINES+=("⚠️  dependency check or routing-block issue detected.")
+    if [ -n "${DEP_MISSING}" ]; then
+        # Sanitize each comma-separated dep name before interpolating.
+        clean_csv=""
+        IFS=',' read -ra raw_parts <<< "${DEP_MISSING}"
+        for raw in "${raw_parts[@]}"; do
+            if clean="$(sanitize_dep_name "${raw}")" && [ -n "${clean}" ]; then
+                if [ -n "${clean_csv}" ]; then
+                    clean_csv="${clean_csv},${clean}"
+                fi
+                if [ -z "${clean_csv}" ]; then
+                    clean_csv="${clean}"
+                fi
+            fi
+        done
+        if [ -n "${clean_csv}" ]; then
+            LINES+=("Missing: ${clean_csv}")
+        fi
+    fi
+    if [ "${DEP_ROUTING}" = "no" ]; then
+        LINES+=("Routing block missing from AGENTS.md / CLAUDE.md.")
+    fi
+    LINES+=("Run scripts/check-deps.sh for details.")
+fi
 
-if has_config == "no":
-    lines.append("")
-    lines.append("ℹ️  No .board-superpowers/config.yml in this repo yet.")
-    lines.append("   In v1-complete, the bootstrapping-repo skill auto-handles first-time setup.")
-    lines.append("   In v1-minimum, set up the GitHub Project + standard labels manually,")
-    lines.append("   then create .board-superpowers/config.yml with your project's owner/number.")
+# Intent-injection marker: at most one INVOKE: per payload (per
+# 02-hook-contracts.md line 218-222). manifest absent or state.yml
+# absent both route to bootstrapping-repo; pick a single REASON line.
+if [ "${MANIFEST_PRESENT}" = "no" ] || [ "${STATE_PRESENT}" = "no" ]; then
+    LINES+=("")
+    LINES+=("INVOKE: bootstrapping-repo")
+    if [ "${MANIFEST_PRESENT}" = "no" ]; then
+        LINES+=("REASON: ~/.board-superpowers/manifest.yml absent (host bootstrap pending).")
+    else
+        LINES+=("REASON: per-repo state.yml absent for this (host, repo) pair.")
+    fi
+fi
 
-# Routing hint — board-superpowers session routing block lives in CLAUDE.md
-# / AGENTS.md. The hook does NOT inject INVOKE markers in v1-minimum
-# because the deferred entry-skill consumers (bootstrapping-repo /
-# migrating-repo-version) don't exist yet. The molecular routing
-# (managing-board / consuming-card) is driven by user prompt content,
-# not by hook intent injection in v1-minimum.
+# --- Emit JSON via Python (RFC 8259 quoting) ---------------------------
+# Python is part of our dep set; if it is missing, the hook silently
+# no-ops (we don't have a JSON-emitter fallback and emitting hand-
+# escaped JSON without python is fragile per the inline json_escape
+# helper above — which we use only for status-line interpolation, not
+# top-level JSON shape).
+if ! command -v python3 >/dev/null 2>&1; then
+    exit 0
+fi
 
-payload = {
+joined=""
+for ln in "${LINES[@]}"; do
+    if [ -z "${joined}" ]; then
+        joined="${ln}"
+    else
+        joined="${joined}"$'\n'"${ln}"
+    fi
+done
+
+PAYLOAD_TEXT="${joined}" python3 - <<'PY' || true
+import json, os, sys
+text = os.environ.get("PAYLOAD_TEXT", "")
+out = {
     "hookSpecificOutput": {
         "hookEventName": "SessionStart",
-        "additionalContext": "\n".join(lines)
+        "additionalContext": text,
     }
 }
-print(json.dumps(payload))
+sys.stdout.write(json.dumps(out))
+sys.stdout.write("\n")
 PY
 
 exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -30,7 +30,10 @@
 # missing lib must never prevent session startup. The path
 # normalization helper bsp_normalize_repo_path (defined in
 # scripts/lib/common.sh) is duplicated INLINE below as
-# normalize_repo_path. Keep the two implementations in lockstep —
+# normalize_repo_path. The primary-repo-root resolver
+# bsp_primary_repo_root is duplicated inline as primary_repo_root.
+# The REASON-line sanitizer sanitize_reason_line is also duplicated
+# inline. Keep the implementations in lockstep —
 # DO NOT deduplicate by sourcing.
 
 set -euo pipefail
@@ -72,6 +75,61 @@ sanitize_dep_name() {
         *[a-zA-Z0-9]*) printf '%s' "${cleaned}" ;;
         *) return 1 ;;
     esac
+}
+
+# sanitize_reason_line — per 02-hook-contracts.md § "Intent-injection
+# markers" lines 213-216 grammar rule: REASON value is "plain ASCII,
+# ≤120 chars, punctuation only `. , ; : - ( )`. No newlines, no JSON,
+# no markup." Drop everything outside that whitelist; truncate to 200
+# chars (well over the spec's 120-char ceiling, leaves headroom for the
+# REASON: prefix accounting elsewhere).
+#
+# Note: sanitize_dep_name's 32-char truncation is too aggressive for a
+# REASON sentence; this helper exists separately. DUPLICATION NOTICE:
+# duplicated as bsp_sanitize_reason_line in scripts/lib/common.sh —
+# keep the two implementations in lockstep per the self-containment
+# contract.
+sanitize_reason_line() {
+    local raw="${1:-}"
+    LC_ALL=C printf '%s' "${raw}" \
+        | LC_ALL=C tr -cd 'a-zA-Z0-9 .,;:\-()' \
+        | head -c 200
+}
+
+# primary_repo_root — resolve PWD to the absolute path of the PRIMARY
+# repo root, NOT the worktree root. From inside a `git worktree`,
+# `git rev-parse --show-toplevel` returns the worktree path; that
+# path normalizes to a different `<normalized>` than the canonical
+# repo, so the hook's per-repo state.yml lookup misses and the hook
+# falsely emits INVOKE: bootstrapping-repo for an already-bootstrapped
+# repo. This helper uses `git rev-parse --git-common-dir` (which
+# always points at the primary repo's .git/ regardless of worktree
+# vs primary) and walks up one level to the primary working tree.
+#
+# Args: <cwd>
+# Stdout: absolute primary-repo-root path on success; nothing on failure.
+# Returns: 0 on success, 1 if not in a git repo (caller should fall
+#   back to `pwd -P`).
+#
+# DUPLICATION NOTICE: duplicated as bsp_primary_repo_root in
+# scripts/lib/common.sh — keep the two implementations in lockstep
+# per the self-containment contract (02-hook-contracts.md
+# § "Self-containment" lines 295-303).
+primary_repo_root() {
+    local cwd="${1:-${PWD}}"
+    command -v git >/dev/null 2>&1 || return 1
+    local common_dir
+    common_dir="$(git -C "${cwd}" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "${common_dir}" ] || return 1
+    # --git-common-dir may return absolute or relative; canonicalize.
+    case "${common_dir}" in
+        /*) ;;
+        *) common_dir="${cwd}/${common_dir}" ;;
+    esac
+    # `dirname` of the primary `.git/` directory is the primary
+    # working tree. Run through `pwd -P` to resolve symlinks (macOS
+    # /var → /private/var bites here otherwise).
+    (cd "$(dirname "${common_dir}")" 2>/dev/null && pwd -P) || return 1
 }
 
 # NOTE: 02-hook-contracts.md § "Sanitization expectation" cites a
@@ -130,9 +188,18 @@ fi
 # defensively — the hook only INVOKEs bootstrapping-repo when we are
 # certain a repo bootstrap is missing).
 
+# Resolve PWD to the PRIMARY repo root, not a worktree root.
+# `git rev-parse --show-toplevel` returns the worktree path when run
+# inside a worktree; the worktree's path normalizes to a different
+# `<normalized>` than the canonical repo, which would make the hook
+# falsely emit INVOKE: bootstrapping-repo for an already-bootstrapped
+# repo. Fall back to `pwd -P` of $PWD on non-git directories so the
+# hook degrades gracefully without crashing.
 REPO_ROOT=""
-if command -v git >/dev/null 2>&1; then
-    REPO_ROOT="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || true)"
+if REPO_ROOT="$(primary_repo_root "${PWD}")" && [ -n "${REPO_ROOT}" ]; then
+    :
+else
+    REPO_ROOT=""
 fi
 
 MANIFEST_PRESENT="no"
@@ -190,14 +257,25 @@ fi
 # Intent-injection marker: at most one INVOKE: per payload (per
 # 02-hook-contracts.md line 218-222). manifest absent or state.yml
 # absent both route to bootstrapping-repo; pick a single REASON line.
+#
+# REASON grammar (02-hook-contracts.md lines 213-216):
+#   plain ASCII, ≤120 chars, punctuation only `. , ; : - ( )`.
+#   No newlines, no JSON, no markup.
+# The `~` and `/` characters previously used in path mentions are
+# OUTSIDE the whitelist; rephrase without paths and pass through
+# sanitize_reason_line as a defensive net.
 if [ "${MANIFEST_PRESENT}" = "no" ] || [ "${STATE_PRESENT}" = "no" ]; then
     LINES+=("")
     LINES+=("INVOKE: bootstrapping-repo")
-    if [ "${MANIFEST_PRESENT}" = "no" ]; then
-        LINES+=("REASON: ~/.board-superpowers/manifest.yml absent (host bootstrap pending).")
+    raw_reason=""
+    if [ "${MANIFEST_PRESENT}" = "no" ] && [ "${STATE_PRESENT}" = "no" ]; then
+        raw_reason="host bootstrap pending; both manifest and per-repo state files are absent."
+    elif [ "${MANIFEST_PRESENT}" = "no" ]; then
+        raw_reason="host bootstrap pending; manifest is absent."
     else
-        LINES+=("REASON: per-repo state.yml absent for this (host, repo) pair.")
+        raw_reason="per-repo bootstrap pending; state file is absent."
     fi
+    LINES+=("REASON: $(sanitize_reason_line "${raw_reason}")")
 fi
 
 # --- Emit JSON via Python (RFC 8259 quoting) ---------------------------

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -23,9 +23,16 @@
 #
 # Path: ${HOME}/.board-superpowers/manifest.yml. Mode: dir 0700, file 0644.
 #
-# Atomicity: write to manifest.yml.tmp first, then atomic mv to the final
-# path. If the mv fails the .tmp file is removed so a Ctrl-C / crash
-# never leaves a half-written manifest behind.
+# Atomicity: render to a per-process scratch file (mktemp) in the same
+# directory, chmod, then atomic mv to the final path. If the mv fails
+# the scratch file is removed so a Ctrl-C / crash never leaves a
+# half-written manifest behind. Per-process tmp filenames mean two
+# concurrent invocations on the same host never race on a shared
+# scratch file — both render their own .tmp and then race on the final
+# rename(2), which POSIX guarantees atomic for same-filesystem moves.
+# Loser's manifest content overwrites winner's, but both writers
+# produce semantically equivalent payloads (same plugin version,
+# timestamps differ by at most µs), so the result is consistent.
 #
 # Argument vector:
 #   bash scripts/bootstrap-host.sh                  # interactive default
@@ -124,21 +131,29 @@ print(v)
 
 STATE_DIR="${HOME}/.board-superpowers"
 MANIFEST="${STATE_DIR}/manifest.yml"
-MANIFEST_TMP="${MANIFEST}.tmp"
+# MANIFEST_TMP is set per-call inside write_manifest() via mktemp so
+# concurrent invocations never collide on a shared scratch file.
+MANIFEST_TMP=""
 
 # --- Helpers ------------------------------------------------------------
 
 # Read a top-level scalar field from a flat YAML file using grep + sed.
 # The shape is fully predictable (3 lines, no nesting); a real YAML
 # parser is overkill. Returns empty string when absent.
+#
+# YAML tolerates whitespace on either side of the `:` separator
+# (`key: value`, `key : value`, `key  :value` are all valid). The
+# regex below admits any amount of whitespace before the colon so a
+# hand-edited manifest with `last_seen_version : "0.2.0"` still
+# parses; this matches what real YAML libraries do.
 yaml_get() {
     local file="$1"
     local key="$2"
     [ -f "${file}" ] || return 0
-    # Match `key: <value>` at line start; strip optional surrounding quotes.
-    grep -E "^${key}:[[:space:]]" "${file}" 2>/dev/null \
+    # Match `key<ws>*:<ws>*<value>` at line start; strip surrounding quotes.
+    grep -E "^${key}[[:space:]]*:" "${file}" 2>/dev/null \
         | head -n1 \
-        | sed -E "s/^${key}:[[:space:]]*//; s/^\"//; s/\"$//"
+        | sed -E "s/^${key}[[:space:]]*:[[:space:]]*//; s/^\"//; s/\"$//"
 }
 
 iso_utc_now() {
@@ -147,7 +162,10 @@ iso_utc_now() {
 }
 
 # write_manifest <bootstrapped_at> <version>
-# Atomic: render to .tmp, chmod, then mv. On mv failure, scrub the .tmp.
+# Atomic: render to a unique per-process .tmp (mktemp), chmod, then mv.
+# On mv failure, scrub the unique .tmp. Two concurrent F-B1 runs each
+# get their own scratch file and never race on a shared path; the
+# final rename(2) is POSIX-atomic.
 write_manifest() {
     local ts="$1"
     local version="$2"
@@ -161,7 +179,20 @@ write_manifest() {
         bsp_die "refuses to write: ${MANIFEST} exists as a directory, not a file"
     fi
 
-    # Trap so any unexpected exit (Ctrl-C, write failure) cleans .tmp.
+    # Per-process unique scratch file in the same directory as the
+    # final manifest, so the subsequent mv is a same-filesystem move
+    # (rename(2) atomic). The Xs MUST be trailing — BSD mktemp on
+    # macOS only randomizes trailing Xs, not middle-of-template Xs,
+    # so a `.tmp` suffix after the Xs would defeat uniqueness and
+    # cause concurrent invocations to collide on a literal filename.
+    # We use a `.tmp.` PREFIX before the random tail to keep the
+    # scratch files identifiable in directory listings and easy to
+    # clean up.
+    MANIFEST_TMP="$(mktemp "${MANIFEST}.tmp.XXXXXX")" \
+        || bsp_die "could not create temp manifest in ${STATE_DIR}"
+
+    # Trap so any unexpected exit (Ctrl-C, write failure) cleans the
+    # unique .tmp file. The trap reads MANIFEST_TMP at fire time.
     trap 'rm -f "${MANIFEST_TMP}"' EXIT
 
     cat > "${MANIFEST_TMP}" <<EOF
@@ -200,6 +231,10 @@ if [ -f "${MANIFEST}" ] && [ "${FORCE}" -eq 0 ]; then
     EXISTING_TS="$(yaml_get "${MANIFEST}" host_bootstrapped_at)"
 
     if [ "${EXISTING_VERSION}" = "${PLUGIN_VERSION}" ]; then
+        # Defensive: even on the no-write fast path, converge file
+        # mode to 0644 in case a hand-edit (or umask drift) left the
+        # file at 0600 / 0400 / etc. Cheap, idempotent.
+        chmod 0644 "${MANIFEST}"
         bsp_log "manifest current at ${MANIFEST} (last_seen_version=${PLUGIN_VERSION}); no write"
         printf '%s\n' "${MANIFEST}"
         exit 0

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# scripts/bootstrap-host.sh — F-B1 host bootstrap.
+#
+# Spec:
+#   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+#     § 1.5.1 F-B1. Host bootstrap
+#   docs/architecture/0005-contracts/07-path-conventions.md
+#     § "Per-host layout"
+#
+# Capability: when ~/.board-superpowers/manifest.yml is absent, run the
+# cross-repo, per-machine initialization — create ~/.board-superpowers/
+# (mode 0700) and write the initial manifest. When the manifest is
+# present, refresh `last_seen_version` if the on-disk value is behind
+# the running plugin's version (host_bootstrapped_at is preserved). The
+# `--force` flag overwrites unconditionally; intended for dev / migration
+# scenarios.
+#
+# Authoritative manifest.yml shape (per spec lines 122-126):
+#
+#   schema_version: 1
+#   host_bootstrapped_at: "2026-04-26T10:30:00Z"
+#   last_seen_version: "0.1.0"
+#
+# Path: ${HOME}/.board-superpowers/manifest.yml. Mode: dir 0700, file 0644.
+#
+# Atomicity: write to manifest.yml.tmp first, then atomic mv to the final
+# path. If the mv fails the .tmp file is removed so a Ctrl-C / crash
+# never leaves a half-written manifest behind.
+#
+# Argument vector:
+#   bash scripts/bootstrap-host.sh                  # interactive default
+#   bash scripts/bootstrap-host.sh --force          # overwrite even when
+#                                                   # manifest is correct
+#   bash scripts/bootstrap-host.sh --plugin-root P  # override
+#                                                   # CLAUDE_PLUGIN_ROOT
+#                                                   # for testability
+#
+# Exit codes:
+#   0 — success (manifest written, refreshed, or already current).
+#   1 — bad args / mkdir failure / write failure / bad plugin root.
+#
+# Output:
+#   stderr — bsp_log progress lines (human-readable).
+#   stdout — on success, the absolute path of the written / refreshed
+#            manifest. Callers can pipe this to other scripts.
+#
+# Self-containment note: this script DOES source scripts/lib/common.sh.
+# That is allowed because F-B1 runs AFTER the dep check (check-deps.sh)
+# has already verified the lib's integrity (per spec § "Self-contained
+# scripts at the dep-check layer" — only check-deps.sh and the
+# SessionStart hook are barred from sourcing common.sh).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/common.sh
+. "${SCRIPT_DIR}/lib/common.sh"
+
+# --- Arg parsing --------------------------------------------------------
+
+FORCE=0
+PLUGIN_ROOT_ARG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force)
+            FORCE=1
+            shift
+            ;;
+        --plugin-root)
+            PLUGIN_ROOT_ARG="${2:-}"
+            if [ -z "${PLUGIN_ROOT_ARG}" ]; then
+                bsp_die "--plugin-root requires a path argument"
+            fi
+            shift 2
+            ;;
+        --help|-h)
+            sed -n '2,/^set -euo pipefail/p' "${BASH_SOURCE[0]}" >&2
+            exit 0
+            ;;
+        *)
+            bsp_die "unknown argument: $1 (try --help)"
+            ;;
+    esac
+done
+
+# --- Resolve plugin root + version --------------------------------------
+
+if [ -n "${PLUGIN_ROOT_ARG}" ]; then
+    PLUGIN_ROOT="${PLUGIN_ROOT_ARG}"
+else
+    PLUGIN_ROOT="$(bsp_plugin_root)"
+fi
+
+if [ ! -d "${PLUGIN_ROOT}" ]; then
+    bsp_die "plugin root not found: ${PLUGIN_ROOT}"
+fi
+
+PLUGIN_JSON="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+if [ ! -f "${PLUGIN_JSON}" ]; then
+    bsp_die "plugin.json not found at ${PLUGIN_JSON}"
+fi
+
+bsp_require_cmd python3 "macOS / Linux ship python3 by default"
+
+# Read the version field. Errors out cleanly if the JSON is malformed
+# or the version field is missing.
+PLUGIN_VERSION="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except (OSError, ValueError) as e:
+    sys.stderr.write('cannot read plugin.json: ' + str(e) + '\n')
+    sys.exit(1)
+v = data.get('version')
+if not v:
+    sys.stderr.write('plugin.json missing version field\n')
+    sys.exit(1)
+print(v)
+" "${PLUGIN_JSON}")" || bsp_die "failed to read version from ${PLUGIN_JSON}"
+
+# --- Resolve target paths -----------------------------------------------
+
+STATE_DIR="${HOME}/.board-superpowers"
+MANIFEST="${STATE_DIR}/manifest.yml"
+MANIFEST_TMP="${MANIFEST}.tmp"
+
+# --- Helpers ------------------------------------------------------------
+
+# Read a top-level scalar field from a flat YAML file using grep + sed.
+# The shape is fully predictable (3 lines, no nesting); a real YAML
+# parser is overkill. Returns empty string when absent.
+yaml_get() {
+    local file="$1"
+    local key="$2"
+    [ -f "${file}" ] || return 0
+    # Match `key: <value>` at line start; strip optional surrounding quotes.
+    grep -E "^${key}:[[:space:]]" "${file}" 2>/dev/null \
+        | head -n1 \
+        | sed -E "s/^${key}:[[:space:]]*//; s/^\"//; s/\"$//"
+}
+
+iso_utc_now() {
+    # GNU/BSD `date -u +%FT%TZ` is portable.
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# write_manifest <bootstrapped_at> <version>
+# Atomic: render to .tmp, chmod, then mv. On mv failure, scrub the .tmp.
+write_manifest() {
+    local ts="$1"
+    local version="$2"
+
+    # Defensive: refuse to proceed if the target path exists as a
+    # directory. A bare `mv source dir/` succeeds on POSIX by moving
+    # source INTO the directory rather than overwriting it — which
+    # silently lands the new manifest at manifest.yml/manifest.yml.tmp
+    # and corrupts the layout. Detect this up front.
+    if [ -d "${MANIFEST}" ]; then
+        bsp_die "refuses to write: ${MANIFEST} exists as a directory, not a file"
+    fi
+
+    # Trap so any unexpected exit (Ctrl-C, write failure) cleans .tmp.
+    trap 'rm -f "${MANIFEST_TMP}"' EXIT
+
+    cat > "${MANIFEST_TMP}" <<EOF
+schema_version: 1
+host_bootstrapped_at: "${ts}"
+last_seen_version: "${version}"
+EOF
+
+    chmod 0644 "${MANIFEST_TMP}"
+
+    # Atomic mv. If the target is otherwise not overwritable
+    # (read-only filesystem, etc.), mv fails — surface the error and
+    # clean the .tmp.
+    if ! mv "${MANIFEST_TMP}" "${MANIFEST}" 2>/dev/null; then
+        rm -f "${MANIFEST_TMP}"
+        trap - EXIT
+        bsp_die "atomic mv to ${MANIFEST} failed"
+    fi
+
+    trap - EXIT
+}
+
+# --- Main flow ----------------------------------------------------------
+
+# Ensure state dir exists with mode 0700 (idempotent).
+if ! mkdir -p "${STATE_DIR}"; then
+    bsp_die "failed to create ${STATE_DIR}"
+fi
+chmod 0700 "${STATE_DIR}"
+
+NOW_TS="$(iso_utc_now)"
+
+if [ -f "${MANIFEST}" ] && [ "${FORCE}" -eq 0 ]; then
+    # Manifest exists. Decide between idempotent no-op and version refresh.
+    EXISTING_VERSION="$(yaml_get "${MANIFEST}" last_seen_version)"
+    EXISTING_TS="$(yaml_get "${MANIFEST}" host_bootstrapped_at)"
+
+    if [ "${EXISTING_VERSION}" = "${PLUGIN_VERSION}" ]; then
+        bsp_log "manifest current at ${MANIFEST} (last_seen_version=${PLUGIN_VERSION}); no write"
+        printf '%s\n' "${MANIFEST}"
+        exit 0
+    fi
+
+    # Version refresh — preserve host_bootstrapped_at, bump version.
+    if [ -z "${EXISTING_TS}" ]; then
+        # Defensive: if the file is malformed and the timestamp is
+        # missing, regenerate one rather than write `""`.
+        EXISTING_TS="${NOW_TS}"
+        bsp_warn "existing manifest missing host_bootstrapped_at; regenerating"
+    fi
+
+    bsp_log "refreshing last_seen_version: ${EXISTING_VERSION:-<unset>} → ${PLUGIN_VERSION}"
+    write_manifest "${EXISTING_TS}" "${PLUGIN_VERSION}"
+    bsp_log "wrote ${MANIFEST}"
+    printf '%s\n' "${MANIFEST}"
+    exit 0
+fi
+
+# Either the manifest is absent OR --force was supplied.
+if [ "${FORCE}" -eq 1 ] && [ -e "${MANIFEST}" ]; then
+    bsp_log "--force: overwriting ${MANIFEST}"
+else
+    bsp_log "writing manifest.yml..."
+fi
+
+write_manifest "${NOW_TS}" "${PLUGIN_VERSION}"
+bsp_log "wrote ${MANIFEST}"
+printf '%s\n' "${MANIFEST}"
+exit 0

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # scripts/bootstrap-project.sh — F-B2 per-repo bootstrap engine
-# (slices 2 + 3 — steps 2a-2e + initial state.yml write).
+# (slices 2 + 3 + 4 — steps 2a-2e, step 4 routing block injection,
+# initial state.yml write with routing_blocks[]).
 #
 # Spec:
 #   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
@@ -18,10 +19,9 @@
 # Capability: when invoked with --owner/--project/--repo-root, run
 # F-B2 steps 2a-2e (standard labels via setup-labels.sh, Status field
 # validation, config.yml write, .gitignore append, BYO-RDBMS credential
-# UX) and write the initial host-local state.yml. Step 4 (routing
-# block injection) is deferred to slice 4 of the same card;
-# routing_blocks is written as the empty list [] so the state file is
-# valid v1 schema today.
+# UX), step 4 (dual-file routing block injection into AGENTS.md +
+# CLAUDE.md with per-file SHA256 tamper hashes), and write the initial
+# host-local state.yml with the recorded routing_blocks[] entries.
 #
 # Argument vector:
 #   bash scripts/bootstrap-project.sh \
@@ -59,6 +59,8 @@
 #   3  step 2a (labels) delegation failed
 #   4  step 2e BYO-RDBMS config invalid (bad scheme; sqlite parent
 #      not writable; interactive retry budget exhausted)
+#   5  step 4 routing block injection blocked by orphan markers
+#      (only one of opening / closing marker present in target file)
 #   64 unknown argument
 
 set -euo pipefail
@@ -670,6 +672,57 @@ else
     audit_interactive_prompt
 fi
 
+# --- Step 4 — dual-file routing block injection --------------------------
+#
+# Per spec § 1.5.2 step 4: inject the canonical routing block into
+# <repo>/AGENTS.md AND <repo>/CLAUDE.md between the marker pair, record
+# per-file SHA256 hashes for state.yml:routing_blocks[].
+#
+# Source-of-truth file:
+#   <plugin-root>/skills/using-board-superpowers/references/agentsmd-routing.md
+#
+# Helper: bsp_inject_routing_block (in scripts/lib/common.sh) — handles
+# normalization, marker scan, atomic write. Returns exit 5 on orphan
+# markers (one but not both); on that we abort step 4 BEFORE any
+# state.yml write so the repo stays in pre-bootstrap state.
+
+ROUTING_SOURCE="${PLUGIN_ROOT}/skills/using-board-superpowers/references/agentsmd-routing.md"
+if [ ! -f "${ROUTING_SOURCE}" ]; then
+    bsp_die "step 4: routing source not found at ${ROUTING_SOURCE}"
+fi
+
+bsp_log "step 4: injecting routing block into AGENTS.md + CLAUDE.md"
+
+ROUTING_HASH_AGENTS=""
+ROUTING_HASH_CLAUDE=""
+
+# AGENTS.md.
+set +e
+ROUTING_HASH_AGENTS="$(bsp_inject_routing_block "${REPO_ROOT}/AGENTS.md" "${ROUTING_SOURCE}")"
+RC_AGENTS=$?
+set -e
+if [ "${RC_AGENTS}" -eq 5 ]; then
+    # Orphan marker — error already printed verbatim by helper. Pass
+    # through the same exit code so end-to-end tests can grep for
+    # "F-B2 step 4" in stderr.
+    exit 5
+fi
+if [ "${RC_AGENTS}" -ne 0 ]; then
+    bsp_die "step 4: routing injection into ${REPO_ROOT}/AGENTS.md failed (exit ${RC_AGENTS})"
+fi
+
+# CLAUDE.md.
+set +e
+ROUTING_HASH_CLAUDE="$(bsp_inject_routing_block "${REPO_ROOT}/CLAUDE.md" "${ROUTING_SOURCE}")"
+RC_CLAUDE=$?
+set -e
+if [ "${RC_CLAUDE}" -eq 5 ]; then
+    exit 5
+fi
+if [ "${RC_CLAUDE}" -ne 0 ]; then
+    bsp_die "step 4: routing injection into ${REPO_ROOT}/CLAUDE.md failed (exit ${RC_CLAUDE})"
+fi
+
 # --- Step 3 — initial state.yml write (host-local) -----------------------
 
 # Ensure ~/.board-superpowers exists at mode 0700; mkdir -p is idempotent.
@@ -700,6 +753,9 @@ yaml_get() {
 write_state_yml() {
     local ts="$1"
     local version="$2"
+    local hash_agents="$3"
+    local hash_claude="$4"
+    local routing_ts="$5"
 
     if [ -d "${STATE_FILE}" ]; then
         bsp_die "refuses to write: ${STATE_FILE} exists as a directory, not a file"
@@ -711,15 +767,29 @@ write_state_yml() {
     # shellcheck disable=SC2064
     trap "rm -f '${tmp}'" EXIT
 
-    cat > "${tmp}" <<EOF
-schema_version: 1
-repo_bootstrapped_at: "${ts}"
-last_seen_version_in_repo: "${version}"
-features_enabled:
-  - bootstrap.host
-  - bootstrap.per_repo
-routing_blocks: []
-EOF
+    {
+        printf 'schema_version: 1\n'
+        printf 'repo_bootstrapped_at: "%s"\n' "${ts}"
+        printf 'last_seen_version_in_repo: "%s"\n' "${version}"
+        printf 'features_enabled:\n'
+        printf '  - bootstrap.host\n'
+        printf '  - bootstrap.per_repo\n'
+        if [ -n "${hash_agents}" ] || [ -n "${hash_claude}" ]; then
+            printf 'routing_blocks:\n'
+            if [ -n "${hash_agents}" ]; then
+                printf '  - target_file: "AGENTS.md"\n'
+                printf '    block_hash: "sha256:%s"\n' "${hash_agents}"
+                printf '    injected_at: "%s"\n' "${routing_ts}"
+            fi
+            if [ -n "${hash_claude}" ]; then
+                printf '  - target_file: "CLAUDE.md"\n'
+                printf '    block_hash: "sha256:%s"\n' "${hash_claude}"
+                printf '    injected_at: "%s"\n' "${routing_ts}"
+            fi
+        else
+            printf 'routing_blocks: []\n'
+        fi
+    } > "${tmp}"
 
     chmod 0644 "${tmp}"
 
@@ -752,14 +822,16 @@ if [ -f "${STATE_FILE}" ]; then
         else
             bsp_log "state.yml refresh: ${EXISTING_VERSION:-<unset>} → ${PLUGIN_VERSION}"
         fi
-        write_state_yml "${EXISTING_TS}" "${PLUGIN_VERSION}"
+        write_state_yml "${EXISTING_TS}" "${PLUGIN_VERSION}" \
+            "${ROUTING_HASH_AGENTS}" "${ROUTING_HASH_CLAUDE}" "${NOW_TS}"
         bsp_log "wrote ${STATE_FILE}"
     fi
 else
     bsp_log "writing initial state.yml at ${STATE_FILE}"
-    write_state_yml "${NOW_TS}" "${PLUGIN_VERSION}"
+    write_state_yml "${NOW_TS}" "${PLUGIN_VERSION}" \
+        "${ROUTING_HASH_AGENTS}" "${ROUTING_HASH_CLAUDE}" "${NOW_TS}"
     bsp_log "wrote ${STATE_FILE}"
 fi
 
-bsp_log "F-B2 slice 3 complete (steps 2a-2e + initial state.yml). Slice 4 (routing block injection) deferred."
+bsp_log "F-B2 slice 4 complete (steps 2a-2e + step 4 routing block injection + state.yml with routing_blocks)."
 exit 0

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -1,25 +1,27 @@
 #!/usr/bin/env bash
 # scripts/bootstrap-project.sh — F-B2 per-repo bootstrap engine
-# (slice 2 — steps 2a-2d + initial state.yml write).
+# (slices 2 + 3 — steps 2a-2e + initial state.yml write).
 #
 # Spec:
 #   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
-#     § 1.5.2 F-B2. Per-repo bootstrap (steps 1, 2a-2d, 3 — initial
+#     § 1.5.2 F-B2. Per-repo bootstrap (steps 1, 2a-2e, 3 — initial
 #     state.yml write).
-#   docs/architecture/0005-contracts/03-config-schemas.md (config.yml
-#     and state.yml shapes).
+#   docs/architecture/0005-contracts/03-config-schemas.md (config.yml,
+#     credentials.yml, and state.yml shapes; 6-scheme allowlist).
 #   docs/architecture/0005-contracts/05-github-artifact-schemas.md
 #     § "Project v2 Status enum" (canonical 6-option contract).
 #   docs/architecture/0005-contracts/07-path-conventions.md
 #     § "Per-host layout" + "The .gitignore block".
+#   docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md
+#     (6-scheme allowlist; SQLite 4-slash absolute-path convention).
 #
 # Capability: when invoked with --owner/--project/--repo-root, run
-# F-B2 steps 2a-2d (standard labels via setup-labels.sh, Status field
-# validation, config.yml write, .gitignore append) and write the
-# initial host-local state.yml. Step 2e (BYO-RDBMS UX) and step 4
-# (routing block injection) are deferred to slices 3 + 4 of the
-# same card; routing_blocks is written as the empty list [] so the
-# state file is valid v1 schema today.
+# F-B2 steps 2a-2e (standard labels via setup-labels.sh, Status field
+# validation, config.yml write, .gitignore append, BYO-RDBMS credential
+# UX) and write the initial host-local state.yml. Step 4 (routing
+# block injection) is deferred to slice 4 of the same card;
+# routing_blocks is written as the empty list [] so the state file is
+# valid v1 schema today.
 #
 # Argument vector:
 #   bash scripts/bootstrap-project.sh \
@@ -30,16 +32,30 @@
 #                             # config.yml even when present)
 #       [--plugin-root P]     # for testability; defaults to derived
 #                             # from this file's location
+#       [--audit-db-url URL]  # non-interactive override for step 2e;
+#                             # highest precedence (above
+#                             # $BOARD_SP_AUDIT_DB_URL and pre-existing
+#                             # credentials.yml). Same 6-scheme
+#                             # allowlist applies.
 #
 # --owner and --project are REQUIRED for step 2b (Status field check).
 # --repo-root defaults to ${CLAUDE_PROJECT_DIR:-$PWD} resolved to
 # `git rev-parse --show-toplevel`.
+#
+# Step 2e BYO-RDBMS resolution priority:
+#   1. --audit-db-url FLAG (highest)
+#   2. $BOARD_SP_AUDIT_DB_URL env var
+#   3. pre-existing ~/.board-superpowers/credentials.yml (with valid
+#      audit_db_url)
+#   4. interactive prompt
 #
 # Exit codes:
 #   0  success
 #   1  bad args / file write failure
 #   2  Status field drift detected (step 2b)
 #   3  step 2a (labels) delegation failed
+#   4  step 2e BYO-RDBMS config invalid (bad scheme; sqlite parent
+#      not writable; interactive retry budget exhausted)
 #   64 unknown argument
 
 set -euo pipefail
@@ -55,6 +71,7 @@ PROJECT_NUM=""
 REPO_ROOT_ARG=""
 FORCE=0
 PLUGIN_ROOT_ARG=""
+AUDIT_DB_URL_FLAG=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -80,6 +97,11 @@ while [ $# -gt 0 ]; do
         --plugin-root)
             PLUGIN_ROOT_ARG="${2:-}"
             [ -n "${PLUGIN_ROOT_ARG}" ] || bsp_die "--plugin-root requires a path"
+            shift 2
+            ;;
+        --audit-db-url)
+            AUDIT_DB_URL_FLAG="${2:-}"
+            [ -n "${AUDIT_DB_URL_FLAG}" ] || bsp_die "--audit-db-url requires a value"
             shift 2
             ;;
         --help|-h)
@@ -312,6 +334,300 @@ else
     write_gitignore_block 0
 fi
 
+# --- Step 2e — BYO-RDBMS audit-log credential UX -------------------------
+#
+# Per spec § 1.5.2 step 2e + 03-config-schemas.md credentials.yml schema +
+# ADR-0009. Three paths:
+#   A. --audit-db-url FLAG or $BOARD_SP_AUDIT_DB_URL env var   →
+#      validate scheme, do NOT write credentials.yml (the runtime
+#      override IS the credential).
+#   B. pre-existing ~/.board-superpowers/credentials.yml with valid
+#      audit_db_url                                            →
+#      re-use; warn on loose mode (don't auto-tighten — user-managed).
+#   C. interactive prompt                                      →
+#      validate, write credentials.yml chmod 0600, OR record decline.
+#
+# Aborts (exit 4) on invalid scheme, sqlite parent dir unwritable,
+# or interactive retry budget exhausted. State.yml is NOT written
+# on abort — same semantics as step 2a/2b.
+
+# 6-scheme allowlist per ADR-0009 + 03-config-schemas.md.
+BSP_AUDIT_SCHEMES="postgresql:// postgres:// mysql:// mysql+pymysql:// sqlite:// sqlite3://"
+
+# Validate a DSN's scheme prefix. Returns 0 on match, 1 on miss.
+# Stdin: nothing. Arg: the DSN to test.
+audit_dsn_scheme_ok() {
+    local dsn="$1"
+    local sch
+    for sch in ${BSP_AUDIT_SCHEMES}; do
+        case "${dsn}" in
+            "${sch}"*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+print_scheme_allowlist() {
+    local target="${1:-stderr}"
+    if [ "${target}" = "stdout" ]; then
+        printf 'Accepted schemes (per ADR-0009 + 03-config-schemas.md):\n'
+        # shellcheck disable=SC2086
+        for s in ${BSP_AUDIT_SCHEMES}; do
+            printf '  - %s\n' "${s}"
+        done
+    else
+        printf 'Accepted schemes (per ADR-0009 + 03-config-schemas.md):\n' >&2
+        # shellcheck disable=SC2086
+        for s in ${BSP_AUDIT_SCHEMES}; do
+            printf '  - %s\n' "${s}" >&2
+        done
+    fi
+}
+
+# Extract sqlite absolute path from a 4-slash sqlite DSN.
+# `sqlite:////abs/path` → `/abs/path`. Returns empty on shape mismatch.
+audit_sqlite_path_extract() {
+    local dsn="$1"
+    case "${dsn}" in
+        sqlite:////*)
+            printf '%s' "/${dsn#sqlite:////}"
+            ;;
+        sqlite3:////*)
+            printf '%s' "/${dsn#sqlite3:////}"
+            ;;
+        *)
+            printf ''
+            ;;
+    esac
+}
+
+# Verify a sqlite DSN's parent dir is writable. Returns 0/1; on
+# failure prints an error to stderr explaining which dir was rejected.
+audit_sqlite_parent_writable() {
+    local dsn="$1"
+    local abs_path parent
+    abs_path="$(audit_sqlite_path_extract "${dsn}")"
+    if [ -z "${abs_path}" ]; then
+        # Not a sqlite DSN, or 3-slash form (which we reject elsewhere).
+        printf '[bsp ERROR] step 2e: SQLite DSN must use 4-slash absolute form (got: %s)\n' "${dsn}" >&2
+        return 1
+    fi
+    parent="$(dirname "${abs_path}")"
+    if [ ! -d "${parent}" ]; then
+        printf '[bsp ERROR] step 2e: SQLite parent directory does not exist: %s\n' "${parent}" >&2
+        return 1
+    fi
+    if [ ! -w "${parent}" ]; then
+        printf '[bsp ERROR] step 2e: SQLite parent directory is not writable: %s\n' "${parent}" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Read top-level audit_db_url from a flat YAML credentials file.
+# Empty stdout if absent or unparseable. Same shape as yaml_get
+# helpers below but inlined here so step 2e is self-contained.
+credentials_yml_dsn() {
+    local file="$1"
+    [ -f "${file}" ] || return 0
+    grep -E '^audit_db_url[[:space:]]*:' "${file}" 2>/dev/null \
+        | head -n1 \
+        | sed -E 's/^audit_db_url[[:space:]]*:[[:space:]]*//; s/^"//; s/"$//; s/^'\''//; s/'\''$//'
+}
+
+# Atomic write of credentials.yml at chmod 0600. Same mktemp+mv
+# pattern as state.yml (step 3 below) and bootstrap-host's manifest.
+write_credentials_yml() {
+    local dsn="$1"
+    local cred_dir="${HOME}/.board-superpowers"
+    local cred_file="${cred_dir}/credentials.yml"
+
+    mkdir -p "${cred_dir}" || bsp_die "step 2e: cannot create ${cred_dir}"
+    chmod 0700 "${cred_dir}"
+
+    if [ -d "${cred_file}" ]; then
+        bsp_die "step 2e: refuses to write — ${cred_file} exists as a directory"
+    fi
+
+    local tmp
+    tmp="$(mktemp "${cred_file}.tmp.XXXXXX")" \
+        || bsp_die "step 2e: could not create temp credentials file in ${cred_dir}"
+    # shellcheck disable=SC2064
+    trap "rm -f '${tmp}'" EXIT INT TERM
+
+    cat > "${tmp}" <<EOF
+# board-superpowers BYO-RDBMS credentials (host-local, NEVER tracked in git).
+# Per ADR-0006 §5 + ADR-0009 + 03-config-schemas.md credentials.yml schema.
+# chmod 0600 (read+write owner only). Never share.
+
+audit_db_url: "${dsn}"
+EOF
+
+    chmod 0600 "${tmp}"
+
+    if ! mv "${tmp}" "${cred_file}" 2>/dev/null; then
+        rm -f "${tmp}"
+        trap - EXIT INT TERM
+        bsp_die "step 2e: atomic mv to ${cred_file} failed"
+    fi
+    trap - EXIT INT TERM
+    bsp_log "step 2e: wrote ${cred_file} (chmod 0600)"
+}
+
+# Run the interactive prompt. Returns 0 on success (with credentials.yml
+# written or decline acknowledged) or invokes exit 4 on retry exhaustion
+# / unwritable sqlite parent.
+audit_interactive_prompt() {
+    # Read attempts from stdin (or /dev/tty if available + interactive).
+    # In test scenarios stdin is preloaded via heredoc-string and there
+    # is no controlling tty; honor that path.
+    local input_source="/dev/stdin"
+    if [ -t 0 ] && [ -r /dev/tty ]; then
+        input_source="/dev/tty"
+    fi
+
+    local attempt max_attempts=3
+    attempt=0
+
+    while [ "${attempt}" -lt "${max_attempts}" ]; do
+        attempt=$((attempt + 1))
+
+        # Show the prompt block on stderr so it doesn't pollute stdout
+        # consumers (none here, but consistent with bsp_log convention).
+        {
+            printf '\n'
+            printf '[bsp] step 2e: BYO-RDBMS audit-log credential setup\n'
+            printf '[bsp]\n'
+            printf '[bsp] Per ADR-0006 §5 + ADR-0009. The architect provisions an\n'
+            printf '[bsp] RDBMS for the audit log. Six accepted schemes:\n'
+            for s in ${BSP_AUDIT_SCHEMES}; do
+                printf '[bsp]   - %s\n' "${s}"
+            done
+            printf '[bsp]\n'
+            printf '[bsp] SQLite default suggestion (4-slash absolute path):\n'
+            printf '[bsp]   sqlite:////%s/.board-superpowers/repos/<normalized>/audit.db\n' "${HOME#/}"
+            printf '[bsp]\n'
+            printf '[bsp] Enter a DSN, or leave blank / type "skip" to decline\n'
+            printf '[bsp] (every A-class action will degrade to R-class until\n'
+            printf '[bsp] you re-run F-B2 with --rebootstrap-db).\n'
+            printf '[bsp] DSN> '
+        } >&2
+
+        local dsn
+        if ! IFS= read -r dsn < "${input_source}"; then
+            # EOF / unreadable input: treat as decline (same as empty).
+            dsn=""
+        fi
+        # Strip leading/trailing whitespace.
+        dsn="${dsn#"${dsn%%[![:space:]]*}"}"
+        dsn="${dsn%"${dsn##*[![:space:]]}"}"
+
+        case "${dsn}" in
+            ""|skip|SKIP|Skip)
+                bsp_warn "step 2e: BYO-RDBMS declined — every A-class action will degrade to R-class until you re-run F-B2 with --rebootstrap-db"
+                BSP_AUDIT_DECLINED=1
+                return 0
+                ;;
+        esac
+
+        if ! audit_dsn_scheme_ok "${dsn}"; then
+            printf '[bsp ERROR] step 2e: invalid scheme in DSN: %s\n' "${dsn}" >&2
+            print_scheme_allowlist stderr
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+                printf '[bsp] retry (%d of %d remaining)\n' \
+                    "$((max_attempts - attempt))" "${max_attempts}" >&2
+                continue
+            fi
+            printf '[bsp ERROR] step 2e: retry budget exhausted (%d attempts)\n' \
+                "${max_attempts}" >&2
+            exit 4
+        fi
+
+        # SQLite parent-dir writability check.
+        case "${dsn}" in
+            sqlite://*|sqlite3://*)
+                if ! audit_sqlite_parent_writable "${dsn}"; then
+                    # Hard fail — don't re-prompt; spec says abort on
+                    # unwritable parent dir before any credentials.yml
+                    # write attempt.
+                    exit 4
+                fi
+                ;;
+        esac
+
+        write_credentials_yml "${dsn}"
+        BSP_AUDIT_DECLINED=0
+        return 0
+    done
+}
+
+bsp_log "step 2e: starting BYO-RDBMS audit-log credential UX"
+
+# Resolve precedence: flag > env var > pre-existing credentials.yml >
+# interactive. BSP_AUDIT_DECLINED records whether the architect
+# declined BYO-RDBMS during the interactive prompt (Path C decline);
+# slice 7 may surface it as a state.yml field. Today it's set as a
+# trace for log forensics — referenced via "${BSP_AUDIT_DECLINED:-0}"
+# downstream consumers.
+# shellcheck disable=SC2034  # consumed in slice 7 (state.yml degradation flag)
+BSP_AUDIT_DECLINED=0
+CREDENTIALS_FILE="${HOME}/.board-superpowers/credentials.yml"
+
+if [ -n "${AUDIT_DB_URL_FLAG}" ]; then
+    if ! audit_dsn_scheme_ok "${AUDIT_DB_URL_FLAG}"; then
+        printf '[bsp ERROR] step 2e: --audit-db-url has invalid scheme: %s\n' \
+            "${AUDIT_DB_URL_FLAG}" >&2
+        print_scheme_allowlist stderr
+        exit 4
+    fi
+    case "${AUDIT_DB_URL_FLAG}" in
+        sqlite://*|sqlite3://*)
+            if ! audit_sqlite_parent_writable "${AUDIT_DB_URL_FLAG}"; then
+                exit 4
+            fi
+            # Flag with a sqlite scheme is intentional persistence
+            # — write credentials.yml so subsequent sessions don't
+            # need the flag re-passed.
+            write_credentials_yml "${AUDIT_DB_URL_FLAG}"
+            ;;
+        *)
+            # Non-sqlite flag is treated as runtime override (same as
+            # env var); we honor it without persisting credentials.yml.
+            bsp_log "step 2e: --audit-db-url provided (non-sqlite); using as runtime override (no credentials.yml write)"
+            ;;
+    esac
+elif [ -n "${BOARD_SP_AUDIT_DB_URL:-}" ]; then
+    if ! audit_dsn_scheme_ok "${BOARD_SP_AUDIT_DB_URL}"; then
+        printf '[bsp ERROR] step 2e: BOARD_SP_AUDIT_DB_URL has invalid scheme: %s\n' \
+            "${BOARD_SP_AUDIT_DB_URL}" >&2
+        print_scheme_allowlist stderr
+        exit 4
+    fi
+    bsp_log "step 2e: BOARD_SP_AUDIT_DB_URL env var present; using as runtime override (no credentials.yml write)"
+elif [ -f "${CREDENTIALS_FILE}" ]; then
+    EXISTING_DSN="$(credentials_yml_dsn "${CREDENTIALS_FILE}")"
+    if [ -n "${EXISTING_DSN}" ] && audit_dsn_scheme_ok "${EXISTING_DSN}"; then
+        # Pre-existing valid file. Check mode; warn if loose.
+        EXISTING_MODE=""
+        if EXISTING_MODE="$(stat -f '%A' "${CREDENTIALS_FILE}" 2>/dev/null)"; then
+            :
+        else
+            EXISTING_MODE="$(stat -c '%a' "${CREDENTIALS_FILE}" 2>/dev/null || true)"
+        fi
+        if [ -n "${EXISTING_MODE}" ] && [ "${EXISTING_MODE}" != "600" ]; then
+            bsp_warn "step 2e: ${CREDENTIALS_FILE} mode is 0${EXISTING_MODE} (expected 0600); proceeding without auto-tightening — user-managed file. chmod 0600 yourself when convenient."
+        fi
+        bsp_log "step 2e: re-using pre-existing credentials.yml (no prompt)"
+    else
+        bsp_warn "step 2e: ${CREDENTIALS_FILE} exists but audit_db_url is missing or has an invalid scheme; falling through to interactive prompt"
+        audit_interactive_prompt
+    fi
+else
+    audit_interactive_prompt
+fi
+
 # --- Step 3 — initial state.yml write (host-local) -----------------------
 
 # Ensure ~/.board-superpowers exists at mode 0700; mkdir -p is idempotent.
@@ -403,5 +719,5 @@ else
     bsp_log "wrote ${STATE_FILE}"
 fi
 
-bsp_log "F-B2 slice 2 complete (steps 2a-2d + initial state.yml). Slice 3 (BYO-RDBMS) and slice 4 (routing block injection) deferred."
+bsp_log "F-B2 slice 3 complete (steps 2a-2e + initial state.yml). Slice 4 (routing block injection) deferred."
 exit 0

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -32,22 +32,25 @@
 #                             # config.yml even when present)
 #       [--plugin-root P]     # for testability; defaults to derived
 #                             # from this file's location
-#       [--audit-db-url URL]  # non-interactive override for step 2e;
-#                             # highest precedence (above
-#                             # $BOARD_SP_AUDIT_DB_URL and pre-existing
-#                             # credentials.yml). Same 6-scheme
-#                             # allowlist applies.
+#       [--audit-db-url URL]  # non-interactive equivalent of typing
+#                             # the DSN at the interactive prompt;
+#                             # ALWAYS persists to credentials.yml
+#                             # (chmod 0600) regardless of scheme. Use
+#                             # $BOARD_SP_AUDIT_DB_URL for ephemeral /
+#                             # runtime override that does NOT persist.
 #
 # --owner and --project are REQUIRED for step 2b (Status field check).
 # --repo-root defaults to ${CLAUDE_PROJECT_DIR:-$PWD} resolved to
 # `git rev-parse --show-toplevel`.
 #
 # Step 2e BYO-RDBMS resolution priority:
-#   1. --audit-db-url FLAG (highest)
-#   2. $BOARD_SP_AUDIT_DB_URL env var
+#   1. --audit-db-url FLAG (highest; PERSISTS to credentials.yml at
+#      chmod 0600 — same end state as Path C accept).
+#   2. $BOARD_SP_AUDIT_DB_URL env var (runtime override; does NOT
+#      persist — ephemeral by design).
 #   3. pre-existing ~/.board-superpowers/credentials.yml (with valid
-#      audit_db_url)
-#   4. interactive prompt
+#      audit_db_url).
+#   4. interactive prompt (PERSISTS on accept; records decline on skip).
 #
 # Exit codes:
 #   0  success
@@ -354,19 +357,55 @@ fi
 # 6-scheme allowlist per ADR-0009 + 03-config-schemas.md.
 BSP_AUDIT_SCHEMES="postgresql:// postgres:// mysql:// mysql+pymysql:// sqlite:// sqlite3://"
 
-# Validate a DSN's scheme prefix. Returns 0 on match, 1 on miss.
-# Stdin: nothing. Arg: the DSN to test.
-audit_dsn_scheme_ok() {
+# Validate a DSN structurally via python3 + urllib.parse.
+# Returns 0 on accept, 1 on reject. The DSN is passed via env var
+# (not heredoc interpolation) so shell metacharacters in the DSN
+# can't break the python source.
+#
+# Accept rules:
+#   - scheme ∈ {postgresql, postgres, mysql, mysql+pymysql, sqlite, sqlite3}
+#   - non-sqlite schemes: urlparse(dsn).hostname must be non-empty
+#   - sqlite / sqlite3: urlparse(dsn).path must start with "/"
+#     (the 4-slash form `sqlite:////abs/path` yields path='//abs/path'
+#     which still starts with '/'; 3-slash relative form yields
+#     path='relative/...' and is rejected)
+audit_dsn_validate() {
     local dsn="$1"
-    local sch
-    for sch in ${BSP_AUDIT_SCHEMES}; do
-        case "${dsn}" in
-            "${sch}"*)
-                return 0
-                ;;
-        esac
-    done
-    return 1
+    BSP_AUDIT_DSN="${dsn}" python3 - <<'PY' 2>/dev/null
+import os, sys
+from urllib.parse import urlparse
+
+dsn = os.environ.get("BSP_AUDIT_DSN", "")
+allowed = {"postgresql", "postgres", "mysql", "mysql+pymysql",
+           "sqlite", "sqlite3"}
+try:
+    u = urlparse(dsn)
+except (ValueError, TypeError):
+    sys.exit(1)
+if u.scheme not in allowed:
+    sys.exit(1)
+if u.scheme in ("sqlite", "sqlite3"):
+    # Per ADR-0009: require the 4-slash absolute form
+    # (sqlite:////abs/path). urlparse on the 4-slash form yields
+    # path='//abs/path' (two leading slashes); the 3-slash relative
+    # form (sqlite:///rel/path) yields path='/rel/path' (one leading
+    # slash). Require two leading slashes so the 3-slash form is
+    # rejected even though it technically begins with '/'.
+    if not u.path or not u.path.startswith("//"):
+        sys.exit(1)
+else:
+    if not u.hostname:
+        sys.exit(1)
+    # Catch malformed port-position garbage — e.g.
+    # `postgres://user@host:5432:wrong/db`. urlparse extracts
+    # hostname='host' but accessing .port raises ValueError because
+    # '5432:wrong' isn't a valid integer port.
+    try:
+        _ = u.port
+    except ValueError:
+        sys.exit(1)
+sys.exit(0)
+PY
 }
 
 print_scheme_allowlist() {
@@ -532,9 +571,11 @@ audit_interactive_prompt() {
                 ;;
         esac
 
-        if ! audit_dsn_scheme_ok "${dsn}"; then
-            printf '[bsp ERROR] step 2e: invalid scheme in DSN: %s\n' "${dsn}" >&2
+        if ! audit_dsn_validate "${dsn}"; then
+            printf '[bsp ERROR] step 2e: DSN is malformed or has unsupported scheme: %s\n' "${dsn}" >&2
             print_scheme_allowlist stderr
+            printf '[bsp]   non-sqlite schemes require a host part\n' >&2
+            printf '[bsp]   sqlite/sqlite3 require the 4-slash absolute form (sqlite:////abs/path) per ADR-0009\n' >&2
             if [ "${attempt}" -lt "${max_attempts}" ]; then
                 printf '[bsp] retry (%d of %d remaining)\n' \
                     "$((max_attempts - attempt))" "${max_attempts}" >&2
@@ -576,39 +617,40 @@ BSP_AUDIT_DECLINED=0
 CREDENTIALS_FILE="${HOME}/.board-superpowers/credentials.yml"
 
 if [ -n "${AUDIT_DB_URL_FLAG}" ]; then
-    if ! audit_dsn_scheme_ok "${AUDIT_DB_URL_FLAG}"; then
-        printf '[bsp ERROR] step 2e: --audit-db-url has invalid scheme: %s\n' \
+    if ! audit_dsn_validate "${AUDIT_DB_URL_FLAG}"; then
+        printf '[bsp ERROR] step 2e: --audit-db-url is malformed or has unsupported scheme: %s\n' \
             "${AUDIT_DB_URL_FLAG}" >&2
         print_scheme_allowlist stderr
+        printf '[bsp]   non-sqlite schemes require a host part\n' >&2
+        printf '[bsp]   sqlite/sqlite3 require the 4-slash absolute form (sqlite:////abs/path) per ADR-0009\n' >&2
         exit 4
     fi
+    # SQLite-only filesystem-side check: parent dir must be writable.
     case "${AUDIT_DB_URL_FLAG}" in
         sqlite://*|sqlite3://*)
             if ! audit_sqlite_parent_writable "${AUDIT_DB_URL_FLAG}"; then
                 exit 4
             fi
-            # Flag with a sqlite scheme is intentional persistence
-            # — write credentials.yml so subsequent sessions don't
-            # need the flag re-passed.
-            write_credentials_yml "${AUDIT_DB_URL_FLAG}"
-            ;;
-        *)
-            # Non-sqlite flag is treated as runtime override (same as
-            # env var); we honor it without persisting credentials.yml.
-            bsp_log "step 2e: --audit-db-url provided (non-sqlite); using as runtime override (no credentials.yml write)"
             ;;
     esac
+    # Flag is the non-interactive equivalent of typing the DSN at the
+    # prompt — persist for ALL valid schemes (chmod 0600). Use
+    # $BOARD_SP_AUDIT_DB_URL for ephemeral / runtime overrides that
+    # should NOT be written to disk.
+    write_credentials_yml "${AUDIT_DB_URL_FLAG}"
 elif [ -n "${BOARD_SP_AUDIT_DB_URL:-}" ]; then
-    if ! audit_dsn_scheme_ok "${BOARD_SP_AUDIT_DB_URL}"; then
-        printf '[bsp ERROR] step 2e: BOARD_SP_AUDIT_DB_URL has invalid scheme: %s\n' \
+    if ! audit_dsn_validate "${BOARD_SP_AUDIT_DB_URL}"; then
+        printf '[bsp ERROR] step 2e: BOARD_SP_AUDIT_DB_URL is malformed or has unsupported scheme: %s\n' \
             "${BOARD_SP_AUDIT_DB_URL}" >&2
         print_scheme_allowlist stderr
+        printf '[bsp]   non-sqlite schemes require a host part\n' >&2
+        printf '[bsp]   sqlite/sqlite3 require the 4-slash absolute form (sqlite:////abs/path) per ADR-0009\n' >&2
         exit 4
     fi
     bsp_log "step 2e: BOARD_SP_AUDIT_DB_URL env var present; using as runtime override (no credentials.yml write)"
 elif [ -f "${CREDENTIALS_FILE}" ]; then
     EXISTING_DSN="$(credentials_yml_dsn "${CREDENTIALS_FILE}")"
-    if [ -n "${EXISTING_DSN}" ] && audit_dsn_scheme_ok "${EXISTING_DSN}"; then
+    if [ -n "${EXISTING_DSN}" ] && audit_dsn_validate "${EXISTING_DSN}"; then
         # Pre-existing valid file. Check mode; warn if loose.
         EXISTING_MODE=""
         if EXISTING_MODE="$(stat -f '%A' "${CREDENTIALS_FILE}" 2>/dev/null)"; then

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# scripts/bootstrap-project.sh — F-B2 per-repo bootstrap engine
+# (slice 2 — steps 2a-2d + initial state.yml write).
+#
+# Spec:
+#   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+#     § 1.5.2 F-B2. Per-repo bootstrap (steps 1, 2a-2d, 3 — initial
+#     state.yml write).
+#   docs/architecture/0005-contracts/03-config-schemas.md (config.yml
+#     and state.yml shapes).
+#   docs/architecture/0005-contracts/05-github-artifact-schemas.md
+#     § "Project v2 Status enum" (canonical 6-option contract).
+#   docs/architecture/0005-contracts/07-path-conventions.md
+#     § "Per-host layout" + "The .gitignore block".
+#
+# Capability: when invoked with --owner/--project/--repo-root, run
+# F-B2 steps 2a-2d (standard labels via setup-labels.sh, Status field
+# validation, config.yml write, .gitignore append) and write the
+# initial host-local state.yml. Step 2e (BYO-RDBMS UX) and step 4
+# (routing block injection) are deferred to slices 3 + 4 of the
+# same card; routing_blocks is written as the empty list [] so the
+# state file is valid v1 schema today.
+#
+# Argument vector:
+#   bash scripts/bootstrap-project.sh \
+#       --owner OWNER \
+#       --project N \
+#       --repo-root PATH      # absolute repo path
+#       [--force]             # bypass idempotency guards (rewrite
+#                             # config.yml even when present)
+#       [--plugin-root P]     # for testability; defaults to derived
+#                             # from this file's location
+#
+# --owner and --project are REQUIRED for step 2b (Status field check).
+# --repo-root defaults to ${CLAUDE_PROJECT_DIR:-$PWD} resolved to
+# `git rev-parse --show-toplevel`.
+#
+# Exit codes:
+#   0  success
+#   1  bad args / file write failure
+#   2  Status field drift detected (step 2b)
+#   3  step 2a (labels) delegation failed
+#   64 unknown argument
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/common.sh
+. "${SCRIPT_DIR}/lib/common.sh"
+
+# --- Arg parsing --------------------------------------------------------
+
+OWNER=""
+PROJECT_NUM=""
+REPO_ROOT_ARG=""
+FORCE=0
+PLUGIN_ROOT_ARG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --owner)
+            OWNER="${2:-}"
+            [ -n "${OWNER}" ] || bsp_die "--owner requires a value"
+            shift 2
+            ;;
+        --project)
+            PROJECT_NUM="${2:-}"
+            [ -n "${PROJECT_NUM}" ] || bsp_die "--project requires a value"
+            shift 2
+            ;;
+        --repo-root)
+            REPO_ROOT_ARG="${2:-}"
+            [ -n "${REPO_ROOT_ARG}" ] || bsp_die "--repo-root requires a path"
+            shift 2
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        --plugin-root)
+            PLUGIN_ROOT_ARG="${2:-}"
+            [ -n "${PLUGIN_ROOT_ARG}" ] || bsp_die "--plugin-root requires a path"
+            shift 2
+            ;;
+        --help|-h)
+            sed -n '2,/^set -euo pipefail/p' "${BASH_SOURCE[0]}" >&2
+            exit 0
+            ;;
+        *)
+            printf '[bsp ERROR] unknown argument: %s (try --help)\n' "$1" >&2
+            exit 64
+            ;;
+    esac
+done
+
+[ -n "${OWNER}" ]       || bsp_die "--owner is required"
+[ -n "${PROJECT_NUM}" ] || bsp_die "--project is required"
+
+# --- Resolve plugin root + repo root + plugin version --------------------
+
+if [ -n "${PLUGIN_ROOT_ARG}" ]; then
+    PLUGIN_ROOT="${PLUGIN_ROOT_ARG}"
+else
+    PLUGIN_ROOT="$(bsp_plugin_root)"
+fi
+
+if [ ! -d "${PLUGIN_ROOT}" ]; then
+    bsp_die "plugin root not found: ${PLUGIN_ROOT}"
+fi
+
+PLUGIN_JSON="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+if [ ! -f "${PLUGIN_JSON}" ]; then
+    bsp_die "plugin.json not found at ${PLUGIN_JSON}"
+fi
+
+bsp_require_cmd python3 "macOS / Linux ship python3 by default"
+bsp_require_cmd gh      "install via 'brew install gh' (or your platform's package manager)"
+bsp_require_cmd git     "install git for your platform"
+
+PLUGIN_VERSION="$(python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except (OSError, ValueError) as e:
+    sys.stderr.write('cannot read plugin.json: ' + str(e) + '\n')
+    sys.exit(1)
+v = data.get('version')
+if not v:
+    sys.stderr.write('plugin.json missing version field\n')
+    sys.exit(1)
+print(v)
+" "${PLUGIN_JSON}")" || bsp_die "failed to read version from ${PLUGIN_JSON}"
+
+# Resolve repo root: explicit arg → CLAUDE_PROJECT_DIR → PWD; then
+# canonicalise via `git rev-parse --show-toplevel` so the normalized
+# host-state path uses the actual repo root rather than a sub-path.
+RAW_REPO_ROOT="${REPO_ROOT_ARG:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+if [ ! -d "${RAW_REPO_ROOT}" ]; then
+    bsp_die "repo root not found: ${RAW_REPO_ROOT}"
+fi
+REPO_ROOT="$(cd "${RAW_REPO_ROOT}" && git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "${REPO_ROOT}" ]; then
+    bsp_die "${RAW_REPO_ROOT} is not inside a git repo"
+fi
+
+bsp_log "F-B2 starting for ${OWNER}/${PROJECT_NUM} in ${REPO_ROOT}"
+
+# --- Step 2a — standard labels (delegate to setup-labels.sh) -------------
+
+# Pass through --repo OWNER/NAME if we can derive it from origin. This
+# lets setup-labels.sh target the right repo without assuming PWD.
+ORIGIN_URL="$(git -C "${REPO_ROOT}" remote get-url origin 2>/dev/null || true)"
+LABEL_REPO_ARGS=()
+if [ -n "${ORIGIN_URL}" ]; then
+    case "${ORIGIN_URL}" in
+        *github.com[:/]*)
+            trimmed="${ORIGIN_URL%.git}"
+            trimmed="${trimmed##*github.com}"
+            trimmed="${trimmed#:}"
+            trimmed="${trimmed#/}"
+            if [ -n "${trimmed}" ]; then
+                LABEL_REPO_ARGS=(--repo "${trimmed}")
+            fi
+            ;;
+    esac
+fi
+
+bsp_log "step 2a: ensuring 13 standard labels (delegating to setup-labels.sh)"
+SETUP_LABELS="${PLUGIN_ROOT}/scripts/setup-labels.sh"
+if [ ! -f "${SETUP_LABELS}" ]; then
+    bsp_die "setup-labels.sh not found at ${SETUP_LABELS}"
+fi
+if ! bash "${SETUP_LABELS}" "${LABEL_REPO_ARGS[@]+"${LABEL_REPO_ARGS[@]}"}" >&2; then
+    # shellcheck disable=SC2016
+    printf '[bsp ERROR] step 2a failed: setup-labels.sh exited non-zero. Likely cause: gh auth missing or insufficient scope (needs `repo` scope for label create). Run `gh auth status` to check.\n' >&2
+    exit 3
+fi
+
+# --- Step 2b — Status field validation -----------------------------------
+
+bsp_log "step 2b: validating Project ${OWNER}/${PROJECT_NUM} Status field"
+
+CANONICAL_STATUS="Backlog,Ready,In Progress,In Review,Done,Blocked"
+
+# Capture gh output then validate. Errors at the gh layer surface as
+# exit 3-equivalent "step failure" but with explanatory message.
+STATUS_VALIDATION_OUTPUT="$(gh project field-list "${PROJECT_NUM}" \
+    --owner "${OWNER}" --format json 2>&1)" || {
+    # shellcheck disable=SC2016
+    printf '[bsp ERROR] step 2b failed: `gh project field-list %s --owner %s` errored. Likely cause: gh auth missing the `project` scope. Run `gh auth refresh -s project` and retry.\n' \
+        "${PROJECT_NUM}" "${OWNER}" >&2
+    printf '%s\n' "${STATUS_VALIDATION_OUTPUT}" >&2
+    exit 3
+}
+
+VALIDATION_RESULT="$(printf '%s' "${STATUS_VALIDATION_OUTPUT}" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except ValueError as e:
+    sys.stderr.write('cannot parse gh project field-list JSON: ' + str(e) + '\n')
+    sys.exit(2)
+canonical = sys.argv[1].split(',')
+for f in data.get('fields', []) or []:
+    if f.get('name') == 'Status':
+        opts = [o.get('name') for o in (f.get('options') or [])]
+        if opts == canonical:
+            print('OK')
+            sys.exit(0)
+        print('DRIFT:' + ','.join(opts))
+        sys.exit(0)
+print('MISSING')
+sys.exit(0)
+" "${CANONICAL_STATUS}")" || {
+    bsp_die "step 2b: failed to parse gh project field-list output"
+}
+
+case "${VALIDATION_RESULT}" in
+    OK)
+        bsp_log "step 2b: Status field options match canonical 6-option order"
+        ;;
+    MISSING)
+        printf '[bsp ERROR] step 2b: Status field not found on Project %s/%s.\n' \
+            "${OWNER}" "${PROJECT_NUM}" >&2
+        printf '  Go to the Project settings on github.com → "Settings" → "Fields" → ensure a "Status" single-select field exists with these 6 options in this order:\n' >&2
+        printf '    Backlog → Ready → In Progress → In Review → Done → Blocked\n' >&2
+        exit 2
+        ;;
+    DRIFT:*)
+        ACTUAL="${VALIDATION_RESULT#DRIFT:}"
+        printf '[bsp ERROR] step 2b: Status field options drift detected on Project %s/%s.\n' \
+            "${OWNER}" "${PROJECT_NUM}" >&2
+        printf '  Expected (canonical 6-option order): Backlog → Ready → In Progress → In Review → Done → Blocked\n' >&2
+        printf '  Actual: %s\n' "${ACTUAL}" >&2
+        printf '  Go to the GitHub Project settings → Status field → ensure 6 options in this exact order, then re-run F-B2.\n' >&2
+        exit 2
+        ;;
+    *)
+        bsp_die "step 2b: unexpected validation result: ${VALIDATION_RESULT}"
+        ;;
+esac
+
+# --- Step 2c — write <repo>/.board-superpowers/config.yml ----------------
+
+CONFIG_DIR="${REPO_ROOT}/.board-superpowers"
+CONFIG_FILE="${CONFIG_DIR}/config.yml"
+
+mkdir -p "${CONFIG_DIR}" || bsp_die "step 2c: cannot create ${CONFIG_DIR}"
+
+write_config_yml() {
+    cat > "${CONFIG_FILE}" <<EOF
+# board-superpowers per-repo configuration (committed to git).
+# Managed by using-board-superpowers. Safe to edit by hand.
+# See docs/architecture/0005-contracts/03-config-schemas.md for the
+# full schema.
+
+project: "${OWNER}/${PROJECT_NUM}"
+wip_limit: 5
+
+# Future fields (uncomment when needed):
+# audit_db_url: "postgresql://user:pwd@host:5432/db"
+# claim_branch_prefix: "claim/"
+# worktree_dir: "/custom/worktrees"
+EOF
+}
+
+if [ -f "${CONFIG_FILE}" ] && [ "${FORCE}" -eq 0 ]; then
+    bsp_log "step 2c: ${CONFIG_FILE} already exists — leaving alone (use --force to overwrite)"
+else
+    if [ -f "${CONFIG_FILE}" ]; then
+        bsp_log "step 2c: --force overwriting ${CONFIG_FILE}"
+    else
+        bsp_log "step 2c: writing ${CONFIG_FILE}"
+    fi
+    write_config_yml
+fi
+
+# --- Step 2d — append to <repo>/.gitignore (idempotent) ------------------
+
+GITIGNORE_FILE="${REPO_ROOT}/.gitignore"
+GITIGNORE_HEADER="# board-superpowers local state (claim markers are per-session)"
+GITIGNORE_ENTRY=".board-superpowers/claims/"
+
+write_gitignore_block() {
+    # Append a leading blank line for visual separation only when the
+    # file already has content. New files start with the block.
+    local prepend_blank="$1"
+    {
+        if [ "${prepend_blank}" = "1" ]; then
+            printf '\n'
+        fi
+        printf '%s\n%s\n' "${GITIGNORE_HEADER}" "${GITIGNORE_ENTRY}"
+    } >> "${GITIGNORE_FILE}"
+}
+
+if [ -f "${GITIGNORE_FILE}" ]; then
+    if grep -Fxq "${GITIGNORE_ENTRY}" "${GITIGNORE_FILE}"; then
+        bsp_log "step 2d: .gitignore already contains '${GITIGNORE_ENTRY}' — no change"
+    else
+        # Defensive: ensure trailing newline before append so we don't
+        # glue our block onto the last line of an unterminated file.
+        if [ -s "${GITIGNORE_FILE}" ]; then
+            tail -c1 "${GITIGNORE_FILE}" | od -An -c | tr -d ' ' | grep -q '\\n' \
+                || printf '\n' >> "${GITIGNORE_FILE}"
+        fi
+        bsp_log "step 2d: appending board-superpowers block to ${GITIGNORE_FILE}"
+        write_gitignore_block 1
+    fi
+else
+    bsp_log "step 2d: creating ${GITIGNORE_FILE} with board-superpowers block"
+    write_gitignore_block 0
+fi
+
+# --- Step 3 — initial state.yml write (host-local) -----------------------
+
+# Ensure ~/.board-superpowers exists at mode 0700; mkdir -p is idempotent.
+HOST_ROOT="${HOME}/.board-superpowers"
+mkdir -p "${HOST_ROOT}" || bsp_die "cannot create ${HOST_ROOT}"
+chmod 0700 "${HOST_ROOT}"
+
+STATE_DIR="$(bsp_host_state_dir "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+mkdir -p "${STATE_DIR}" || bsp_die "cannot create ${STATE_DIR}"
+chmod 0700 "${STATE_DIR}"
+
+iso_utc_now() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# Read a top-level scalar from a flat YAML file. Same shape as the
+# helper in bootstrap-host.sh.
+yaml_get() {
+    local file="$1"
+    local key="$2"
+    [ -f "${file}" ] || return 0
+    grep -E "^${key}[[:space:]]*:" "${file}" 2>/dev/null \
+        | head -n1 \
+        | sed -E "s/^${key}[[:space:]]*:[[:space:]]*//; s/^\"//; s/\"$//"
+}
+
+write_state_yml() {
+    local ts="$1"
+    local version="$2"
+
+    if [ -d "${STATE_FILE}" ]; then
+        bsp_die "refuses to write: ${STATE_FILE} exists as a directory, not a file"
+    fi
+
+    local tmp
+    tmp="$(mktemp "${STATE_FILE}.tmp.XXXXXX")" \
+        || bsp_die "could not create temp state file in ${STATE_DIR}"
+    # shellcheck disable=SC2064
+    trap "rm -f '${tmp}'" EXIT
+
+    cat > "${tmp}" <<EOF
+schema_version: 1
+repo_bootstrapped_at: "${ts}"
+last_seen_version_in_repo: "${version}"
+features_enabled:
+  - bootstrap.host
+  - bootstrap.per_repo
+routing_blocks: []
+EOF
+
+    chmod 0644 "${tmp}"
+
+    if ! mv "${tmp}" "${STATE_FILE}" 2>/dev/null; then
+        rm -f "${tmp}"
+        trap - EXIT
+        bsp_die "atomic mv to ${STATE_FILE} failed"
+    fi
+    trap - EXIT
+}
+
+NOW_TS="$(iso_utc_now)"
+
+if [ -f "${STATE_FILE}" ]; then
+    EXISTING_VERSION="$(yaml_get "${STATE_FILE}" last_seen_version_in_repo)"
+    EXISTING_TS="$(yaml_get "${STATE_FILE}" repo_bootstrapped_at)"
+
+    if [ "${EXISTING_VERSION}" = "${PLUGIN_VERSION}" ] && [ "${FORCE}" -eq 0 ]; then
+        chmod 0644 "${STATE_FILE}"
+        bsp_log "state.yml current at ${STATE_FILE} (last_seen_version_in_repo=${PLUGIN_VERSION}); no write"
+    else
+        # Refresh path. Preserve repo_bootstrapped_at when present,
+        # bump last_seen_version_in_repo to the running plugin version.
+        if [ -z "${EXISTING_TS}" ]; then
+            EXISTING_TS="${NOW_TS}"
+            bsp_warn "existing state.yml missing repo_bootstrapped_at; regenerating"
+        fi
+        if [ "${FORCE}" -eq 1 ]; then
+            bsp_log "state.yml: --force rewriting at ${STATE_FILE}"
+        else
+            bsp_log "state.yml refresh: ${EXISTING_VERSION:-<unset>} → ${PLUGIN_VERSION}"
+        fi
+        write_state_yml "${EXISTING_TS}" "${PLUGIN_VERSION}"
+        bsp_log "wrote ${STATE_FILE}"
+    fi
+else
+    bsp_log "writing initial state.yml at ${STATE_FILE}"
+    write_state_yml "${NOW_TS}" "${PLUGIN_VERSION}"
+    bsp_log "wrote ${STATE_FILE}"
+fi
+
+bsp_log "F-B2 slice 2 complete (steps 2a-2d + initial state.yml). Slice 3 (BYO-RDBMS) and slice 4 (routing block injection) deferred."
+exit 0

--- a/scripts/bootstrap-rollback.sh
+++ b/scripts/bootstrap-rollback.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# scripts/bootstrap-rollback.sh — undo F-B2 in symmetric reverse order.
+#
+# Per Card 2 slice 7 + the A2 decision recorded in
+# docs/plans/bootstrap/card-2-bootstrap.md (the boil-the-lake symmetry
+# enforcer): every F-B2 side effect has a matching rollback step here,
+# applied in reverse order. F-B1 (host bootstrap) is INDEPENDENT; this
+# script never touches manifest.yml.
+#
+# Symmetry rule:
+#   ANY future F-B2 step addition MUST add a matching rollback step
+#   here in reverse order. The CI gate currently observes this contract
+#   only via tests/test-bootstrap-rollback.sh + the end-to-end smoke;
+#   reviewers also enforce it on PR. Drift = the rollback subset stops
+#   matching the bootstrap superset, which leaves users with un-undoable
+#   half-state on `bootstrap-rollback.sh`.
+#
+# Reverse order:
+#   1. rm <repo>/.board-superpowers/config.yml
+#   2. remove the bootstrap entry (and its leading header line) from
+#      <repo>/.gitignore — leave the file even when it becomes empty
+#   3. remove the routing block (between markers) from <repo>/AGENTS.md
+#      AND <repo>/CLAUDE.md, preserving everything outside markers
+#   4. rm ~/.board-superpowers/repos/<normalized>/state.yml
+#   5. PROMPT before rm ~/.board-superpowers/credentials.yml — default =
+#      no. Flags below short-circuit the prompt.
+#
+# What this script does NOT do:
+#   - delete labels (cheap to keep, hard to know if user wants them gone)
+#   - touch ~/.board-superpowers/manifest.yml (F-B1 is independent)
+#   - delete ~/.board-superpowers/repos/<normalized>/audit-local.jsonl
+#     (audit history is durable; rollback is for un-bootstrapping a
+#     repo, not for forensic-grade purges)
+#
+# Argument vector:
+#   bash scripts/bootstrap-rollback.sh \
+#       --repo-root PATH      # absolute repo path; defaults to PWD
+#       [--yes]               # auto-confirm credentials.yml prompt as YES (rm)
+#       [--keep-credentials]  # NO without prompt (preserve credentials.yml)
+#       [--rm-credentials]    # YES without prompt (rm credentials.yml)
+#       [--plugin-root P]     # for testability; defaults to derived from
+#                             # this file's location
+#
+# Default behavior with no credentials flag and no --yes:
+#   - if credentials.yml is absent: silent no-op (no prompt fires).
+#   - if credentials.yml is present: interactive prompt (default NO).
+#
+# Exit codes:
+#   0  success (idempotent on a clean repo too).
+#   1  bad args / unrecoverable filesystem failure (rare).
+#   64 unknown argument.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/common.sh
+. "${SCRIPT_DIR}/lib/common.sh"
+
+# --- Arg parsing --------------------------------------------------------
+
+REPO_ROOT_ARG=""
+YES_FLAG=0
+KEEP_CREDS=0
+RM_CREDS=0
+PLUGIN_ROOT_ARG=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo-root)
+            REPO_ROOT_ARG="${2:-}"
+            [ -n "${REPO_ROOT_ARG}" ] || bsp_die "--repo-root requires a path"
+            shift 2
+            ;;
+        --yes)
+            YES_FLAG=1
+            shift
+            ;;
+        --keep-credentials)
+            KEEP_CREDS=1
+            shift
+            ;;
+        --rm-credentials)
+            RM_CREDS=1
+            shift
+            ;;
+        --plugin-root)
+            PLUGIN_ROOT_ARG="${2:-}"
+            [ -n "${PLUGIN_ROOT_ARG}" ] || bsp_die "--plugin-root requires a path"
+            shift 2
+            ;;
+        --help|-h)
+            sed -n '2,/^set -euo pipefail/p' "${BASH_SOURCE[0]}" >&2
+            exit 0
+            ;;
+        *)
+            printf '[bsp ERROR] unknown argument: %s (try --help)\n' "$1" >&2
+            exit 64
+            ;;
+    esac
+done
+
+if [ "${KEEP_CREDS}" -eq 1 ] && [ "${RM_CREDS}" -eq 1 ]; then
+    bsp_die "--keep-credentials and --rm-credentials are mutually exclusive"
+fi
+
+# --- Resolve plugin root + repo root -----------------------------------
+
+if [ -n "${PLUGIN_ROOT_ARG}" ]; then
+    PLUGIN_ROOT="${PLUGIN_ROOT_ARG}"
+else
+    PLUGIN_ROOT="$(bsp_plugin_root)"
+fi
+[ -d "${PLUGIN_ROOT}" ] || bsp_die "plugin root not found: ${PLUGIN_ROOT}"
+
+# Suppress shellcheck unused-var warning — kept for future extensibility
+# (e.g., plugin-version-aware rollback messaging).
+: "${PLUGIN_ROOT:?}"
+
+bsp_require_cmd python3 "macOS / Linux ship python3 by default"
+bsp_require_cmd git     "install git for your platform"
+
+RAW_REPO_ROOT="${REPO_ROOT_ARG:-${CLAUDE_PROJECT_DIR:-$PWD}}"
+[ -d "${RAW_REPO_ROOT}" ] || bsp_die "repo root not found: ${RAW_REPO_ROOT}"
+REPO_ROOT="$(cd "${RAW_REPO_ROOT}" && git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "${REPO_ROOT}" ]; then
+    # Fall back to the literal directory if it is not a git repo. Rollback
+    # ought to remain useful for partial-bootstrap cleanup even outside a
+    # git workspace.
+    REPO_ROOT="$(cd "${RAW_REPO_ROOT}" && pwd -P)"
+fi
+
+bsp_log "rollback starting for ${REPO_ROOT}"
+
+# --- Step 1 (reverse): rm <repo>/.board-superpowers/config.yml ----------
+
+CONFIG_FILE="${REPO_ROOT}/.board-superpowers/config.yml"
+if [ -f "${CONFIG_FILE}" ]; then
+    rm -f "${CONFIG_FILE}"
+    bsp_log "removed ${CONFIG_FILE}"
+    # Best-effort: if .board-superpowers/ is now empty (no claims/, no
+    # other files), remove it. rmdir fails silently when non-empty.
+    rmdir "${REPO_ROOT}/.board-superpowers" 2>/dev/null || true
+else
+    bsp_log "config.yml absent — skip"
+fi
+
+# --- Step 2 (reverse): remove bootstrap entry from <repo>/.gitignore ----
+
+GITIGNORE_FILE="${REPO_ROOT}/.gitignore"
+GITIGNORE_HEADER="# board-superpowers local state (claim markers are per-session)"
+GITIGNORE_ENTRY=".board-superpowers/claims/"
+
+if [ -f "${GITIGNORE_FILE}" ] && grep -Fxq "${GITIGNORE_ENTRY}" "${GITIGNORE_FILE}"; then
+    # Remove BOTH the entry line AND its preceding header comment if
+    # the header sits immediately above the entry. Atomic rewrite via
+    # python3 (bash 3.2 lacks reliable in-place sed).
+    GITIGNORE_FILE="${GITIGNORE_FILE}" \
+    HEADER_LINE="${GITIGNORE_HEADER}" \
+    ENTRY_LINE="${GITIGNORE_ENTRY}" \
+    python3 - <<'PY'
+import os
+import sys
+import tempfile
+
+path   = os.environ["GITIGNORE_FILE"]
+header = os.environ["HEADER_LINE"]
+entry  = os.environ["ENTRY_LINE"]
+
+with open(path, "rb") as f:
+    raw = f.read()
+
+# Preserve trailing-newline semantics: split on b"\n" so empty trailing
+# is captured.
+text = raw.decode("utf-8", errors="replace")
+lines = text.split("\n")
+
+out = []
+i = 0
+n = len(lines)
+removed = False
+while i < n:
+    cur = lines[i]
+    nxt = lines[i + 1] if i + 1 < n else None
+    # Header followed immediately by entry → drop both.
+    if cur == header and nxt == entry:
+        i += 2
+        removed = True
+        # Skip a single trailing blank that exists ONLY because we
+        # injected one as a separator on bootstrap. Conservative:
+        # only drop when the previous emitted line is also blank or
+        # nothing has been emitted yet.
+        if i < n and lines[i] == "" and (not out or out[-1] == ""):
+            i += 1
+        continue
+    # Entry alone (no header above) → drop the entry only.
+    if cur == entry:
+        i += 1
+        removed = True
+        continue
+    out.append(cur)
+    i += 1
+
+new_text = "\n".join(out)
+
+# Collapse a run of multiple trailing blank lines down to a single
+# trailing newline (cosmetic — rollback should not leave a forest of
+# empty lines behind).
+while new_text.endswith("\n\n\n"):
+    new_text = new_text[:-1]
+
+# If the file was non-empty originally and we collapsed everything,
+# leave it as a single empty line so the file still exists per spec
+# ("leave the file even if it becomes empty").
+if not removed:
+    sys.exit(0)
+
+# Atomic write.
+parent = os.path.dirname(path) or "."
+fd, tmp = tempfile.mkstemp(prefix=".bsp-rollback-", dir=parent)
+try:
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(new_text.encode("utf-8"))
+    os.replace(tmp, path)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PY
+    bsp_log "removed bootstrap entry from ${GITIGNORE_FILE}"
+else
+    bsp_log ".gitignore bootstrap entry absent — skip"
+fi
+
+# --- Step 3 (reverse): remove routing block from AGENTS.md + CLAUDE.md --
+
+remove_routing_block() {
+    local target="$1"
+    if [ ! -f "${target}" ]; then
+        bsp_log "${target} absent — skip"
+        return 0
+    fi
+    if ! grep -Fq '<!-- board-superpowers:routing -->' "${target}" \
+        && ! grep -Fq '<!-- /board-superpowers:routing -->' "${target}"
+    then
+        bsp_log "${target} has no routing markers — skip"
+        return 0
+    fi
+    BSP_TARGET="${target}" python3 - <<'PY'
+import os
+import tempfile
+
+target = os.environ["BSP_TARGET"]
+OPEN  = b"<!-- board-superpowers:routing -->"
+CLOSE = b"<!-- /board-superpowers:routing -->"
+BOM   = b"\xef\xbb\xbf"
+
+with open(target, "rb") as f:
+    raw = f.read()
+
+bom_prefix = b""
+body = raw
+if body.startswith(BOM):
+    bom_prefix = BOM
+    body = body[len(BOM):]
+
+# Best-effort cleanup. We accept any of:
+#   - both markers present (the standard case): excise the block + a
+#     leading blank line if one immediately precedes the OPEN marker.
+#   - only OPEN present (orphan): strip the OPEN marker line only.
+#   - only CLOSE present (orphan): strip the CLOSE marker line only.
+#   - multiple pairs: greedy-strip the FIRST pair; leave subsequent
+#     ones to a re-run. Not the steady-state we expect, but rollback
+#     should make progress, not block on partial-bootstrap pathology.
+
+def _strip_pair(buf: bytes) -> bytes:
+    o = buf.find(OPEN)
+    c = buf.find(CLOSE)
+    if o == -1 or c == -1 or c < o:
+        return buf  # caller falls through to orphan handling
+    # Extend the OPEN slice backwards over a single preceding LF so the
+    # blank line bootstrap inserted gets cleaned too.
+    open_start = o
+    if open_start > 0 and buf[open_start - 1:open_start] == b"\n":
+        # Walk back across an additional blank-line LF if present.
+        if open_start - 2 >= 0 and buf[open_start - 2:open_start - 1] == b"\n":
+            open_start -= 1
+    close_end = c + len(CLOSE)
+    # Eat one trailing newline immediately after CLOSE so we don't leave
+    # a stray blank line where the block lived.
+    if close_end < len(buf) and buf[close_end:close_end + 1] == b"\n":
+        close_end += 1
+    return buf[:open_start] + buf[close_end:]
+
+def _strip_orphan_line(buf: bytes, marker: bytes) -> bytes:
+    idx = buf.find(marker)
+    if idx == -1:
+        return buf
+    line_start = buf.rfind(b"\n", 0, idx) + 1  # works when idx == 0
+    line_end = buf.find(b"\n", idx)
+    if line_end == -1:
+        line_end = len(buf)
+    else:
+        line_end += 1  # include the trailing newline
+    return buf[:line_start] + buf[line_end:]
+
+# Strip pairs greedily until no more remain.
+while True:
+    new = _strip_pair(body)
+    if new == body:
+        break
+    body = new
+
+# Any orphan markers left behind? Strip their lines.
+body = _strip_orphan_line(body, OPEN)
+body = _strip_orphan_line(body, CLOSE)
+
+# Collapse runaway blank lines at EOF down to a single trailing newline.
+while body.endswith(b"\n\n\n"):
+    body = body[:-1]
+# Guarantee a final newline if any content remains.
+if body and not body.endswith(b"\n"):
+    body += b"\n"
+
+payload = bom_prefix + body
+
+parent = os.path.dirname(target) or "."
+fd, tmp = tempfile.mkstemp(prefix=".bsp-rollback-", dir=parent)
+try:
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(payload)
+    os.replace(tmp, target)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PY
+    bsp_log "removed routing block from ${target}"
+}
+
+remove_routing_block "${REPO_ROOT}/AGENTS.md"
+remove_routing_block "${REPO_ROOT}/CLAUDE.md"
+
+# --- Step 4 (reverse): rm host-local state.yml --------------------------
+
+STATE_DIR="$(bsp_host_state_dir "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+if [ -f "${STATE_FILE}" ]; then
+    rm -f "${STATE_FILE}"
+    bsp_log "removed ${STATE_FILE}"
+    # rmdir up the chain best-effort — only succeeds when empty.
+    rmdir "${STATE_DIR}" 2>/dev/null || true
+    # Don't rmdir the parent ~/.board-superpowers/repos/ — it might
+    # legitimately still hold other repos' subdirs.
+else
+    bsp_log "state.yml absent — skip"
+fi
+
+# --- Step 5 (reverse): credentials.yml prompt ---------------------------
+
+CRED_FILE="${HOME}/.board-superpowers/credentials.yml"
+
+if [ ! -f "${CRED_FILE}" ]; then
+    bsp_log "credentials.yml absent — skip"
+elif [ "${KEEP_CREDS}" -eq 1 ]; then
+    bsp_log "--keep-credentials: leaving ${CRED_FILE} in place"
+elif [ "${RM_CREDS}" -eq 1 ]; then
+    rm -f "${CRED_FILE}"
+    bsp_log "--rm-credentials: removed ${CRED_FILE}"
+elif [ "${YES_FLAG}" -eq 1 ]; then
+    rm -f "${CRED_FILE}"
+    bsp_log "--yes: removed ${CRED_FILE}"
+else
+    # Interactive prompt — DEFAULT NO. credentials.yml might predate
+    # this bootstrap or apply to other repos.
+    {
+        printf '\n'
+        printf '[bsp] %s exists.\n' "${CRED_FILE}"
+        printf '[bsp] It might predate this bootstrap or apply to other repos.\n'
+        printf '[bsp] Remove it? [y/N] '
+    } >&2
+    input_source="/dev/stdin"
+    if [ -t 0 ] && [ -r /dev/tty ]; then
+        input_source="/dev/tty"
+    fi
+    answer=""
+    if ! IFS= read -r answer < "${input_source}"; then
+        answer=""
+    fi
+    case "${answer}" in
+        y|Y|yes|YES|Yes)
+            rm -f "${CRED_FILE}"
+            bsp_log "removed ${CRED_FILE}"
+            ;;
+        *)
+            bsp_log "leaving ${CRED_FILE} in place (default)"
+            ;;
+    esac
+fi
+
+bsp_log "rollback complete for ${REPO_ROOT}"
+exit 0

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -221,8 +221,9 @@ check_routing_block() {
     # Asymmetric rule (per 05-bootstrap-surface.md):
     #   - no AGENTS.md AND no CLAUDE.md → skipped (silent, ROUTING_STATE=yes)
     #   - either file present without the heading → ROUTING_STATE=no
-    # Detection is heading-presence only. Card 2 will tighten this to a
-    # SHA-hash protocol; for v0.1.1 a literal heading match suffices.
+    # Detection is heading-presence only. The SHA-hash protocol lives
+    # in F-B2 step 4 (state.yml:routing_blocks[]); for v0.2.0 the dep
+    # check uses a literal heading match as a fast first-line signal.
     local agents="${toplevel}/AGENTS.md"
     local claude="${toplevel}/CLAUDE.md"
     local heading='## board-superpowers session routing'
@@ -310,5 +311,5 @@ if [ "${RUNTIME_FAILURES}" -gt 0 ]; then
     exit 3
 fi
 
-printf '\nAll dependencies satisfied (board-superpowers v0.1.1).\n'
+printf '\nAll dependencies satisfied (board-superpowers v0.2.0).\n'
 exit 0

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -52,6 +52,14 @@ bsp_plugin_root() {
 #
 # Input MUST be absolute (start with "/"); relative input is a usage
 # error that exits non-zero.
+#
+# DUPLICATION NOTICE: this function is duplicated INLINE inside
+# hooks/session-start.sh as `normalize_repo_path` because the hook
+# is contractually self-contained (per
+# docs/architecture/0005-contracts/02-hook-contracts.md
+# § "Self-containment" line 297-298). DO NOT deduplicate by sourcing
+# common.sh from the hook — a broken lib must never block session
+# start. When the rule changes here it MUST also change in the hook.
 
 bsp_normalize_repo_path() {
     local p="${1:?usage: bsp_normalize_repo_path <abs-repo-root>}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -75,6 +75,73 @@ bsp_normalize_repo_path() {
     printf '%s\n' "${p//\//-}"
 }
 
+# bsp_primary_repo_root <cwd> — resolve a working directory to its
+# PRIMARY repo root (the original `git init`-ed working tree), NOT
+# the worktree root the caller may currently sit in. Required because
+# `git rev-parse --show-toplevel` returns the WORKTREE root from
+# inside a `git worktree`, and the worktree's absolute path normalizes
+# (via bsp_normalize_repo_path) to a different `<normalized>` than the
+# canonical repo. Any per-repo state lookup keyed by `<normalized>`
+# (host-local state.yml, audit-local.jsonl) MUST use this helper —
+# otherwise a worktree-launched session sees a fresh "no state.yml
+# yet" path and false-emits a bootstrap prompt.
+#
+# Mechanics: `git rev-parse --git-common-dir` always points at the
+# primary repo's `.git/` directory (regardless of worktree vs primary
+# linked checkout). dirname of that is the primary working tree.
+#
+# Args:   <cwd>
+# Stdout: absolute primary-repo-root path on success; nothing on failure.
+# Returns: 0 on success, 1 if not in a git repo (caller should fall
+#   back to whatever the surrounding context calls for).
+#
+# DUPLICATION NOTICE: this function is duplicated INLINE inside
+# hooks/session-start.sh as `primary_repo_root` because the hook is
+# contractually self-contained (per 02-hook-contracts.md
+# § "Self-containment" lines 295-303). DO NOT deduplicate by sourcing
+# common.sh from the hook. When the rule changes here it MUST also
+# change in the hook.
+
+bsp_primary_repo_root() {
+    local cwd="${1:?usage: bsp_primary_repo_root <cwd>}"
+    command -v git >/dev/null 2>&1 || return 1
+    local common_dir
+    common_dir="$(git -C "${cwd}" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "${common_dir}" ] || return 1
+    case "${common_dir}" in
+        /*) ;;
+        *) common_dir="${cwd}/${common_dir}" ;;
+    esac
+    # `dirname` of the primary `.git/` directory is the primary
+    # working tree. Run through `pwd -P` so symlinks (macOS
+    # /var → /private/var) don't bite.
+    (cd "$(dirname "${common_dir}")" 2>/dev/null && pwd -P) || return 1
+}
+
+# bsp_sanitize_reason_line <raw> — sanitize a string for use as the
+# value portion of a hook-injected `REASON:` marker. Per
+# 02-hook-contracts.md § "Intent-injection markers" lines 213-216:
+#   plain ASCII, ≤120 chars, punctuation only `. , ; : - ( )`.
+#   No newlines, no JSON, no markup.
+#
+# Drops any character outside the whitelist (alnum + space +
+# `. , ; : - ( )`); truncates to 200 chars (well over the spec's
+# 120-char ceiling, leaves headroom).
+#
+# Note: bsp_sanitize_dep_name's 32-char truncation is too aggressive
+# for a sentence-shaped REASON line; this helper exists separately.
+#
+# DUPLICATION NOTICE: duplicated INLINE inside hooks/session-start.sh
+# as `sanitize_reason_line`. Keep the implementations in lockstep
+# (per 02-hook-contracts.md § "Self-containment").
+
+bsp_sanitize_reason_line() {
+    local raw="${1:-}"
+    LC_ALL=C printf '%s' "${raw}" \
+        | LC_ALL=C tr -cd 'a-zA-Z0-9 .,;:\-()' \
+        | head -c 200
+}
+
 # --- Host-local + per-repo state paths ----------------------------------
 #
 # Per AGENTS.md Architecture-at-a-glance + 07-path-conventions.md

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -414,6 +414,264 @@ bsp_pick_worktree_dir() {
     printf '%s\n' "${HOME}/.config/superpowers/worktrees"
 }
 
+# --- Routing block injection ---------------------------------------------
+#
+# Injects the canonical routing block from a source file (typically
+# skills/using-board-superpowers/references/agentsmd-routing.md) into a
+# target file (typically <repo>/AGENTS.md or <repo>/CLAUDE.md) between
+# the marker pair:
+#
+#     <!-- board-superpowers:routing -->
+#     ...
+#     <!-- /board-superpowers:routing -->
+#
+# Source-file normalization (always applied before hashing AND before
+# injection — see spec
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § 1.5.2 step 4 + the slice-4 note in
+# docs/plans/bootstrap/card-2-bootstrap.md):
+#   1. Strip leading UTF-8 BOM (EF BB BF) if present.
+#   2. Replace every CRLF / CR with LF.
+# The post-normalization bytes ARE the canonical routing block and
+# are SHA256-hashed to populate state.yml:routing_blocks[].block_hash.
+#
+# Target-file rules:
+#   - Absent: create with marker pair wrapping the block content.
+#   - Existing, BOTH markers present: replace bytes between markers
+#     with normalized block content. Bytes OUTSIDE markers (including
+#     BOM at byte 0, original line endings) are preserved verbatim.
+#   - Existing, NEITHER marker present: append the marker-wrapped
+#     block to the file (preserving original ending).
+#   - Existing, exactly ONE marker (orphan): emit verbatim error and
+#     return exit 5 — DO NOT modify the file.
+#
+# Stdout on success: the hex SHA256 hash (no "sha256:" prefix), one
+# line. Caller is expected to prepend "sha256:" when recording into
+# state.yml.
+#
+# Args: <target_file> <source_file>
+# Exit codes:
+#   0  success — hash printed to stdout
+#   1  bad args / source file unreadable / target write failure
+#   5  target has orphan marker (one but not both)
+
+bsp_inject_routing_block() {
+    local target="${1:?usage: bsp_inject_routing_block <target_file> <source_file>}"
+    local source="${2:?usage: bsp_inject_routing_block <target_file> <source_file>}"
+
+    if [ ! -f "${source}" ]; then
+        bsp_die "bsp_inject_routing_block: source file not found: ${source}"
+    fi
+
+    bsp_require_cmd python3 "macOS / Linux ship python3 by default"
+
+    # Hand the entire injection to python3: reading binary, BOM
+    # stripping, LF normalization, SHA256 over the post-normalization
+    # bytes, marker scan, byte-precise replacement, atomic write via
+    # mktemp+os.replace are all easier in python than bash. The script
+    # writes the hex hash to stdout; bash captures it.
+    BSP_TARGET="${target}" BSP_SOURCE="${source}" python3 - <<'PY'
+import hashlib
+import os
+import sys
+import tempfile
+
+target = os.environ["BSP_TARGET"]
+source = os.environ["BSP_SOURCE"]
+
+OPEN  = b"<!-- board-superpowers:routing -->"
+CLOSE = b"<!-- /board-superpowers:routing -->"
+BOM   = b"\xef\xbb\xbf"
+
+def normalize(data: bytes) -> bytes:
+    # Strip leading UTF-8 BOM if present.
+    if data.startswith(BOM):
+        data = data[len(BOM):]
+    # Normalize CRLF / lone CR to LF.
+    data = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return data
+
+# Read + normalize source bytes.
+try:
+    with open(source, "rb") as f:
+        raw_source = f.read()
+except OSError as e:
+    sys.stderr.write(f"[bsp ERROR] cannot read source: {e}\n")
+    sys.exit(1)
+
+block_content = normalize(raw_source)
+# Hash over the normalized bytes (which become exactly what we write
+# between markers). Trim a single trailing newline before hashing so
+# the recorded hash matches the bytes literally between markers.
+content_for_hash = block_content
+if content_for_hash.endswith(b"\n"):
+    content_for_hash = content_for_hash[:-1]
+block_hash = hashlib.sha256(content_for_hash).hexdigest()
+
+# The bytes that go between markers — no leading newline, exactly one
+# trailing newline so closing marker sits on its own line.
+between = content_for_hash + b"\n"
+
+def atomic_write(path, payload):
+    parent = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(prefix=".bsp-inject-", dir=parent)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+if not os.path.exists(target):
+    payload = OPEN + b"\n" + between + CLOSE + b"\n"
+    try:
+        atomic_write(target, payload)
+    except OSError as e:
+        sys.stderr.write(f"[bsp ERROR] cannot write target: {e}\n")
+        sys.exit(1)
+    print(block_hash)
+    sys.exit(0)
+
+# Existing target — read, scan, classify.
+try:
+    with open(target, "rb") as f:
+        original = f.read()
+except OSError as e:
+    sys.stderr.write(f"[bsp ERROR] cannot read target: {e}\n")
+    sys.exit(1)
+
+# Preserve a leading BOM at byte 0 of the target file. It's NOT part
+# of the marker scan and NOT part of the hashed region. The scan
+# happens against `body`; final write reattaches the BOM unchanged.
+bom_prefix = b""
+body = original
+if body.startswith(BOM):
+    bom_prefix = BOM
+    body = body[len(BOM):]
+
+open_idx  = body.find(OPEN)
+close_idx = body.find(CLOSE)
+
+# Orphan detection.
+if (open_idx == -1) ^ (close_idx == -1):
+    # Determine line numbers (1-based) for the present marker — only
+    # for stderr explanatory text. Use original (with BOM) so the
+    # numbers match what `cat -n` would show the architect.
+    def line_of(buf, idx_no_bom):
+        if idx_no_bom == -1:
+            return -1
+        idx = idx_no_bom + len(bom_prefix)
+        return buf[:idx].count(b"\n") + 1
+
+    open_present = open_idx != -1
+    if open_present:
+        present_marker = OPEN.decode("utf-8")
+        absent_marker  = CLOSE.decode("utf-8")
+        line_no = line_of(original, open_idx)
+    else:
+        present_marker = CLOSE.decode("utf-8")
+        absent_marker  = OPEN.decode("utf-8")
+        line_no = line_of(original, close_idx)
+
+    sys.stderr.write(
+        "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
+        "\n"
+        f"Target file:    {target}\n"
+        f"Detected:       opening marker '{OPEN.decode('utf-8')}'\n"
+        f"                present at line {line_no if open_present else '?'}, but closing marker\n"
+        f"                '{CLOSE.decode('utf-8')}' is absent.\n"
+        "                (Or vice versa.)\n"
+        "\n"
+        "This indicates either:\n"
+        "  (1) a partial or corrupted previous injection\n"
+        "  (2) hand-edited markers (one removed, one left)\n"
+        "  (3) a third party stripped one marker\n"
+        "\n"
+        "Recovery options (pick one, then re-run F-B2):\n"
+        "  (a) Restore both markers — add the closing marker AT or AFTER the\n"
+        "      content you want preserved as plugin-managed.\n"
+        "  (b) Delete the entire file — F-B2 will re-create it with just the\n"
+        "      routing block. Use only if AGENTS.md content was minimal.\n"
+        "  (c) Strip the orphan marker — manually remove the lone opening\n"
+        "      marker. F-B2 will then treat the file as case-C (no markers,\n"
+        "      will append fresh block).\n"
+        "\n"
+        "F-B2 has NOT written state.yml. Repo state remains pre-bootstrap.\n"
+        "Re-run after fixing.\n"
+    )
+    # Dummy reads to keep flake8 happy if any are unused
+    _ = present_marker, absent_marker
+    sys.exit(5)
+
+if open_idx == -1 and close_idx == -1:
+    # Append marker-wrapped block. Preserve everything before; tack
+    # on a leading newline if the file doesn't already end with one.
+    suffix = b""
+    if body and not body.endswith(b"\n"):
+        suffix += b"\n"
+    suffix += b"\n"  # blank line separator between existing content + marker
+    suffix += OPEN + b"\n" + between + CLOSE + b"\n"
+    payload = bom_prefix + body + suffix
+    try:
+        atomic_write(target, payload)
+    except OSError as e:
+        sys.stderr.write(f"[bsp ERROR] cannot write target: {e}\n")
+        sys.exit(1)
+    print(block_hash)
+    sys.exit(0)
+
+# Both markers present — replace bytes between them.
+if open_idx > close_idx:
+    sys.stderr.write(
+        "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
+        f"Target file:    {target}\n"
+        "Detected:       closing marker appears BEFORE opening marker.\n"
+        "                Markers are reversed or the file is corrupted.\n"
+        "\n"
+        "Fix the file manually (markers must appear in the order\n"
+        "open-then-close), then re-run F-B2.\n"
+        "\n"
+        "F-B2 has NOT written state.yml. Repo state remains pre-bootstrap.\n"
+    )
+    sys.exit(5)
+
+# Inclusive end position: keep everything through CLOSE marker bytes.
+close_end = close_idx + len(CLOSE)
+
+before = body[: open_idx]
+after  = body[close_end :]
+
+# Strip the immediate newline AFTER the OPEN marker we are removing
+# (start of region to replace) and the immediate newline BEFORE the
+# CLOSE marker we are keeping start-of (end of region) is implicit in
+# how we slice; we replace bytes between OPEN and CLOSE wholesale.
+new_middle = OPEN + b"\n" + between + CLOSE
+
+# Ensure the file ends with a single trailing newline. Don't double
+# up if `after` already starts with content, just preserve.
+payload = bom_prefix + before + new_middle + after
+# Guarantee single trailing newline at EOF.
+if not payload.endswith(b"\n"):
+    payload += b"\n"
+else:
+    # Trim accidental trailing-newline doubling at EOF only.
+    while payload.endswith(b"\n\n"):
+        payload = payload[:-1]
+
+try:
+    atomic_write(target, payload)
+except OSError as e:
+    sys.stderr.write(f"[bsp ERROR] cannot write target: {e}\n")
+    sys.exit(1)
+print(block_hash)
+sys.exit(0)
+PY
+}
+
 # --- Card slug helper ----------------------------------------------------
 #
 # Convert a card title to a branch-safe slug per board-canon's

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -425,25 +425,50 @@ bsp_pick_worktree_dir() {
 #     ...
 #     <!-- /board-superpowers:routing -->
 #
-# Source-file normalization (always applied before hashing AND before
-# injection — see spec
+# Source-file fence extraction:
+#   The source file MUST contain a fence sentinel pair distinct from
+#   the target marker pair so a naive find() for the target markers
+#   against the source returns nothing:
+#
+#     <!-- routing-block:start -->
+#     ...content the helper extracts and injects...
+#     <!-- routing-block:end -->
+#
+#   Any prose ABOVE the start fence is plugin-maintainer-facing
+#   docstring (NOT injected). Any prose BELOW the end fence is
+#   maintainer notes (NOT injected).
+#
+# Source-file normalization (always applied to the fence-bounded
+# content before hashing AND before injection — see spec
 # docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
-# § 1.5.2 step 4 + the slice-4 note in
-# docs/plans/bootstrap/card-2-bootstrap.md):
+# § 1.5.2 step 4):
 #   1. Strip leading UTF-8 BOM (EF BB BF) if present.
 #   2. Replace every CRLF / CR with LF.
+#   3. Strip leading/trailing newlines so the injected block is tight.
 # The post-normalization bytes ARE the canonical routing block and
 # are SHA256-hashed to populate state.yml:routing_blocks[].block_hash.
 #
+# Source-file fatal errors:
+#   - Fence sentinels missing → fatal error pointing at the source
+#     file path.
+#   - Fence-bounded content contains a literal target marker
+#     (<!-- board-superpowers:routing --> or its closing form) → fatal
+#     error (would otherwise produce nested markers in the target).
+#
 # Target-file rules:
 #   - Absent: create with marker pair wrapping the block content.
-#   - Existing, BOTH markers present: replace bytes between markers
-#     with normalized block content. Bytes OUTSIDE markers (including
-#     BOM at byte 0, original line endings) are preserved verbatim.
-#   - Existing, NEITHER marker present: append the marker-wrapped
-#     block to the file (preserving original ending).
-#   - Existing, exactly ONE marker (orphan): emit verbatim error and
-#     return exit 5 — DO NOT modify the file.
+#   - Existing, exactly 1 OPEN + exactly 1 CLOSE: replace bytes
+#     between markers with normalized block content. Bytes OUTSIDE
+#     markers (including BOM at byte 0, original line endings) are
+#     preserved verbatim.
+#   - Existing, 0 OPEN + 0 CLOSE: append the marker-wrapped block
+#     to the file (preserving original ending).
+#   - Existing, exactly ONE marker but not both (orphan): emit
+#     verbatim error pointing at the actual line number of the
+#     present marker, and return exit 5 — DO NOT modify the file.
+#   - Existing, 2+ OPEN OR 2+ CLOSE: emit multi-pair error
+#     (user copy-pasted the block twice; only the first pair would
+#     be updated, second would silently rot) and return exit 5.
 #
 # Stdout on success: the hex SHA256 hash (no "sha256:" prefix), one
 # line. Caller is expected to prepend "sha256:" when recording into
@@ -452,8 +477,10 @@ bsp_pick_worktree_dir() {
 # Args: <target_file> <source_file>
 # Exit codes:
 #   0  success — hash printed to stdout
-#   1  bad args / source file unreadable / target write failure
-#   5  target has orphan marker (one but not both)
+#   1  bad args / source file unreadable / source missing fences /
+#      source has nested target markers / target write failure
+#   5  target has orphan marker (one but not both) OR multiple marker
+#      pairs (2+ open or 2+ close)
 
 bsp_inject_routing_block() {
     local target="${1:?usage: bsp_inject_routing_block <target_file> <source_file>}"
@@ -479,9 +506,11 @@ import tempfile
 target = os.environ["BSP_TARGET"]
 source = os.environ["BSP_SOURCE"]
 
-OPEN  = b"<!-- board-superpowers:routing -->"
-CLOSE = b"<!-- /board-superpowers:routing -->"
-BOM   = b"\xef\xbb\xbf"
+OPEN        = b"<!-- board-superpowers:routing -->"
+CLOSE       = b"<!-- /board-superpowers:routing -->"
+FENCE_OPEN  = b"<!-- routing-block:start -->"
+FENCE_CLOSE = b"<!-- routing-block:end -->"
+BOM         = b"\xef\xbb\xbf"
 
 def normalize(data: bytes) -> bytes:
     # Strip leading UTF-8 BOM if present.
@@ -491,7 +520,7 @@ def normalize(data: bytes) -> bytes:
     data = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
     return data
 
-# Read + normalize source bytes.
+# Read source bytes.
 try:
     with open(source, "rb") as f:
         raw_source = f.read()
@@ -499,18 +528,129 @@ except OSError as e:
     sys.stderr.write(f"[bsp ERROR] cannot read source: {e}\n")
     sys.exit(1)
 
-block_content = normalize(raw_source)
-# Hash over the normalized bytes (which become exactly what we write
-# between markers). Trim a single trailing newline before hashing so
-# the recorded hash matches the bytes literally between markers.
-content_for_hash = block_content
-if content_for_hash.endswith(b"\n"):
-    content_for_hash = content_for_hash[:-1]
-block_hash = hashlib.sha256(content_for_hash).hexdigest()
+# Locate the fence sentinels in the source. Both must be present and
+# must appear on their own lines (start of line + end of line) so that
+# documentation prose mentioning the sentinel keywords (e.g. inside
+# backticks for explanatory purposes elsewhere in the source file)
+# does not accidentally satisfy the find. The "own line" rule is:
+#   - preceded by a newline OR start-of-file
+#   - followed by a newline OR end-of-file (with optional trailing
+#     whitespace before the newline)
+# We implement this by scanning line-by-line over normalized bytes.
+def find_standalone(buf: bytes, sentinel: bytes) -> int:
+    """Return absolute byte offset of `sentinel` on a line by itself,
+    or -1 if no such occurrence exists. Trailing whitespace on the
+    line is tolerated. Raw `buf` is expected to use LF line endings —
+    callers may normalize CRLF first if needed.
+    """
+    pos = 0
+    n = len(buf)
+    while pos < n:
+        nl = buf.find(b"\n", pos)
+        line_end = nl if nl != -1 else n
+        line = buf[pos:line_end].rstrip(b" \t\r")
+        if line == sentinel:
+            return pos
+        if nl == -1:
+            return -1
+        pos = nl + 1
+    return -1
 
-# The bytes that go between markers — no leading newline, exactly one
-# trailing newline so closing marker sits on its own line.
-between = content_for_hash + b"\n"
+# Normalize source line endings BEFORE the fence scan so a CRLF
+# source still matches the fence sentinels on standalone-line basis.
+normalized_source = raw_source.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+fence_open_idx  = find_standalone(normalized_source, FENCE_OPEN)
+fence_close_idx = find_standalone(normalized_source, FENCE_CLOSE)
+
+if fence_open_idx == -1 or fence_close_idx == -1:
+    sys.stderr.write(
+        "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
+        "\n"
+        f"Source-of-truth file at {source}\n"
+        "missing fence markers; expected\n"
+        f"  `{FENCE_OPEN.decode('utf-8')}` and\n"
+        f"  `{FENCE_CLOSE.decode('utf-8')}`\n"
+        "to bracket the routing block content (each on its own line).\n"
+        "The docstring header outside the fence is plugin-maintainer\n"
+        "documentation and is NOT injected; only fence-bounded bytes are.\n"
+        "\n"
+        "Fix the source file, then re-run F-B2.\n"
+    )
+    sys.exit(1)
+
+if fence_close_idx < fence_open_idx:
+    sys.stderr.write(
+        "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
+        "\n"
+        f"Source-of-truth file at {source}\n"
+        "has fence markers in the wrong order: closing fence\n"
+        f"  `{FENCE_CLOSE.decode('utf-8')}`\n"
+        "appears BEFORE opening fence\n"
+        f"  `{FENCE_OPEN.decode('utf-8')}`.\n"
+        "\n"
+        "Fix the source file, then re-run F-B2.\n"
+    )
+    sys.exit(1)
+
+# Extract bytes BETWEEN the fences (exclusive of fence markers).
+# Use the normalized source so the slice indices match the bytes we
+# analyzed. The fenced region runs from the byte after the opening
+# fence's newline to the byte before the closing fence.
+fence_open_line_end = normalized_source.find(b"\n", fence_open_idx)
+if fence_open_line_end == -1:
+    fence_open_line_end = fence_open_idx + len(FENCE_OPEN)
+fenced = normalized_source[fence_open_line_end + 1 : fence_close_idx]
+
+# Normalize: strip leading BOM (defensive), strip leading/trailing
+# newlines so the injected block is tight. Source already had CRLF→LF
+# normalization applied above before the fence scan.
+block_content = fenced
+if block_content.startswith(BOM):
+    block_content = block_content[len(BOM):]
+block_content = block_content.strip(b"\n")
+
+# Sanity: fence-bounded content MUST NOT contain literal target
+# markers — that would produce nested markers in the target file.
+def find_line(buf: bytes, needle: bytes) -> int:
+    """Return 1-based line number of needle in buf, or -1 if absent."""
+    idx = buf.find(needle)
+    if idx == -1:
+        return -1
+    return buf[:idx].count(b"\n") + 1
+
+target_open_in_src  = find_line(block_content, OPEN)
+target_close_in_src = find_line(block_content, CLOSE)
+if target_open_in_src != -1 or target_close_in_src != -1:
+    if target_open_in_src != -1:
+        bad_marker = OPEN.decode("utf-8")
+        bad_line   = target_open_in_src
+    else:
+        bad_marker = CLOSE.decode("utf-8")
+        bad_line   = target_close_in_src
+    sys.stderr.write(
+        "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
+        "\n"
+        f"Source-of-truth file at {source}\n"
+        f"has literal target-file marker `{bad_marker}`\n"
+        f"inside the fence at line {bad_line} of the fenced content.\n"
+        "Injecting it would produce nested markers in the target file.\n"
+        "\n"
+        "Remove the literal target marker from inside the fence, then\n"
+        "re-run F-B2. The fence sentinels (routing-block:start /\n"
+        "routing-block:end) are the source-side delimiters; the target\n"
+        "marker pair (board-superpowers:routing) wraps injected content\n"
+        "in the consumer repo's AGENTS.md / CLAUDE.md and must not\n"
+        "appear inside the source fence.\n"
+    )
+    sys.exit(1)
+
+# block_content is the canonical routing block bytes. Hash it as-is
+# (no trailing newline), then assemble the bytes that go between
+# target markers (with exactly one trailing newline so the closing
+# marker sits on its own line).
+block_hash = hashlib.sha256(block_content).hexdigest()
+between = block_content + b"\n"
 
 def atomic_write(path, payload):
     parent = os.path.dirname(path) or "."
@@ -553,38 +693,87 @@ if body.startswith(BOM):
     bom_prefix = BOM
     body = body[len(BOM):]
 
-open_idx  = body.find(OPEN)
-close_idx = body.find(CLOSE)
+# Count occurrences of OPEN and CLOSE in body (unique non-overlapping).
+def count_occurrences(buf: bytes, needle: bytes) -> int:
+    count = 0
+    start = 0
+    n = len(needle)
+    while True:
+        idx = buf.find(needle, start)
+        if idx == -1:
+            return count
+        count += 1
+        start = idx + n
 
-# Orphan detection.
-if (open_idx == -1) ^ (close_idx == -1):
-    # Determine line numbers (1-based) for the present marker — only
-    # for stderr explanatory text. Use original (with BOM) so the
-    # numbers match what `cat -n` would show the architect.
-    def line_of(buf, idx_no_bom):
-        if idx_no_bom == -1:
-            return -1
-        idx = idx_no_bom + len(bom_prefix)
-        return buf[:idx].count(b"\n") + 1
+open_count  = count_occurrences(body, OPEN)
+close_count = count_occurrences(body, CLOSE)
 
-    open_present = open_idx != -1
-    if open_present:
-        present_marker = OPEN.decode("utf-8")
-        absent_marker  = CLOSE.decode("utf-8")
-        line_no = line_of(original, open_idx)
+def line_of(buf: bytes, idx_no_bom: int) -> int:
+    """1-based line number, accounting for an optional preserved BOM."""
+    if idx_no_bom == -1:
+        return -1
+    idx = idx_no_bom + len(bom_prefix)
+    return buf[:idx].count(b"\n") + 1
+
+# Multi-pair detection: if either marker appears more than once, the
+# target is in an ambiguous state (e.g. user copy-pasted the routing
+# block twice). Refuse to silently update only the first occurrence.
+if open_count > 1 or close_count > 1:
+    sys.stderr.write(
+        "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
+        "\n"
+        f"Target file:    {target}\n"
+        f"Detected:       {open_count} opening markers and {close_count} closing markers\n"
+        f"                in {target}. Expected exactly 0 or 1 of each.\n"
+        "\n"
+        "This indicates either:\n"
+        "  (1) the routing block was copy-pasted into the target multiple\n"
+        "      times — only the first pair would be updated, leaving the\n"
+        "      others to silently drift\n"
+        "  (2) hand-edited duplication\n"
+        "  (3) a merge artifact left two stale blocks\n"
+        "\n"
+        "Recovery options (pick one, then re-run F-B2):\n"
+        "  (a) Strip the duplicate marker pairs — keep at most ONE\n"
+        "      `<!-- board-superpowers:routing -->` /\n"
+        "      `<!-- /board-superpowers:routing -->` block.\n"
+        "  (b) Delete the entire file — F-B2 will re-create it with just\n"
+        "      the routing block. Use only if AGENTS.md content was\n"
+        "      minimal.\n"
+        "  (c) Strip ALL marker pairs — F-B2 will then treat the file as\n"
+        "      case-C (no markers, will append a fresh block).\n"
+        "\n"
+        "F-B2 has NOT written state.yml. Repo state remains pre-bootstrap.\n"
+        "Re-run after fixing.\n"
+    )
+    sys.exit(5)
+
+open_idx  = body.find(OPEN)  if open_count  == 1 else -1
+close_idx = body.find(CLOSE) if close_count == 1 else -1
+
+# Orphan detection: exactly one of OPEN / CLOSE present, the other
+# absent.
+if (open_count == 1) ^ (close_count == 1):
+    if open_count == 1:
+        kind            = "opening"
+        present_marker  = OPEN.decode("utf-8")
+        other_kind      = "closing"
+        absent_marker   = CLOSE.decode("utf-8")
+        present_line    = line_of(original, open_idx)
     else:
-        present_marker = CLOSE.decode("utf-8")
-        absent_marker  = OPEN.decode("utf-8")
-        line_no = line_of(original, close_idx)
+        kind            = "closing"
+        present_marker  = CLOSE.decode("utf-8")
+        other_kind      = "opening"
+        absent_marker   = OPEN.decode("utf-8")
+        present_line    = line_of(original, close_idx)
 
     sys.stderr.write(
         "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"
         "\n"
         f"Target file:    {target}\n"
-        f"Detected:       opening marker '{OPEN.decode('utf-8')}'\n"
-        f"                present at line {line_no if open_present else '?'}, but closing marker\n"
-        f"                '{CLOSE.decode('utf-8')}' is absent.\n"
-        "                (Or vice versa.)\n"
+        f"Detected:       {kind} marker '{present_marker}' present at line {present_line},\n"
+        f"                but matching {other_kind} marker '{absent_marker}'\n"
+        "                is absent.\n"
         "\n"
         "This indicates either:\n"
         "  (1) a partial or corrupted previous injection\n"
@@ -592,22 +781,20 @@ if (open_idx == -1) ^ (close_idx == -1):
         "  (3) a third party stripped one marker\n"
         "\n"
         "Recovery options (pick one, then re-run F-B2):\n"
-        "  (a) Restore both markers — add the closing marker AT or AFTER the\n"
+        "  (a) Restore both markers — add the missing marker AT or AFTER the\n"
         "      content you want preserved as plugin-managed.\n"
         "  (b) Delete the entire file — F-B2 will re-create it with just the\n"
         "      routing block. Use only if AGENTS.md content was minimal.\n"
-        "  (c) Strip the orphan marker — manually remove the lone opening\n"
-        "      marker. F-B2 will then treat the file as case-C (no markers,\n"
-        "      will append fresh block).\n"
+        "  (c) Strip the orphan marker — manually remove the lone marker.\n"
+        "      F-B2 will then treat the file as case-C (no markers, will\n"
+        "      append fresh block).\n"
         "\n"
         "F-B2 has NOT written state.yml. Repo state remains pre-bootstrap.\n"
         "Re-run after fixing.\n"
     )
-    # Dummy reads to keep flake8 happy if any are unused
-    _ = present_marker, absent_marker
     sys.exit(5)
 
-if open_idx == -1 and close_idx == -1:
+if open_count == 0 and close_count == 0:
     # Append marker-wrapped block. Preserve everything before; tack
     # on a leading newline if the file doesn't already end with one.
     suffix = b""
@@ -624,7 +811,8 @@ if open_idx == -1 and close_idx == -1:
     print(block_hash)
     sys.exit(0)
 
-# Both markers present — replace bytes between them.
+# Both markers present (exactly one of each) — replace bytes between
+# them.
 if open_idx > close_idx:
     sys.stderr.write(
         "ERROR: F-B2 step 4 (routing block injection) cannot proceed.\n"

--- a/scripts/submit-pr.sh
+++ b/scripts/submit-pr.sh
@@ -106,7 +106,7 @@ trap 'rm -f "${TMP_BODY}"' EXIT
 cp "${BODY_FILE}" "${TMP_BODY}"
 {
     printf '\n\n---\n'
-    printf 'Closes #%s — board-superpowers v0.1.1 claim trailer.\n' "${CARD}"
+    printf 'Closes #%s — board-superpowers v0.2.0 claim trailer.\n' "${CARD}"
 } >> "${TMP_BODY}"
 
 # --- Open the PR ---------------------------------------------------------

--- a/skills/bootstrapping-repo/.skill-meta.yaml
+++ b/skills/bootstrapping-repo/.skill-meta.yaml
@@ -1,0 +1,8 @@
+# board-superpowers skill metadata (machine-readable, single source of truth).
+# Schema: SKILL_DEVELOPMENT.md § "board-superpowers metadata convention".
+# CI gate: scripts/verify-skill-metadata.sh.
+version: v0.2.0
+layer: molecular
+type: pattern
+mode: both
+bounded-context: bootstrap

--- a/skills/bootstrapping-repo/SKILL.md
+++ b/skills/bootstrapping-repo/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: bootstrapping-repo
+description: Use when board-superpowers is being run for the FIRST time on a (host, repo) pair — when the host manifest at ~/.board-superpowers/manifest.yml is absent, or the per-repo state at ~/.board-superpowers/repos/<normalized>/state.yml is absent. Triggers on the SessionStart hook injecting an `INVOKE: bootstrapping-repo` marker (fast path) AND on user phrases like "set up board-superpowers", "first time on this repo", "bootstrap this repo", "I just installed the plugin". Apply this skill even when the user does not say "bootstrap" — any session whose state probe reveals the manifest or per-repo state is missing routes here. Do NOT use this skill once both state files exist; the regular Producer / Consumer skills take over from there.
+when_to_use: Use when the SessionStart hook injected `INVOKE: bootstrapping-repo`, OR the user says "set up board-superpowers", "first time on this repo", "bootstrap this repo", "I just installed the plugin", "what do I need to do to start using this", OR the entry skill (using-board-superpowers) detects an absent manifest.yml / state.yml during its Layer 2 reliable-gate probe.
+---
+
+# bootstrapping-repo
+
+This is the molecular skill that drives **first-time setup** of board-superpowers on a `(host, repo)` pair. It orchestrates the two bootstrap features defined in [`docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md`](../../docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md):
+
+- **F-B1 (host bootstrap)** — once per host (machine). Writes `~/.board-superpowers/manifest.yml`.
+- **F-B2 (per-repo bootstrap)** — once per `(host, repo)` pair. Validates the GitHub Project, writes `<repo>/.board-superpowers/config.yml`, appends a `.gitignore` entry, sets up BYO-RDBMS audit credentials, injects the routing block into `CLAUDE.md` + `AGENTS.md`, and writes the host-local per-repo `state.yml`.
+
+The skill is a thin orchestration layer over two scripts: `scripts/bootstrap-host.sh` (F-B1) and `scripts/bootstrap-project.sh` (F-B2). Both scripts are idempotent — re-running this skill on an already-bootstrapped repo is a no-op.
+
+## When this skill fires
+
+Two paths deliver the architect into this skill:
+
+1. **Hook fast path**: `hooks/session-start.sh` detects `manifest.yml` or per-repo `state.yml` is absent and injects `INVOKE: bootstrapping-repo` + `REASON: <one-liner>` into the session via `additionalContext`. The entry skill `using-board-superpowers` consumes the marker and routes here.
+2. **Architect-spoken fallback**: the architect says "set up board-superpowers", "first time on this repo", "bootstrap this repo", or similar. The entry skill matches the phrase and routes here.
+
+Both paths arrive at the same procedure below. The hook is best-effort (CC `SessionStart` delivery is unreliable per the spec); the entry skill's Layer-2 state probe is the reliable gate. This skill itself does NOT re-probe — by the time control reaches here, the entry skill has confirmed at least one of the state files is missing.
+
+## Required atomic dependencies
+
+- `board-superpowers:board-canon` — read-only schema authority. Step 2's preflight relies on the canonical 6-status field contract documented there. (Not invoked as a skill at v1-minimum; the contract is a static reference.)
+
+The deferred atomic `auditing-actions` would normally consolidate the audit-log writes; in v1-minimum the inline jsonl writer below stands in.
+
+## Procedure
+
+The full sequence is four steps. Each step is independently idempotent and surfaces progress to the architect.
+
+### Step 1 — F-B1 host bootstrap
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-host.sh"
+```
+
+The script:
+
+1. Verifies `~/.board-superpowers/` exists with mode 0700 (creates it if absent).
+2. Writes `manifest.yml` with `schema_version: 1`, `host_bootstrapped_at: <iso8601>`, `last_seen_version: <plugin version>`. Atomic via `mktemp` + `mv`.
+3. If the manifest already exists with the same `last_seen_version`, exits 0 with no write (idempotent fast path).
+4. Prints the absolute manifest path to stdout on success.
+
+**Surface to the architect**: report whether the manifest was newly written, refreshed (version bump), or already current. On failure (exit code 1), surface the script's stderr and STOP — do not attempt step 2 with a broken host state.
+
+`--force` is available as an escape hatch (overwrites unconditionally) but should be reserved for migration / dev scenarios; the architect must explicitly request it.
+
+### Step 2 — preflight check for F-B2
+
+Before running F-B2 the architect must confirm two things:
+
+1. **GitHub Project v2 exists** with the canonical 6-option Status field — `Backlog → Ready → In Progress → In Review → Done → Blocked` (the order is load-bearing). Per ADR-0001's substrate-commitment posture, the script does NOT create the project — Project v2 single-select option creation via API is unreliable with standard tokens.
+
+   If the project does NOT exist yet, walk the architect through `references/project-creation-walkthrough.md` (UI steps), wait for them to confirm completion, then proceed.
+
+2. **`OWNER/PROJECT_NUMBER` resolved**. The architect provides this (e.g., `PanQiWei/4`). The script needs both to query the project and validate the Status field.
+
+R-class discipline applies here too — do NOT proceed to step 3 without the architect's explicit confirmation that the Status field is set up correctly. F-B2's Status validation will hard-abort if the field drifts; that abort is recoverable but expensive (architect fixes UI, re-runs).
+
+### Step 3 — F-B2 per-repo bootstrap
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-project.sh" \
+  --owner "${OWNER}" \
+  --project "${PROJECT_NUM}" \
+  --repo-root "${REPO_ROOT}"
+```
+
+`--repo-root` defaults to `${CLAUDE_PROJECT_DIR:-$PWD}` resolved via `git rev-parse --show-toplevel`. Pass it explicitly when the architect is operating from a worktree to guarantee the correct primary-repo path is used.
+
+The script handles the five F-B2 sub-steps + step 4 (routing injection) + step 3 (state.yml write) internally:
+
+| F-B2 sub-step | What `bootstrap-project.sh` does |
+|---------------|----------------------------------|
+| 2a — labels | `setup-labels.sh` — creates the 9 standard labels (`type:feature`, `type:bug`, `type:chore`, `type:refactor`, `type:epic`, `size:XS`, `size:S`, `size:M`, `size:L`). Idempotent — pre-existing labels skipped. |
+| 2b — Status field validation | Reads the project's Status field via `gh project field-list`; aborts with exit 2 if the 6 options are missing or out of order. |
+| 2c — config.yml write | Renders `<repo>/.board-superpowers/config.yml` with `project: "OWNER/NUM"` and `wip_limit: 5`. Skipped when present unless `--force`. |
+| 2d — .gitignore append | Appends an idempotent block ignoring `.board-superpowers/claims/`. |
+| 2e — credentials.yml | Walks BYO-RDBMS DSN setup. Accepts the 6-scheme allowlist (`postgresql://`, `postgres://`, `mysql://`, `mysql+pymysql://`, `sqlite://`, `sqlite3://` per ADR-0009). Architect can decline → all A-class actions degrade to R-class until they reconfigure. |
+| step 4 — routing injection | Appends the canonical routing block to BOTH `CLAUDE.md` and `AGENTS.md` between the marker pair `<!-- board-superpowers:routing -->` / `<!-- /board-superpowers:routing -->`. Records each block's SHA256 hash for F-B4 tamper detection. |
+| step 3 — state.yml write | Writes `~/.board-superpowers/repos/<normalized>/state.yml` with `schema_version: 1`, `repo_bootstrapped_at`, `last_seen_version_in_repo`, `features_enabled: [bootstrap.host, bootstrap.per_repo]`, and the `routing_blocks[]` array recorded during step 4. |
+
+**Surface to the architect** after each F-B2 sub-step completes:
+
+- Number of labels created / skipped at 2a.
+- Status field validation result at 2b (PASS / drift detected — print the specific mismatched options).
+- File path of `config.yml` at 2c.
+- Lines appended to `.gitignore` at 2d (or "already present" on idempotent skip).
+- BYO-RDBMS scheme accepted (or declined with degradation notice) at 2e.
+- Files routing-injected at step 4 (CLAUDE.md / AGENTS.md / both / neither).
+- Final state.yml absolute path at step 3.
+
+On exit codes 2 / 3 / 4 / 5, surface the script's stderr verbatim and STOP — F-B2 has surface-specific failure paths (Status drift, label delegation, BYO-RDBMS misconfiguration, orphan routing markers) and the script's error message names the recovery path.
+
+### Step 4 — deliver the first-time user guide
+
+After F-B2 completes successfully, hand the architect the post-bootstrap orientation. Load the content from `references/first-time-user-guide.md` and present it. The guide covers:
+
+- How to create the first card (Manager session via `managing-board` intake routine, or hand-pasted in the GitHub UI using the `board-canon` Card body schema).
+- How to claim a card (`[board-card:#N]` token in a fresh session).
+- Where state files live (host manifest, per-repo state, in-repo config, gitignored claims).
+- Two-role mental model — when to invoke `managing-board` vs `consuming-card`.
+
+The introduction in `references/intro.md` covers conceptual onboarding (what this plugin is, the cross-plugin composition with `superpowers` + `gstack`, common first-time questions). Surface it inline if the architect asks "what does this thing actually do" during step 4 — otherwise treat it as on-demand reading.
+
+## How mutating actions are handled (v1-minimum R-class default)
+
+Every mutating action this skill orchestrates follows the propose → ack → act → audit discipline. F-B1's manifest write is borderline (D-AUTONOMY-1 classifies it A — trivial first-run setup), but at v1-minimum every step is treated R-class and audit-logged. When `classifying-actions` ships, the matrix below moves into that atomic and this section gets a single-line cross-reference.
+
+```
+For each mutating action:
+  1. Propose the action to the architect with a one-line description.
+  2. Wait for explicit acknowledgement.
+  3. Act (run the script / write the file).
+  4. Append an audit-log entry via bsp_audit_local_write
+     (defined in scripts/lib/common.sh).
+```
+
+Some actions may be classified auto-act-OK by per-repo or per-user `autonomy_overrides:` in `.board-superpowers/config.yml`; until those overrides are configured, treat every action as requiring acknowledgement.
+
+### Action ID catalog (inlined, deferred replacement by `classifying-actions`)
+
+```
+Bootstrap actions:
+  bootstrap-host          — F-B1 manifest write (mode 0644, ts + version)
+  bootstrap-project-2a    — labels create (delegates to setup-labels.sh)
+  bootstrap-project-2b    — Status field validation (read-only; no audit)
+  bootstrap-project-2c    — config.yml write (project + wip_limit)
+  bootstrap-project-2d    — .gitignore append (idempotent block)
+  bootstrap-project-2e    — credentials.yml write (chmod 0600; DSN allowlist)
+  bootstrap-project-4     — routing block injection (CLAUDE.md + AGENTS.md)
+  bootstrap-project-3     — state.yml write (host-local per-repo)
+```
+
+All R-class in v1-minimum-degraded mode. The action_id values land in the formal D-AUTONOMY-1 catalog when `classifying-actions` ships.
+
+### Audit log entry
+
+Each acted-on action appends one jsonl line to `~/.board-superpowers/repos/<normalized>/audit-local.jsonl` via `bsp_audit_local_write` from `scripts/lib/common.sh`:
+
+```bash
+bsp_audit_local_write "${REPO_ROOT}" "<action_id>" R bootstrapping-repo "<one-line summary>"
+```
+
+This is the v1-minimum-degraded interim trace per the [`SKILLS.md`](../../SKILLS.md) v1-minimum degradation note for `auditing-actions`. The full BYO-RDBMS schema lands when `auditing-actions` ships — at that point this inline write becomes a single-line call to the atomic.
+
+## Idempotency invariants
+
+- **Re-running this skill on an already-bootstrapped repo is a no-op.** F-B1 detects an existing manifest with the current version and skips the write. F-B2 detects an existing `state.yml` and skips the per-repo work entirely (per the spec § 1.5.2 trigger condition). The architect can re-invoke this skill safely; nothing is mutated when nothing needs to change.
+- **`--force` is the escape hatch.** Both scripts accept `--force` to overwrite unconditionally. Only use this on explicit architect request — typical scenarios are recovering from a partial bootstrap, dev-loop schema work, or migrating a corrupted manifest.
+- **F-B1's idempotency fast path is the version-equal check**, not a "does the file exist" check. A version bump after a plugin upgrade triggers a manifest refresh on next session — that's the F-B3 path (deferred to `migrating-repo-version`), but the host-side write itself is the same atomic mv used here.
+
+## Failure paths (brief)
+
+| Where | Symptom | Recovery |
+|-------|---------|---------|
+| F-B1 | exit 1 — bad plugin root, mkdir failure, write failure | Surface the script's stderr; do NOT attempt F-B2; ask the architect to inspect filesystem permissions or `${CLAUDE_PLUGIN_ROOT}` wiring. |
+| F-B2 step 2b | exit 2 — Status field options missing or out of order | Surface the named mismatched options; tell the architect to fix in the GitHub Project UI; re-run this skill after they confirm. |
+| F-B2 step 2a | exit 3 — `setup-labels.sh` delegation failed | Usually a token-scope issue (`gh auth status` to verify). After fix, re-run. |
+| F-B2 step 2e | exit 4 — BYO-RDBMS DSN invalid (bad scheme; sqlite parent unwritable; interactive retry budget exhausted) | Surface the specific error from the script; offer two paths — fix the DSN or decline BYO-RDBMS (sets degraded R-class default). |
+| F-B2 step 4 | exit 5 — orphan routing markers (only one of `<!-- board-superpowers:routing -->` / `<!-- /board-superpowers:routing -->` present in the target file) | Surface the script's verbatim error; abort. The architect inspects `CLAUDE.md` / `AGENTS.md`, removes the orphaned marker, then re-runs. Do NOT auto-repair — the architect's intent is unknown. |
+
+In every failure path, leave the pre-bootstrap state intact: the scripts use atomic write semantics so a half-completed F-B2 does not leave a half-written `state.yml` claiming bootstrap completed.
+
+## Anti-pattern: bootstrapping without consent
+
+This skill MUST NOT run F-B2 silently. The first interaction with a fresh repo is the architect's introduction to the plugin — the routing block injection alone modifies two files (`CLAUDE.md`, `AGENTS.md`) the architect has been editing by hand. Auto-mutating those files without consent burns trust in a way that's hard to recover from.
+
+Always:
+
+1. Surface the F-B1 result (manifest written / refreshed) before asking about F-B2.
+2. Confirm `OWNER/PROJECT_NUMBER` and the GitHub Project's Status field state before invoking F-B2.
+3. Surface each F-B2 sub-step's outcome as it completes — do NOT batch-report at the end.
+
+If the architect declines BYO-RDBMS at step 2e, the bootstrap completes and the friction is captured (every A-class action becomes R-class until they reconfigure). That trade-off is documented per ADR-0006's "trade-off explicitly registered" note — surface it once at decline time, do NOT nag on every subsequent session.
+
+## Cross-platform notes
+
+This skill works on both Claude Code and Codex CLI. Both `bootstrap-host.sh` and `bootstrap-project.sh` resolve their plugin root via `bsp_plugin_root` (Claude uses `${CLAUDE_PLUGIN_ROOT}`, Codex uses path-derivation) so the architect's invocation works without platform-specific argument shaping.
+
+Routing block injection is dual-target by design — `CLAUDE.md` (for Claude Code's auto-load) and `AGENTS.md` (for Codex CLI's auto-load) both receive the same content, which is why the architect's session lands cleanly regardless of which platform they next open in this repo.

--- a/skills/bootstrapping-repo/references/changelog/v0.2.0.md
+++ b/skills/bootstrapping-repo/references/changelog/v0.2.0.md
@@ -1,0 +1,78 @@
+# changelog — board-superpowers v0.2.0
+
+This changelog file is consumed by F-B3 (host version transition) and F-B4 (per-repo version transition) — both of those features are deferred to the `migrating-repo-version` skill (v1-complete). At v0.2.0, this file primarily documents what bootstrapping-repo has just configured and what to expect on subsequent versions.
+
+The file follows the F-B3 / F-B4 contract per the spec § 1.5.3 / § 1.5.4: three sections — "what's new for the host", "what's new that affects every repo", "what to expect when you next visit your existing repos" — plus a breaking-changes section. The sections stay short by design (highlights only; the full release notes are link-fetchable from `https://github.com/PanQiWei/board-superpowers/releases/tag/v0.2.0`).
+
+## What's new for the host
+
+v0.2.0 is the first version that creates a host manifest. Prior to v0.2.0 there was no `~/.board-superpowers/manifest.yml` — the plugin ran statelessly across sessions. F-B1 now writes the manifest on the first session each architect opens after upgrading to v0.2.0:
+
+- `schema_version: 1` — pins the manifest schema for future migrations.
+- `host_bootstrapped_at: <iso8601>` — when this host first ran F-B1.
+- `last_seen_version: 0.2.0` — used by F-B3 to detect future upgrades.
+
+The manifest lives at mode 0644 in a directory at mode 0700. The conservative directory permission is defense-in-depth; nothing secret lives there yet, but the BYO-RDBMS `credentials.yml` (chmod 0600, mode 0600) does land in the same directory if you opt into the audit log.
+
+## What's new that affects every repo
+
+F-B2 (per-repo bootstrap) writes / updates the following on first visit to each repo on each host:
+
+1. **9 standard labels** on the GitHub repo: `type:feature`, `type:bug`, `type:chore`, `type:refactor`, `type:epic`, `size:XS`, `size:S`, `size:M`, `size:L`. Pre-existing labels with the same name are skipped (idempotent).
+2. **Status field validation** on the GitHub Project — verifies the canonical 6 options exist in the right order: `Backlog → Ready → In Progress → In Review → Done → Blocked`. Aborts with exit 2 if drift detected; the architect fixes the UI and re-invokes.
+3. **`<repo>/.board-superpowers/config.yml`** — committed, hand-editable. Contains `project: "OWNER/NUMBER"` and `wip_limit: <N>`.
+4. **`.gitignore` block** — appended idempotently:
+   ```
+   # board-superpowers local state (claim markers are per-session)
+   .board-superpowers/claims/
+   ```
+   Note the narrow scope — only `claims/` is gitignored (per-session forensic state). `config.yml` is intentionally tracked. `state.yml` does not live in the repo at all (it is host-local).
+5. **BYO-RDBMS credential setup** — interactive at F-B2 step 2e. Allowlisted DSN schemes per ADR-0009: `postgresql://`, `postgres://`, `mysql://`, `mysql+pymysql://`, `sqlite://`, `sqlite3://`. Decline path is supported (sets degraded R-class default).
+6. **Routing block injection** into BOTH `CLAUDE.md` AND `AGENTS.md`, between the marker pair:
+   ```
+   <!-- board-superpowers:routing -->
+   ...
+   <!-- /board-superpowers:routing -->
+   ```
+   The block content is mirrored verbatim from `skills/using-board-superpowers/references/agentsmd-routing.md`. Each file's block content is hashed (SHA256) and the hash recorded in `state.yml` for tamper detection on future plugin upgrades.
+7. **`~/.board-superpowers/repos/<normalized>/state.yml`** — host-local per-repo state. Contains `schema_version`, `repo_bootstrapped_at`, `last_seen_version_in_repo: 0.2.0`, `features_enabled: [bootstrap.host, bootstrap.per_repo]`, and the per-file `routing_blocks[]` with SHA256 hashes.
+
+The routing block is what allows fresh CC / Codex sessions in the repo to find the right entry skill on session start. The `<!-- board-superpowers:routing -->` markers are the source-of-truth boundary — the plugin owns content between them, the architect owns content outside them.
+
+## What to expect on the next existing-repo visit
+
+v0.2.0 is the **first version that records routing-block hashes**, so prior repos (if any — there are none for v0.2.0 since this is the introduction of bootstrap) would not have hashes recorded. F-B4 (deferred to `migrating-repo-version` — v1-complete) handles the migration path: when it encounters a repo whose `state.yml:routing_blocks` is empty or missing the hash for a target file, it treats the file as "no markers, append" (not "modified, prompt") and re-injects safely.
+
+Specifically, F-B4 on a future v0.2.x → v0.3.x transition will:
+
+- Compare on-disk routing block content (between markers in `CLAUDE.md` / `AGENTS.md`) to the recorded hash in `state.yml:routing_blocks`.
+- **Match** → auto-update the block to the new source-of-truth, update the recorded hash.
+- **Mismatch** → present a 3-way prompt (replace / merge / leave alone) à la chezmoi or `dpkg conffile`.
+- **No prior hash recorded** → treat as plugin-pristine, auto-update, record the new hash.
+
+At v0.2.0 there is nothing to migrate from — this is the introduction of the manifest + state.yml + hash-recording mechanism.
+
+## Breaking changes
+
+**None.** v0.2.0 is the first version with bootstrap state. There is no prior version to break from.
+
+## Migration from v0.1.1
+
+Nothing required. v0.1.1 did not have host manifest or per-repo state files; v0.2.0 creates them on first session per the F-B1 + F-B2 procedures above. Architects upgrading from v0.1.1 will see F-B1 fire once per host, then F-B2 fire once per repo — exactly the same path a brand-new architect sees.
+
+If you had a v0.1.1 repo with a hand-injected routing block (say, copied from documentation), F-B2 step 4's marker detection will recognize the existing markers and refuse to inject a duplicate. Either:
+
+- Remove the existing markers and re-invoke this skill (clean slate).
+- Or accept the existing block as canonical (no re-injection happens).
+
+The first option is recommended if the existing block predates v0.2.0 — the source-of-truth content has been refined since the early-version documentation copies.
+
+## Where to find the full release notes
+
+The full GitHub release notes for v0.2.0 are at:
+
+```
+https://github.com/PanQiWei/board-superpowers/releases/tag/v0.2.0
+```
+
+Per the F-B3 spec § 1.5.5 "F-B3 changelog content" rationale, this file deliberately stays a highlights-and-pointer artifact rather than a full notes dump — full notes are skim-bait at this length and the architect can fetch them on demand.

--- a/skills/bootstrapping-repo/references/first-time-user-guide.md
+++ b/skills/bootstrapping-repo/references/first-time-user-guide.md
@@ -1,0 +1,138 @@
+# bootstrapping-repo — first-time user guide
+
+This is the "what now" content delivered immediately after F-B2 step 4 (state.yml write) completes. Surface it inline to the architect once F-B2 reports success. The guide is post-bootstrap orientation — it assumes the architect has just had F-B1 + F-B2 succeed and now needs to know what to do next.
+
+For pre-bootstrap conceptual orientation, see `references/intro.md`. For the GitHub Project UI walkthrough that has to happen BEFORE F-B2, see `references/project-creation-walkthrough.md`.
+
+## You are bootstrapped — what now
+
+Two paths for the first card on your board:
+
+### Path 1 — drive the first card via a Manager session (recommended)
+
+This is the path that gets you the most out of the plugin from day one. Open a fresh CC / Codex session in this repo and say something like:
+
+> "Let's intake this idea: <one-line description of the feature>"
+
+The router (`using-board-superpowers`) sees an intake-shaped phrase and routes to `managing-board` (intake routine). That skill walks you through the routing decision: is this a direction question (`gstack:/office-hours`), an architecture question (`gstack:/plan-eng-review`), a multi-step requirement (`superpowers:brainstorming`), or a single-card-sized piece of work (direct card creation)? After the appropriate sibling skill returns its artifact, the Manager session drafts cards and proposes them to you for `gh issue create`.
+
+### Path 2 — paste a card body in the GitHub UI
+
+If you already know what you want to build and just need a card on the board, open your Project on GitHub, click "Add item", and paste a card body following the `board-canon` Card body schema. The schema has 5 mandatory sections plus a thin pointer at the top:
+
+```
+**Spec**: <link or "(none)">
+**Owner**: <handle>
+**Estimate**: <XS|S|M|L>
+
+## Goal
+
+<one sentence>
+
+## Acceptance criteria
+
+- <verifiable bullet 1>
+- <verifiable bullet 2>
+
+## Out of scope
+
+- <bullet>
+
+## Dependencies
+
+- <none, or "depends-on: #<N>">
+
+## Notes
+
+<freeform>
+
+<!-- board-superpowers:card -->
+```
+
+The bottom marker `<!-- board-superpowers:card -->` is what the plugin uses to recognize a board-superpowers-shaped card vs a generic GitHub Issue. Cards without the marker are still readable but get treated as untracked-by-board.
+
+After pasting, set the card's Status field to `Backlog` (or `Ready` if it is genuinely ready to claim).
+
+## Claiming a card
+
+Once at least one card is in `Ready`, open a fresh session and use either:
+
+- **The literal token**: `[board-card:#N]` somewhere in your first message. Example: `let's do [board-card:#12]`.
+- **A natural phrase that names the card**: `claim card 12`, `work on card 12`, `let me take #12`, `let's pick up 12`.
+
+The router fires `consuming-card`. That skill:
+
+1. Reads the card body.
+2. Verifies the card is in `Ready` (not already claimed).
+3. Creates a git worktree at `$HOME/.config/superpowers/worktrees/<repo>/claim/<N>-<slug>` and a branch `claim/<N>-<slug>`.
+4. Flips the card's Status to `In Progress`.
+5. Walks you through TDD-driven implementation, the verification chain, and PR submission.
+
+Do NOT claim cards by hand — the worktree + branch + Status flip happens as a four-step transaction, and a partial claim leaves the board in an inconsistent state. Always go through `consuming-card`.
+
+## Where things live
+
+After bootstrap, four locations matter:
+
+| Path | Layer | Tracked in git? | What's in it |
+|------|-------|-----------------|--------------|
+| `~/.board-superpowers/manifest.yml` | Host | No (per machine) | `schema_version`, `host_bootstrapped_at`, `last_seen_version`. Plugin-managed. |
+| `~/.board-superpowers/repos/<normalized>/state.yml` | Repo (host-local) | No (per `(host, repo)`) | `schema_version`, `repo_bootstrapped_at`, `last_seen_version_in_repo`, `features_enabled`, `routing_blocks` (with SHA256 hashes). Plugin-managed. |
+| `~/.board-superpowers/credentials.yml` | Host | No (chmod 0600) | Optional `audit_db_url`. Only present if you accepted BYO-RDBMS at F-B2 step 2e. |
+| `<repo>/.board-superpowers/config.yml` | Repo | **Yes** | `project: "OWNER/NUMBER"`, `wip_limit`. Hand-editable. Team-shared. |
+| `<repo>/.board-superpowers/claims/` | Repo | No (gitignored) | Per-session claim markers. Forensic state, not configuration. |
+
+`<normalized>` is the repo's absolute path with leading `/` stripped and remaining `/` replaced by `-`. For `/Users/foo/proj` the normalized name is `Users-foo-proj`.
+
+## Routing block injected into CLAUDE.md and AGENTS.md
+
+F-B2 step 4 appended a routing block to both `CLAUDE.md` (for Claude Code's auto-load) and `AGENTS.md` (for Codex CLI's auto-load). The block sits between the marker pair:
+
+```
+<!-- board-superpowers:routing -->
+...routing instructions for sessions in this repo...
+<!-- /board-superpowers:routing -->
+```
+
+The block content is plugin-owned within the marker pair, user-owned outside. The plugin records a SHA256 hash of the injected content in `state.yml`; on the next plugin upgrade, F-B4 (deferred to `migrating-repo-version`) compares the on-disk block to the recorded hash. Match → auto-update. Mismatch → ask you what to do (replace / merge / leave alone).
+
+Do not edit anything **between** the markers by hand — your edits will be overwritten by the next auto-update. If you need to customize the routing, edit content **outside** the markers (CLAUDE.md / AGENTS.md are otherwise yours).
+
+## When to invoke each skill
+
+This skill (`bootstrapping-repo`) does NOT fire again unless one of the state files goes missing. From here on:
+
+- "What should I work on" / "morning briefing" / "review the PRs" / "intake this feature" / "what's blocked" → `managing-board` (Producer routines).
+- `[board-card:#N]` / "claim card N" / "work on card N" → `consuming-card` (Consumer lifecycle).
+- "What does this plugin do" / "how does this work" → answered inline by `using-board-superpowers` from `references/first-time-user-guide.md` (note: that's the entry-skill's first-time guide, separate from this one).
+
+If you forget which skill drives which routine, the entry skill `using-board-superpowers` always re-routes — start a session with a vague phrase like "let's look at the board" and it asks rather than guessing.
+
+## Verifying the bootstrap
+
+Quick sanity checks you can run after F-B2 reports success:
+
+```bash
+# Host manifest exists.
+test -f ~/.board-superpowers/manifest.yml && echo "host OK"
+
+# Per-repo state exists (replace <normalized> with your repo path).
+ls ~/.board-superpowers/repos/
+
+# Project config in the repo is committed.
+cat .board-superpowers/config.yml
+
+# Routing block injected into CLAUDE.md.
+grep -A1 'board-superpowers:routing' CLAUDE.md | head -5
+
+# Dependency check passes (the same check that runs on every session start).
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh"
+```
+
+The `check-deps.sh` invocation should exit 0. If it exits 2, the routing block injection failed in some way; if it exits 3, a runtime command (`gh`, `python3`) is missing from PATH.
+
+## What about audit logging
+
+If you accepted BYO-RDBMS at F-B2 step 2e, every R-class mutating action writes a row to your audit DB once `auditing-actions` ships (deferred to v1-complete). At v0.2.0 the audit goes to a host-local jsonl trace file at `~/.board-superpowers/repos/<normalized>/audit-local.jsonl` — that's the v1-minimum-degraded interim trace, not your forever solution.
+
+If you declined BYO-RDBMS, the same jsonl trace is your audit log. Every A-class action that would normally auto-act becomes R-class (the agent asks you first). That's the documented friction-feature per ADR-0006 — chattier sessions, but no silent state mutation.

--- a/skills/bootstrapping-repo/references/intro.md
+++ b/skills/bootstrapping-repo/references/intro.md
@@ -1,0 +1,83 @@
+# bootstrapping-repo — introduction
+
+This is the conceptual onboarding for an architect who just ran `bootstrapping-repo` for the first time on this `(host, repo)` pair. Surface this content inline if the architect asks "what does this thing actually do" during or after F-B2 — otherwise treat it as on-demand reading.
+
+## What is board-superpowers?
+
+board-superpowers is a **scheduling layer** that sits on top of two sibling plugins:
+
+- **`superpowers`** — the coding-discipline library (`brainstorming`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`).
+- **`gstack`** — the production-quality bookends (`/office-hours`, `/plan-ceo-review`, `/plan-eng-review`, `/review`, `/qa`, `/cso`).
+
+board-superpowers does not reimplement what those plugins already do. It coordinates **when** they run, **what card** they target, and **who reviews** the result — using GitHub as the substrate. There is no server. The board lives on a GitHub Project, the work lives in a git worktree, the audit lives in your own RDBMS (or in a degraded local trace if you opt out).
+
+## The two-role mental model
+
+Every session in a board-superpowers repo plays one of two roles. The first thing you do in a new session is decide which:
+
+| Role | When | Skill that drives it |
+|------|------|----------------------|
+| **Producer / Manager** | You are orchestrating the board — daily briefing, intaking new ideas, reviewing open PRs, triaging blocked cards. You are NOT writing implementation code. | `managing-board` |
+| **Consumer / Implementer** | You are claiming and implementing ONE specific card from start to PR. You are NOT shaping the board. | `consuming-card` |
+
+The roles are intentionally separate. A Producer session that drifts into implementation makes the board the Producer's responsibility forever; a Consumer session that drifts into board orchestration burns context that should have been spent on the card.
+
+The router `using-board-superpowers` makes the role decision for you on session start — it reads the user's first message and either fires the bootstrap chain (you just did this), routes to `managing-board`, or routes to `consuming-card`. If the intent is ambiguous it asks rather than guessing.
+
+## Day-1 happy path
+
+Once F-B1 + F-B2 are both done, your first day with the plugin looks like this:
+
+1. **Bootstrap** (you just did this — F-B1 + F-B2 are complete).
+2. **First Manager session** — open a fresh CC / Codex session and say "let's intake this feature: <one-line idea>". The router fires `managing-board` (intake routine), which walks you through deciding whether the idea needs `gstack:/office-hours` (direction-setting), `gstack:/plan-eng-review` (architecture lock), `superpowers:brainstorming` (decomposition), or direct card creation.
+3. **Decompose into Ready cards** — the architect hand-decomposes the brainstorming output into small cards on the board, each with the canonical 5-section body schema (per `board-canon`).
+4. **First Consumer session** — open a fresh session, type `[board-card:#N]`, the router fires `consuming-card`. That skill creates a worktree, drives Red→Green→Refactor TDD via `superpowers:test-driven-development`, runs the verification chain (`superpowers:verification-before-completion`, `gstack:/review`, `superpowers:requesting-code-review`), and submits the PR with the three-section contract.
+5. **Review and merge** — the Producer (probably you) reviews the PR via `managing-board` (review-queue routine) and merges. The card auto-transitions to Done.
+
+The Producer / Consumer split lets you context-switch cleanly: Producer sessions track the bigger picture; Consumer sessions go deep on one card without the board's gravity tugging at your attention.
+
+## Frequently-asked first-time questions
+
+### Do I need a Postgres / MySQL DB just to use this?
+
+No. The BYO-RDBMS audit log is **opt-in** and supports SQLite (host-local) per ADR-0009. If you decline BYO-RDBMS at F-B2 step 2e entirely, every A-class action degrades to R-class — meaning the agent asks you to acknowledge every mutating action instead of acting autonomously. That is a usable mode (just chattier); reconsider RDBMS later if the prompts get tedious.
+
+### What if my GitHub Project does not have the 6 statuses yet?
+
+You need to create the Status field's options manually in the GitHub Project UI before F-B2 can succeed. Per ADR-0001, the bootstrap script does NOT create the project or its options — single-select option creation via the GraphQL API is unreliable with standard tokens, and we deliberately do not work around that. See `references/project-creation-walkthrough.md` for the UI steps. Once the field is set up correctly, re-invoke this skill — F-B1 detects the manifest already exists (idempotent fast path), and F-B2 picks up where step 2b previously aborted.
+
+### What does this plugin actually DO at runtime?
+
+Three things, in three different places:
+
+- **In your CC / Codex session**, two skills (`managing-board` for Producer, `consuming-card` for Consumer) drive the workflow with cross-plugin handoffs to `superpowers` and `gstack`.
+- **On GitHub**, the source of truth — your Project, your Issues (= cards), your branches (`claim/<N>-<slug>`), your PRs (with the three-section contract).
+- **On your machine**, two state files — `~/.board-superpowers/manifest.yml` (host-level, version tracking) and `~/.board-superpowers/repos/<normalized>/state.yml` (per-repo, host-local), plus the optional BYO-RDBMS audit log.
+
+Nothing runs as a daemon. Nothing watches your filesystem. The plugin's primitives all execute when the agent calls them inside a session.
+
+### Why two state files instead of one?
+
+Because the install is per-host (one plugin reachable from many sessions across many repos) but the workflow is per-repo (each project has its own board). Some events fire host-wide on plugin upgrade (changelog highlights — F-B3); other events fire per-repo on first-touch-after-upgrade (feature opt-in, routing-block re-injection — F-B4). The two-layer state machine is what lets those events fire correctly without double-firing or missing.
+
+The committed-vs-host-local split is also important: `config.yml` is committed (your team agrees on `OWNER/NUMBER` and the WIP cap), but `state.yml` is host-local (every architect's machine independently tracks its bootstrap state). This is invariant I-13 in the spec.
+
+### What if I screw up and want to start over?
+
+You can re-run this skill with the `--force` flag on either script:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-host.sh" --force
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-project.sh" \
+  --owner OWNER --project NUM --force
+```
+
+Both rewrite their state files unconditionally. The routing block injection is idempotent and recognizes its own marker pair, so it does not duplicate. To remove all bootstrap state for this repo entirely, delete `~/.board-superpowers/repos/<normalized>/` (host-local) and `<repo>/.board-superpowers/` (in-repo), then re-bootstrap.
+
+The `<normalized>` directory name is the repo's absolute path with leading `/` stripped and remaining `/` replaced by `-`. For `/Users/foo/proj` that is `Users-foo-proj`.
+
+## What this skill does NOT do
+
+- It does not migrate state across plugin versions. Once you upgrade past v0.2.0 to a newer version, the F-B3 / F-B4 transitions are handled by a separate skill (`migrating-repo-version`, deferred to v1-complete). At v0.2.0 there is nothing to migrate from.
+- It does not seed your board with cards. After bootstrap completes, your board is empty — the first card is your responsibility (use the Manager session intake routine).
+- It does not configure the BYO-RDBMS schema for you. F-B2 step 2e records your DSN in `credentials.yml`; the schema migration runs the first time `auditing-actions` writes to the DB (and `auditing-actions` itself is deferred to v1-complete).

--- a/skills/using-board-superpowers/SKILL.md
+++ b/skills/using-board-superpowers/SKILL.md
@@ -29,9 +29,11 @@ The hook is best-effort; this skill is the contract. Always run BOTH probes itse
    - `~/.board-superpowers/manifest.yml` — present or absent?
    - `~/.board-superpowers/repos/<normalized>/state.yml` — present or absent?
 
-   `<normalized>` is the repo's absolute path with leading `/` stripped and remaining `/` replaced by `-` (e.g. `/Users/foo/proj` → `Users-foo-proj`). Use `bsp_normalize_repo_path` from `scripts/lib/common.sh` if invoking helper bash; the hook duplicates the same rule inline (per the self-containment contract).
+   Resolve the repo root with `bsp_primary_repo_root "${PWD}"` from `scripts/lib/common.sh` — NEVER call `git rev-parse --show-toplevel` directly. From inside a `git worktree`, `--show-toplevel` returns the worktree path, which normalizes to a different `<normalized>` than the canonical primary repo. Probing under that path misses an already-written `state.yml` and falsely concludes the repo is unbootstrapped, which would make every worktree-launched session re-emit the bootstrap prompt. `bsp_primary_repo_root` uses `git rev-parse --git-common-dir` (which always points at the primary repo regardless of worktree vs primary), then takes `dirname` of that, then runs `pwd -P` to resolve symlinks. The same incantation is duplicated inline in `hooks/session-start.sh` as `primary_repo_root` (per the hook's self-containment contract) — keep the two in lockstep when changing the rule.
 
-   For worktrees consult `bsp_pick_worktree_dir` so the probe lands on the right repo root, not the worktree.
+   `<normalized>` is the resolved primary repo's absolute path with leading `/` stripped and remaining `/` replaced by `-` (e.g. `/Users/foo/proj` → `Users-foo-proj`). Use `bsp_normalize_repo_path` from `scripts/lib/common.sh` AFTER the primary-repo-root resolution.
+
+   For worktree-base path resolution (a different concern — where to PUT new worktrees, not where the primary repo IS) consult `bsp_pick_worktree_dir`. The two helpers do not interchange.
 
 ## Step 2 — consume `INVOKE: bootstrapping-repo` marker if present
 

--- a/skills/using-board-superpowers/SKILL.md
+++ b/skills/using-board-superpowers/SKILL.md
@@ -8,15 +8,61 @@ when_to_use: Use as a router when intent is ambiguous, when no other board-super
 
 This is the entry skill — first touch when a board-superpowers session starts. It routes; it does not perform real work itself.
 
-The skill handles three things, in this order:
+The skill operates in three steps. Steps 1-3 are the **Layer 2 reliable gate** of the bootstrap surface (the SessionStart hook is Layer 1, advisory). Per [`docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md`](../../docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md) § "three-layer alert + intent-injection strategy", Layer 2 always re-runs the same dep + state check Layer 1 ran, so routing works even when CC `SessionStart` delivery silently drops the hook output.
 
-1. **Verifies dependencies** are present (`bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh`, or the equivalent absolute path on Codex). If they fail, surface the dep-check output and stop — no point routing further work into a broken plugin.
+## Step 1 — re-run dep + state check (Layer 2 reliable gate)
 
-2. **Consumes any hook-injected intent marker** delivered as `additionalContext` from the SessionStart hook. Markers follow the format `INVOKE: <skill-name>` followed by `REASON: <one-line>`. The marker is a fast-path hint; if a marker arrives, route to the named skill directly and pass through the reason as orientation.
+The hook is best-effort; this skill is the contract. Always run BOTH probes itself, even if the hook fired correctly.
 
-3. **Routes the user's message** to the right downstream skill using the table below.
+1. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh --machine` (or the equivalent absolute path on Codex). Parse stdout — when non-empty, exactly three lines arrive:
+
+   ```
+   MISSING=<csv-or-empty>
+   ROUTING_INJECTED=<yes|no>
+   PROJECT=<absolute path>
+   ```
+
+   When stdout is empty, all is well — proceed to step 2. When stdout is non-empty, surface the dep / routing problem to the user before any further routing — a broken plugin can't run the routes anyway.
+
+2. Probe the host-local state files (paths per [`07-path-conventions.md`](../../docs/architecture/0005-contracts/07-path-conventions.md) "Per-host layout"):
+
+   - `~/.board-superpowers/manifest.yml` — present or absent?
+   - `~/.board-superpowers/repos/<normalized>/state.yml` — present or absent?
+
+   `<normalized>` is the repo's absolute path with leading `/` stripped and remaining `/` replaced by `-` (e.g. `/Users/foo/proj` → `Users-foo-proj`). Use `bsp_normalize_repo_path` from `scripts/lib/common.sh` if invoking helper bash; the hook duplicates the same rule inline (per the self-containment contract).
+
+   For worktrees consult `bsp_pick_worktree_dir` so the probe lands on the right repo root, not the worktree.
+
+## Step 2 — consume `INVOKE: bootstrapping-repo` marker if present
+
+Inspect the system-reminder / `additionalContext` content delivered with this turn for a marker shaped:
+
+```
+INVOKE: bootstrapping-repo
+REASON: <one-line explanation>
+```
+
+Marker grammar is pinned in [`02-hook-contracts.md`](../../docs/architecture/0005-contracts/02-hook-contracts.md) § "Intent-injection markers". Rules:
+
+- **Marker present, recognized skill name** — route immediately to the named skill. At v0.2.0 the only legal value is `bootstrapping-repo`. Pass through the REASON line as orientation context.
+- **Marker present, unknown skill name** — stop and surface "unrecognized hook intent marker — please file a bug" rather than guessing.
+- **Marker absent BUT step 1 found state files absent** — route the same way (do NOT depend on the hook firing). This is what makes Layer 2 the reliable gate.
+
+The marker is a fast-path optimization, not a correctness requirement. Same routing decision regardless of whether Layer 1 delivered the marker or not.
+
+## Step 3 — chain F-B1 → F-B2 when state files are absent
+
+When step 1's state probe reports a missing file (whether or not step 2 saw the marker), chain bootstrap:
+
+- **`~/.board-superpowers/manifest.yml` absent** — invoke `bash ${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap-host.sh` (F-B1). This writes the host manifest and is idempotent on re-run.
+- **Per-repo `state.yml` absent** — invoke the `bootstrapping-repo` skill, which drives F-B2 via `scripts/bootstrap-project.sh`. F-B2 collects `OWNER/NUMBER`, writes per-repo `config.yml` + host-local `state.yml`, and injects the routing block into `AGENTS.md` / `CLAUDE.md`.
+- **Both absent** — F-B1 first, then chain into F-B2.
+
+After bootstrap completes, continue with the routing table below for the user's actual request.
 
 ## Routing table
+
+The post-bootstrap routing — used after step 1 surfaces no problems and step 2/3 detect no pending bootstrap.
 
 | Signal in user message | Route to |
 |------------------------|---------|
@@ -27,7 +73,7 @@ The skill handles three things, in this order:
 | "new requirement" / "intake this idea" / "I have a feature" | `board-superpowers:managing-board` (intake routine) |
 | "what's blocked" / "triage the board" / "release stale claims" | `board-superpowers:managing-board` (triage routine) |
 | "what does this plugin do" / "how does this work" / "what's available" | Answer inline (informational query) — see `references/first-time-user-guide.md` |
-| "set up board-superpowers on this repo" / "first time on this repo" | Surface manual-setup walkthrough from `references/first-time-user-guide.md` |
+| "set up board-superpowers on this repo" / "first time on this repo" | Route to `bootstrapping-repo` skill (F-B2) |
 | Anything clearly board-related but not in the table | Ask the user to disambiguate — do NOT pick a default |
 
 ## Routing discipline
@@ -49,31 +95,11 @@ Some user messages sound board-related but actually belong to sibling plugins. D
 
 This entry skill exists to route board-scoped intent — not to be the universal entry point for all sessions in this repo.
 
-## Hook-injected intent markers
-
-The SessionStart hook (`hooks/session-start.sh`) emits `additionalContext` JSON with:
-
-- A status line confirming the plugin is loaded.
-- Any failed dep-check details with install hints.
-- A friendly note about manual setup if the per-repo `.board-superpowers/config.yml` is absent.
-
-When this skill triggers, check the most recent system-injected context for the dep-check output. If checks failed, surface that BEFORE attempting any routing — a broken plugin can't run the routes anyway.
-
-If a future plugin version starts injecting `INVOKE: <skill>` markers via the same `additionalContext` channel, the marker is a hint, not a contract — this skill remains free to override based on richer message context.
-
 ## Cross-platform notes
 
 This skill works on both Claude Code and Codex CLI. The routing logic uses only `name` + `description` frontmatter; downstream skills' Tier-2 fields (like the `argument-hint` on `consuming-card`) take effect after routing.
 
-On Codex CLI, the SessionStart hook is wired via `~/.codex/hooks.json` after running `bash scripts/register-codex-hooks.sh --install-user` once per Codex install. The dep-check output reaches this skill via the same `additionalContext` payload — no platform-specific code path needed.
-
-## Friendly intro for first-time invocations
-
-If this is the user's first time invoking the plugin (detection: `.board-superpowers/config.yml` does NOT exist in the current repo), prepend the response with a 3-sentence orientation:
-
-> board-superpowers is a board-driven scheduling layer on top of `superpowers` and `gstack`. It routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode and delegates real work — TDD, debugging, review, QA, security audit — to the sibling plugins. See `references/first-time-user-guide.md` for the per-repo setup walkthrough.
-
-Then proceed with routing.
+On Codex CLI, the SessionStart hook is wired via `~/.codex/hooks.json` after running `bash scripts/register-codex-hooks.sh --install-user` once per Codex install. The dep-check output and intent-injection marker reach this skill via the same `additionalContext` payload — no platform-specific code path needed.
 
 ## Anti-pattern: routing that becomes work
 

--- a/skills/using-board-superpowers/references/agentsmd-routing.md
+++ b/skills/using-board-superpowers/references/agentsmd-routing.md
@@ -13,23 +13,42 @@ matcher).
 `docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md`
 § 1.5.2 step 4 + `scripts/lib/common.sh:bsp_inject_routing_block`):
 
-1. The injection helper reads THIS file, normalizes the bytes — strip
-   UTF-8 BOM if present, replace CRLF / CR with LF — and treats the
-   normalized bytes as the routing block content.
-2. SHA256 over the post-normalization bytes (with a single trailing
-   newline trimmed) yields the recorded hash.
-3. The helper writes the block between the marker pair into AGENTS.md
-   and CLAUDE.md and records one entry per file —
+1. The injection helper reads THIS file and locates the fence
+   sentinels — `<!-- routing-block:start -->` and
+   `<!-- routing-block:end -->` — to extract ONLY the bytes between
+   them. The docstring header above the fence (this prose) is NOT
+   injected. Anything outside the fence is treated as
+   maintainer-facing notes.
+2. The extracted bytes are normalized — strip UTF-8 BOM if present,
+   replace CRLF / CR with LF, strip leading + trailing whitespace
+   newlines so the injected block is tight.
+3. SHA256 over the normalized fence-bounded bytes (with a single
+   trailing newline trimmed) yields the recorded hash.
+4. The helper writes the block between the target's marker pair
+   (`<!-- board-superpowers:routing -->` /
+   `<!-- /board-superpowers:routing -->`) into AGENTS.md and CLAUDE.md
+   and records one entry per file —
    `{target_file, block_hash: "sha256:<hex>", injected_at: <iso8601>}`
    — into `~/.board-superpowers/repos/<normalized>/state.yml`'s
    `routing_blocks:` list.
-4. F-B4 (deferred to the `migrating-repo-version` skill) consumes
+5. F-B4 (deferred to the `migrating-repo-version` skill) consumes
    `state.yml:routing_blocks[]` hashes for tamper detection at plugin
    upgrade time.
 
 LF-only line endings. No BOM. Final line of the block ends with a
 single LF.
 
+**Why the fence sentinels differ from the target marker pair.** The
+fence keywords (`routing-block:start` / `routing-block:end`) are
+distinct from the target file marker keywords
+(`board-superpowers:routing` / `/board-superpowers:routing`) so a
+naive `find()` for the target marker pair against the source file
+returns nothing. This guards against the helper accidentally treating
+this docstring as a target file. A sanity check inside the helper
+also rejects source content with literal target markers nested inside
+the fence.
+
+<!-- routing-block:start -->
 This project uses the `board-superpowers` plugin (v0.2.0).
 Any Claude Code session in this project plays one of two roles:
 
@@ -123,3 +142,22 @@ a release process.
   `superpowers:test-driven-development`. An adjacent planning
   skill's "start coding" suggestion does not excuse skipping
   Red → Green → Refactor.
+<!-- routing-block:end -->
+
+## Maintainer notes (NOT injected)
+
+Anything below the closing fence sentinel is for plugin maintainers
+only and stays in this file — the helper extracts strictly between
+the fence sentinels and discards everything outside.
+
+When updating the routing block content above, remember:
+
+- The fence sentinels (`<!-- routing-block:start -->` and
+  `<!-- routing-block:end -->`) must remain on lines by themselves.
+- Do NOT place a literal `<!-- board-superpowers:routing -->` or
+  `<!-- /board-superpowers:routing -->` between the fence sentinels —
+  the helper's sanity check rejects nested target markers.
+- The hash recorded in user repos' `state.yml:routing_blocks[]`
+  changes whenever the bytes between the fences change. F-B4 tamper
+  detection treats a hash mismatch as plausible user edit; document
+  the change in the v0.x release notes.

--- a/skills/using-board-superpowers/references/agentsmd-routing.md
+++ b/skills/using-board-superpowers/references/agentsmd-routing.md
@@ -1,0 +1,125 @@
+# board-superpowers routing block — source of truth
+
+This file holds the canonical bytes that `scripts/bootstrap-project.sh`
+step 4 injects into a consuming repo's AGENTS.md and CLAUDE.md,
+between the marker pair (the literal HTML-comment opening + closing
+sentinels are deliberately not shown verbatim in this header so that
+the helper's marker-scan does not match against them; see
+`skills/using-board-superpowers/SKILL.md` Step 1 for the verbatim
+form, and `scripts/lib/common.sh:bsp_inject_routing_block` for the
+matcher).
+
+**Injection contract** (per
+`docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md`
+§ 1.5.2 step 4 + `scripts/lib/common.sh:bsp_inject_routing_block`):
+
+1. The injection helper reads THIS file, normalizes the bytes — strip
+   UTF-8 BOM if present, replace CRLF / CR with LF — and treats the
+   normalized bytes as the routing block content.
+2. SHA256 over the post-normalization bytes (with a single trailing
+   newline trimmed) yields the recorded hash.
+3. The helper writes the block between the marker pair into AGENTS.md
+   and CLAUDE.md and records one entry per file —
+   `{target_file, block_hash: "sha256:<hex>", injected_at: <iso8601>}`
+   — into `~/.board-superpowers/repos/<normalized>/state.yml`'s
+   `routing_blocks:` list.
+4. F-B4 (deferred to the `migrating-repo-version` skill) consumes
+   `state.yml:routing_blocks[]` hashes for tamper detection at plugin
+   upgrade time.
+
+LF-only line endings. No BOM. Final line of the block ends with a
+single LF.
+
+This project uses the `board-superpowers` plugin (v0.2.0).
+Any Claude Code session in this project plays one of two roles:
+
+- **Board Consumer** — if the first message contains `[board-card:#N]`,
+  or the user asks to work on / claim / implement card N, invoke the
+  `consuming-card` skill immediately. That skill owns the full
+  lifecycle: claim → implement → PR → update board.
+- **Board Manager** — if the user asks about planning today's work,
+  reviewing the board, decomposing a requirement, triaging blocked
+  cards, or running a retro, invoke the `managing-board` skill.
+- When unsure, invoke `using-board-superpowers` first.
+
+board-superpowers depends on the `superpowers` and `gstack` plugins
+and will delegate design and execution work to them. Do not
+reimplement what they already do.
+
+### How to compose gstack and superpowers
+
+Both plugins are runtime dependencies of board-superpowers. They are
+complementary, not alternatives — route by phase of work, not by
+preference.
+
+**Division of labor**
+
+- **gstack owns the bookends.** Direction-setting before a card is
+  claimed (is this worth building, what's the right shape) and
+  delivery-side verification (code review, QA, security). CEO /
+  design / QA / security-officer viewpoints.
+- **superpowers owns the middle.** The coding-discipline loop:
+  `brainstorming` → `writing-plans` → `test-driven-development` →
+  `systematic-debugging` → `verification-before-completion` →
+  `requesting-code-review`. TDD is mandatory inside this loop.
+- **Conflict arbitration** follows `superpowers:using-superpowers`:
+  **user instructions > skill > default behavior.** A gstack skill's
+  "plan is ready, start coding" advice does not override superpowers'
+  TDD discipline unless the user explicitly says so in the current
+  conversation.
+
+**Typical flow — menu, not checklist**
+
+Pick skills that fit the card; do not run them all.
+
+Pre-card intake (Manager's Intake routine routes here before a card
+is created):
+
+1. `gstack:/office-hours` or `/plan-ceo-review` — is this worth
+   building.
+2. `gstack:/plan-eng-review` — lock the architecture.
+3. `superpowers:brainstorming` — sharpen requirements and design.
+4. `superpowers:writing-plans` — turn the output into an executable
+   plan.
+
+Implementation (inside a Consumer session):
+
+5. `superpowers:test-driven-development` drives Red → Green →
+   Refactor.
+6. Stuck? `superpowers:systematic-debugging`, or
+   `gstack:/investigate` for a second angle.
+7. Parallelizable subtasks:
+   `superpowers:dispatching-parallel-agents` or
+   `superpowers:subagent-driven-development`.
+
+Self-check and delivery (still inside the Consumer session, before
+opening the PR):
+
+8. `superpowers:verification-before-completion` — evidence-first; do
+   not claim "done" without it.
+9. `gstack:/review` — production-bug viewpoint.
+10. `superpowers:requesting-code-review` — independent
+    second-pair-of-eyes.
+11. `gstack:/qa <url>` — real-browser QA. Mandatory for any
+    UI-touching card.
+12. `gstack:/cso` — security / OWASP / STRIDE audit. superpowers has
+    no equivalent.
+
+Release, deploy, canary, and document-release skills
+(`gstack:/ship`, `/canary`, `/land-and-deploy`,
+`/document-release`) are project-specific. Enable them only if they
+match this repo's deployment shape; otherwise use whatever release
+flow the project already has. board-superpowers does not prescribe
+a release process.
+
+**Pitfalls**
+
+- **Skill-name collisions.** Two large libraries have overlapping
+  descriptions. Route by this block, not by letting the model guess
+  from skill descriptions.
+- **Browser tools — one source.** Always use `gstack:/browse`. Do
+  not mix with other browser tooling.
+- **TDD is not optional** inside
+  `superpowers:test-driven-development`. An adjacent planning
+  skill's "start coding" suggestion does not excuse skipping
+  Red → Green → Refactor.

--- a/tests/fixtures/session-start-v0.1.1.txt
+++ b/tests/fixtures/session-start-v0.1.1.txt
@@ -1,1 +1,0 @@
-{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.1.1 loaded."}}

--- a/tests/fixtures/session-start-v0.2.0-post-bootstrap.txt
+++ b/tests/fixtures/session-start-v0.2.0-post-bootstrap.txt
@@ -1,0 +1,1 @@
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.2.0 loaded."}}

--- a/tests/fixtures/session-start-v0.2.0-pre-bootstrap.txt
+++ b/tests/fixtures/session-start-v0.2.0-pre-bootstrap.txt
@@ -1,1 +1,1 @@
-{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.2.0 loaded.\n\nINVOKE: bootstrapping-repo\nREASON: ~/.board-superpowers/manifest.yml absent (host bootstrap pending)."}}
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.2.0 loaded.\n\nINVOKE: bootstrapping-repo\nREASON: host bootstrap pending; both manifest and per-repo state files are absent."}}

--- a/tests/fixtures/session-start-v0.2.0-pre-bootstrap.txt
+++ b/tests/fixtures/session-start-v0.2.0-pre-bootstrap.txt
@@ -1,0 +1,1 @@
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "board-superpowers v0.2.0 loaded.\n\nINVOKE: bootstrapping-repo\nREASON: ~/.board-superpowers/manifest.yml absent (host bootstrap pending)."}}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,39 @@
+# tests/integration/ — opt-in real-network tests
+
+This directory is the future home of board-superpowers tests that hit
+**real network resources**:
+
+- a real GitHub Project (requires `gh` auth + the maintainer's
+  `project` scope token);
+- a real BYO-RDBMS instance (requires Postgres / MySQL / SQLite
+  credentials).
+
+Tests under `tests/` (the parent directory) are **hermetic** — they
+stub `gh`, run inside `mktemp -d` HOME directories, and never reach the
+network. CI runners do not carry the secrets needed for the integration
+suite, so these tests must remain **opt-in**.
+
+## How to opt in
+
+Set `BSP_INTEGRATION=1` in the environment before running an
+integration test:
+
+```sh
+BSP_INTEGRATION=1 bash tests/integration/<name>.sh
+```
+
+Tests in this directory MUST gate their actual side-effecting work on
+the env var. Without it they should print a friendly skip message and
+exit 0.
+
+## Currently empty
+
+This card (Card 2 / `v0.2.0-bootstrap`) ships only the convention. No
+integration tests exist yet. Future cards add tests here when they need
+real-network coverage — for example, an end-to-end `bootstrap-project.sh`
+run against a maintainer-owned scratch GitHub Project, or a real
+Postgres-write smoke for `auditing-actions` once that skill ships.
+
+When you author the first integration test, copy the BSP_INTEGRATION
+gate from the canonical reference (will be added with the first real
+test) and update this README to point at it.

--- a/tests/test-bootstrap-end-to-end.sh
+++ b/tests/test-bootstrap-end-to-end.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# tests/test-bootstrap-end-to-end.sh — gold-standard hermetic smoke
+# wiring slices 1-6 outputs (F-B1 + F-B2 + rollback). Per Card 2
+# slice 7 + acceptance criterion §1 of the card body.
+#
+# What this test asserts:
+#   1. Tmp HOME + tmp git repo + stubbed gh with the canonical 6-option
+#      Status field.
+#   2. F-B1: bootstrap-host.sh writes ~/.board-superpowers/manifest.yml
+#      with the expected schema fields.
+#   3. F-B2 (steps 2a-2e + step 4 routing-block injection + initial
+#      state.yml write): bootstrap-project.sh + --audit-db-url for the
+#      BYO-RDBMS DSN. Asserts all 13+ files / state:
+#        - manifest.yml (from step 2)
+#        - <repo>/.board-superpowers/config.yml
+#        - <repo>/.gitignore (with bootstrap entry)
+#        - <repo>/AGENTS.md (with marker pair + injected block)
+#        - <repo>/CLAUDE.md (with marker pair + injected block)
+#        - ~/.board-superpowers/credentials.yml (chmod 0600)
+#        - ~/.board-superpowers/repos/<normalized>/state.yml with
+#          schema_version + repo_bootstrapped_at + last_seen_version_in_repo
+#          + features_enabled + routing_blocks (2 entries with
+#          sha256: prefixed hashes).
+#   4. Re-run idempotency: re-running bootstrap-project.sh on the
+#      same fixture is a no-op — file bytes for config.yml + state.yml
+#      unchanged.
+#   5. Rollback: bootstrap-rollback.sh --keep-credentials cleans every
+#      F-B2 side effect AND leaves manifest.yml + credentials.yml in
+#      place.
+#
+# Hermeticity: tmp dirs only; stubs gh via PATH. No real network. No
+# real ~/.board-superpowers contact.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BOOTSTRAP_HOST="${PLUGIN_ROOT_REAL}/scripts/bootstrap-host.sh"
+BOOTSTRAP_PROJECT="${PLUGIN_ROOT_REAL}/scripts/bootstrap-project.sh"
+BOOTSTRAP_ROLLBACK="${PLUGIN_ROOT_REAL}/scripts/bootstrap-rollback.sh"
+
+for script in "${BOOTSTRAP_HOST}" "${BOOTSTRAP_PROJECT}" "${BOOTSTRAP_ROLLBACK}"; do
+    if [ ! -f "${script}" ]; then
+        printf 'FATAL: %s not found\n' "${script}" >&2
+        exit 99
+    fi
+done
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+file_mode() {
+    local path="$1"
+    if stat -f '%A' "${path}" >/dev/null 2>&1; then
+        stat -f '%A' "${path}"
+    else
+        stat -c '%a' "${path}"
+    fi
+}
+
+make_stub_plugin_root() {
+    local version="$1"
+    local target_dir="$2"
+    mkdir -p "${target_dir}/.claude-plugin"
+    cat > "${target_dir}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+    mkdir -p "${target_dir}/scripts/lib"
+    cp "${PLUGIN_ROOT_REAL}/scripts/lib/common.sh" "${target_dir}/scripts/lib/common.sh"
+    cp "${PLUGIN_ROOT_REAL}/scripts/setup-labels.sh" "${target_dir}/scripts/setup-labels.sh"
+    cp "${BOOTSTRAP_HOST}"     "${target_dir}/scripts/bootstrap-host.sh"
+    cp "${BOOTSTRAP_PROJECT}"  "${target_dir}/scripts/bootstrap-project.sh"
+    cp "${BOOTSTRAP_ROLLBACK}" "${target_dir}/scripts/bootstrap-rollback.sh"
+    chmod +x "${target_dir}/scripts/setup-labels.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-host.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-rollback.sh"
+    mkdir -p "${target_dir}/skills/using-board-superpowers/references"
+    cp "${PLUGIN_ROOT_REAL}/skills/using-board-superpowers/references/agentsmd-routing.md" \
+       "${target_dir}/skills/using-board-superpowers/references/agentsmd-routing.md"
+}
+
+init_tmp_repo() {
+    local repo_root="$1"
+    local owner_name="$2"
+    mkdir -p "${repo_root}"
+    git -C "${repo_root}" init --quiet
+    git -C "${repo_root}" remote add origin "https://github.com/${owner_name}.git"
+    git -C "${repo_root}" config user.email "test@example.com"
+    git -C "${repo_root}" config user.name  "test"
+}
+
+stub_gh() {
+    local dir="$1"
+    cat > "${dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+LABELS_FILE="${STUB_DIR}/labels.json"
+STATUS_OPTS_FILE="${STUB_DIR}/status_opts"
+
+if [ ! -f "${LABELS_FILE}" ]; then
+    printf '[]\n' > "${LABELS_FILE}"
+fi
+
+case "${1:-}" in
+    label)
+        shift
+        case "${1:-}" in
+            list)
+                cat "${LABELS_FILE}"
+                exit 0
+                ;;
+            create)
+                shift
+                NAME="${1:?label create needs NAME}"
+                shift
+                python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+if not any(l['name'] == sys.argv[2] for l in data):
+    data.append({'name': sys.argv[2]})
+    with open(sys.argv[1], 'w') as f:
+        json.dump(data, f)
+" "${LABELS_FILE}" "${NAME}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    project)
+        shift
+        case "${1:-}" in
+            field-list)
+                python3 -c "
+import json, sys, os
+opts_path = sys.argv[1]
+options = []
+if os.path.exists(opts_path):
+    with open(opts_path) as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                options.append({'id': 'opt-' + line.replace(' ', '-').lower(),
+                                'name': line})
+fields = []
+if options:
+    fields.append({'id': 'fld-status', 'name': 'Status', 'options': options})
+print(json.dumps({'fields': fields}))
+" "${STATUS_OPTS_FILE}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+CANONICAL_STATUS="Backlog
+Ready
+In Progress
+In Review
+Done
+Blocked"
+
+normalized_state_dir() {
+    local home_dir="$1"
+    local repo_root="$2"
+    local canonical
+    canonical="$(cd "${repo_root}" && git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -z "${canonical}" ]; then
+        canonical="$(cd "${repo_root}" && pwd -P)"
+    fi
+    local stripped="${canonical#/}"
+    stripped="${stripped%/}"
+    local normalized="${stripped//\//-}"
+    printf '%s/.board-superpowers/repos/%s\n' "${home_dir}" "${normalized}"
+}
+
+# ---------------------------------------------------------------------------
+# Single-scenario gold-standard smoke
+# ---------------------------------------------------------------------------
+printf 'End-to-end smoke: F-B1 + F-B2 + idempotent re-run + rollback\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+SQLITE_DIR="${TMP}/dbdir"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}" "${SQLITE_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+DSN="sqlite:////${SQLITE_DIR#/}/audit.db"
+
+# --- F-B1 host bootstrap -------------------------------------------------
+set +e
+HOST_OUT="$(env -i HOME="${HOME_DIR}" PATH="${STUBS_DIR}:/usr/bin:/bin" \
+    bash "${PLUGIN_ROOT}/scripts/bootstrap-host.sh" \
+        --plugin-root "${PLUGIN_ROOT}" </dev/null 2>&1)"
+RC_HOST=$?
+set -e
+
+assert_eq 'F-B1: bootstrap-host.sh exit 0' '0' "${RC_HOST}"
+check 'F-B1: ~/.board-superpowers/manifest.yml present' \
+    test -f "${HOME_DIR}/.board-superpowers/manifest.yml"
+check 'F-B1: manifest.yml has schema_version: 1' \
+    grep -Eq '^schema_version:[[:space:]]*1$' \
+    "${HOME_DIR}/.board-superpowers/manifest.yml"
+check 'F-B1: manifest.yml has last_seen_version: "0.2.0"' \
+    grep -Eq '^last_seen_version:[[:space:]]*"0\.2\.0"$' \
+    "${HOME_DIR}/.board-superpowers/manifest.yml"
+check 'F-B1: manifest.yml has ISO 8601 host_bootstrapped_at' \
+    grep -Eq '^host_bootstrapped_at:[[:space:]]*"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' \
+    "${HOME_DIR}/.board-superpowers/manifest.yml"
+check 'F-B1: ~/.board-superpowers dir mode 0700' \
+    bash -c "[ \"\$(stat -f '%A' \"\$1\" 2>/dev/null || stat -c '%a' \"\$1\")\" = '700' ]" \
+    _ "${HOME_DIR}/.board-superpowers"
+
+: "${HOST_OUT:-}"
+
+# --- F-B2 per-repo bootstrap ---------------------------------------------
+set +e
+PROJ_OUT="$(env -i HOME="${HOME_DIR}" PATH="${STUBS_DIR}:/usr/bin:/bin" \
+    bash "${PLUGIN_ROOT}/scripts/bootstrap-project.sh" \
+        --plugin-root "${PLUGIN_ROOT}" \
+        --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+        --audit-db-url "${DSN}" </dev/null 2>&1)"
+RC_PROJ=$?
+set -e
+
+assert_eq 'F-B2: bootstrap-project.sh exit 0' '0' "${RC_PROJ}"
+
+# Per-repo writes:
+CONFIG_FILE="${REPO_ROOT}/.board-superpowers/config.yml"
+GITIGNORE="${REPO_ROOT}/.gitignore"
+AGENTS="${REPO_ROOT}/AGENTS.md"
+CLAUDE="${REPO_ROOT}/CLAUDE.md"
+CRED_FILE="${HOME_DIR}/.board-superpowers/credentials.yml"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+
+check 'F-B2: config.yml present' test -f "${CONFIG_FILE}"
+check 'F-B2: config.yml has project: "foo/1"' \
+    grep -Fq 'project: "foo/1"' "${CONFIG_FILE}"
+check 'F-B2: config.yml has wip_limit: 5' \
+    grep -Eq '^wip_limit:[[:space:]]*5$' "${CONFIG_FILE}"
+
+check 'F-B2: .gitignore present with bootstrap entry' \
+    grep -Fxq '.board-superpowers/claims/' "${GITIGNORE}"
+
+check 'F-B2: AGENTS.md present with both markers' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\" && grep -Fq '<!-- /board-superpowers:routing -->' \"\$1\"" \
+    _ "${AGENTS}"
+check 'F-B2: CLAUDE.md present with both markers' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\" && grep -Fq '<!-- /board-superpowers:routing -->' \"\$1\"" \
+    _ "${CLAUDE}"
+
+check 'F-B2: credentials.yml present (chmod 0600)' test -f "${CRED_FILE}"
+assert_eq 'F-B2: credentials.yml mode is 600' '600' "$(file_mode "${CRED_FILE}")"
+check 'F-B2: credentials.yml carries the DSN' \
+    bash -c "grep -Fq \"audit_db_url: \\\"\$1\\\"\" \"\$2\"" _ "${DSN}" "${CRED_FILE}"
+
+check 'F-B2: state.yml present' test -f "${STATE_FILE}"
+check 'F-B2: state.yml schema_version: 1' \
+    grep -Eq '^schema_version:[[:space:]]*1$' "${STATE_FILE}"
+check 'F-B2: state.yml last_seen_version_in_repo: "0.2.0"' \
+    grep -Eq '^last_seen_version_in_repo:[[:space:]]*"0\.2\.0"$' "${STATE_FILE}"
+check 'F-B2: state.yml has ISO 8601 repo_bootstrapped_at' \
+    grep -Eq '^repo_bootstrapped_at:[[:space:]]*"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "${STATE_FILE}"
+check 'F-B2: state.yml features_enabled lists bootstrap.host' \
+    grep -Fq -- '- bootstrap.host' "${STATE_FILE}"
+check 'F-B2: state.yml features_enabled lists bootstrap.per_repo' \
+    grep -Fq -- '- bootstrap.per_repo' "${STATE_FILE}"
+
+# routing_blocks list count.
+RB_COUNT="$(grep -c '^  - target_file:' "${STATE_FILE}" || true)"
+assert_eq 'F-B2: state.yml routing_blocks has 2 entries' '2' "${RB_COUNT}"
+check 'F-B2: state.yml mentions AGENTS.md target' \
+    bash -c "grep -Eq 'target_file:.*AGENTS\\.md' \"\$1\"" _ "${STATE_FILE}"
+check 'F-B2: state.yml mentions CLAUDE.md target' \
+    bash -c "grep -Eq 'target_file:.*CLAUDE\\.md' \"\$1\"" _ "${STATE_FILE}"
+check 'F-B2: every block_hash has sha256:<64-hex> shape' \
+    bash -c "grep -Eq 'block_hash:[[:space:]]*\"sha256:[0-9a-f]{64}\"' \"\$1\"" \
+    _ "${STATE_FILE}"
+
+: "${PROJ_OUT:-}"
+
+# --- Idempotent re-run ---------------------------------------------------
+SHA_CONFIG_BEFORE="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${CONFIG_FILE}")"
+SHA_STATE_BEFORE="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${STATE_FILE}")"
+SHA_AGENTS_BEFORE="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${AGENTS}")"
+SHA_CLAUDE_BEFORE="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${CLAUDE}")"
+
+set +e
+RERUN_OUT="$(env -i HOME="${HOME_DIR}" PATH="${STUBS_DIR}:/usr/bin:/bin" \
+    bash "${PLUGIN_ROOT}/scripts/bootstrap-project.sh" \
+        --plugin-root "${PLUGIN_ROOT}" \
+        --owner foo --project 1 --repo-root "${REPO_ROOT}" </dev/null 2>&1)"
+RC_RERUN=$?
+set -e
+
+assert_eq 're-run: bootstrap-project.sh exit 0' '0' "${RC_RERUN}"
+
+SHA_CONFIG_AFTER="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${CONFIG_FILE}")"
+SHA_STATE_AFTER="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${STATE_FILE}")"
+SHA_AGENTS_AFTER="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${AGENTS}")"
+SHA_CLAUDE_AFTER="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "${CLAUDE}")"
+
+assert_eq 're-run: config.yml byte-identical' \
+    "${SHA_CONFIG_BEFORE}" "${SHA_CONFIG_AFTER}"
+assert_eq 're-run: state.yml byte-identical (no rewrite when version matches)' \
+    "${SHA_STATE_BEFORE}" "${SHA_STATE_AFTER}"
+assert_eq 're-run: AGENTS.md byte-identical' \
+    "${SHA_AGENTS_BEFORE}" "${SHA_AGENTS_AFTER}"
+assert_eq 're-run: CLAUDE.md byte-identical' \
+    "${SHA_CLAUDE_BEFORE}" "${SHA_CLAUDE_AFTER}"
+
+: "${RERUN_OUT:-}"
+
+# --- Rollback ------------------------------------------------------------
+set +e
+ROLL_OUT="$(env -i HOME="${HOME_DIR}" PATH="${STUBS_DIR}:/usr/bin:/bin" \
+    bash "${PLUGIN_ROOT}/scripts/bootstrap-rollback.sh" \
+        --repo-root "${REPO_ROOT}" --keep-credentials </dev/null 2>&1)"
+RC_ROLL=$?
+set -e
+
+assert_eq 'rollback: bootstrap-rollback.sh exit 0' '0' "${RC_ROLL}"
+
+check_not 'rollback: config.yml gone' test -f "${CONFIG_FILE}"
+check_not 'rollback: state.yml gone'  test -f "${STATE_FILE}"
+check_not 'rollback: gitignore entry gone' \
+    grep -Fxq '.board-superpowers/claims/' "${GITIGNORE}"
+check_not 'rollback: AGENTS.md routing markers gone' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${AGENTS}"
+check_not 'rollback: CLAUDE.md routing markers gone' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${CLAUDE}"
+
+# Manifest preserved (F-B1 is independent).
+check 'rollback: manifest.yml preserved' \
+    test -f "${HOME_DIR}/.board-superpowers/manifest.yml"
+# --keep-credentials honored.
+check 'rollback: credentials.yml preserved (--keep-credentials)' \
+    test -f "${CRED_FILE}"
+
+: "${ROLL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n— TOTALS —\nPASS: %d\nFAIL: %d\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/tests/test-bootstrap-rollback.sh
+++ b/tests/test-bootstrap-rollback.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+# tests/test-bootstrap-rollback.sh — assert scripts/bootstrap-rollback.sh
+# undoes F-B2 in symmetric reverse order per Card 2 slice 7 + the A2
+# decision recorded in `docs/plans/bootstrap/card-2-bootstrap.md`.
+#
+# Symmetric reverse order (rollback):
+#   1. rm <repo>/.board-superpowers/config.yml (if present)
+#   2. remove the bootstrap entry from <repo>/.gitignore (if present,
+#      idempotent — leave the file even when it becomes empty)
+#   3. remove the routing block (between markers) from <repo>/AGENTS.md
+#      AND <repo>/CLAUDE.md (preserve everything outside markers)
+#   4. rm ~/.board-superpowers/repos/<normalized>/state.yml
+#   5. PROMPT before rm ~/.board-superpowers/credentials.yml — default
+#      = no. --keep-credentials skips prompt + keeps. --rm-credentials
+#      skips prompt + removes. --yes auto-confirms YES.
+#   6. Does NOT delete labels.
+#   7. Leaves F-B1 manifest.yml intact.
+#
+# Scenarios:
+#   1. Bootstrap → rollback flow: full F-B2, then rollback. Assert all
+#      F-B2 side effects undone (config.yml gone, .gitignore entry gone,
+#      routing blocks AGENTS+CLAUDE gone, state.yml gone).
+#   2. Manifest preserved: after rollback, manifest.yml still exists.
+#   3. Credentials preserved by default: --keep-credentials keeps
+#      credentials.yml.
+#   4. Credentials removed with --rm-credentials: explicit rm path.
+#   5. Idempotent: rollback on a clean repo (nothing to undo) is a
+#      no-op, no errors.
+#   6. Routing block removal preserves surrounding content: AGENTS.md
+#      with content before AND after the markers — assert non-marker
+#      content preserved verbatim post-rollback.
+#   7. Partial bootstrap rollback: if F-B2 aborted mid-way (e.g.,
+#      orphan markers), rollback should still clean what's there
+#      without erroring.
+#
+# Hermeticity: tmp HOME + tmp git repo + stub gh on PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_UNDER_TEST="${PLUGIN_ROOT_REAL}/scripts/bootstrap-rollback.sh"
+BOOTSTRAP_PROJECT="${PLUGIN_ROOT_REAL}/scripts/bootstrap-project.sh"
+
+if [ ! -f "${SCRIPT_UNDER_TEST}" ]; then
+    printf 'FATAL: %s not found\n' "${SCRIPT_UNDER_TEST}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Build a stub plugin tree so bootstrap-project.sh resolves cleanly.
+make_stub_plugin_root() {
+    local version="$1"
+    local target_dir="$2"
+    mkdir -p "${target_dir}/.claude-plugin"
+    cat > "${target_dir}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+    mkdir -p "${target_dir}/scripts/lib"
+    cp "${PLUGIN_ROOT_REAL}/scripts/lib/common.sh" \
+       "${target_dir}/scripts/lib/common.sh"
+    cp "${PLUGIN_ROOT_REAL}/scripts/setup-labels.sh" \
+       "${target_dir}/scripts/setup-labels.sh"
+    cp "${BOOTSTRAP_PROJECT}" \
+       "${target_dir}/scripts/bootstrap-project.sh"
+    cp "${SCRIPT_UNDER_TEST}" \
+       "${target_dir}/scripts/bootstrap-rollback.sh"
+    chmod +x "${target_dir}/scripts/setup-labels.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-rollback.sh"
+    mkdir -p "${target_dir}/skills/using-board-superpowers/references"
+    cp "${PLUGIN_ROOT_REAL}/skills/using-board-superpowers/references/agentsmd-routing.md" \
+       "${target_dir}/skills/using-board-superpowers/references/agentsmd-routing.md"
+}
+
+init_tmp_repo() {
+    local repo_root="$1"
+    local owner_name="$2"
+    mkdir -p "${repo_root}"
+    git -C "${repo_root}" init --quiet
+    git -C "${repo_root}" remote add origin "https://github.com/${owner_name}.git"
+    git -C "${repo_root}" config user.email "test@example.com"
+    git -C "${repo_root}" config user.name  "test"
+}
+
+stub_gh() {
+    local dir="$1"
+    cat > "${dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+LABELS_FILE="${STUB_DIR}/labels.json"
+STATUS_OPTS_FILE="${STUB_DIR}/status_opts"
+
+if [ ! -f "${LABELS_FILE}" ]; then
+    printf '[]\n' > "${LABELS_FILE}"
+fi
+
+case "${1:-}" in
+    label)
+        shift
+        case "${1:-}" in
+            list)
+                cat "${LABELS_FILE}"
+                exit 0
+                ;;
+            create)
+                shift
+                NAME="${1:?label create needs NAME}"
+                shift
+                python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+if not any(l['name'] == sys.argv[2] for l in data):
+    data.append({'name': sys.argv[2]})
+    with open(sys.argv[1], 'w') as f:
+        json.dump(data, f)
+" "${LABELS_FILE}" "${NAME}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    project)
+        shift
+        case "${1:-}" in
+            field-list)
+                python3 -c "
+import json, sys, os
+opts_path = sys.argv[1]
+options = []
+if os.path.exists(opts_path):
+    with open(opts_path) as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                options.append({'id': 'opt-' + line.replace(' ', '-').lower(),
+                                'name': line})
+fields = []
+if options:
+    fields.append({'id': 'fld-status', 'name': 'Status', 'options': options})
+print(json.dumps({'fields': fields}))
+" "${STATUS_OPTS_FILE}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+CANONICAL_STATUS="Backlog
+Ready
+In Progress
+In Review
+Done
+Blocked"
+
+# Run bootstrap-project.sh with stdin /dev/null (declines BYO-RDBMS) so
+# tests don't leave a credentials.yml unless the test explicitly creates
+# one.
+run_bootstrap() {
+    local home_dir="$1"; shift
+    local plugin_root="$1"; shift
+    local stubs_dir="$1"; shift
+    env -i HOME="${home_dir}" PATH="${stubs_dir}:/usr/bin:/bin" \
+        bash "${plugin_root}/scripts/bootstrap-project.sh" \
+            --plugin-root "${plugin_root}" \
+            "$@" </dev/null
+}
+
+run_rollback() {
+    local home_dir="$1"; shift
+    local plugin_root="$1"; shift
+    local stubs_dir="$1"; shift
+    env -i HOME="${home_dir}" PATH="${stubs_dir}:/usr/bin:/bin" \
+        bash "${plugin_root}/scripts/bootstrap-rollback.sh" "$@"
+}
+
+normalized_state_dir() {
+    local home_dir="$1"
+    local repo_root="$2"
+    local canonical
+    canonical="$(cd "${repo_root}" && git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -z "${canonical}" ]; then
+        canonical="$(cd "${repo_root}" && pwd -P)"
+    fi
+    local stripped="${canonical#/}"
+    stripped="${stripped%/}"
+    local normalized="${stripped//\//-}"
+    printf '%s/.board-superpowers/repos/%s\n' "${home_dir}" "${normalized}"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Full bootstrap → rollback flow
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: full bootstrap → rollback (default keeps credentials)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-create a manifest.yml so we can prove rollback leaves it intact
+# even though our flow runs F-B2 only.
+mkdir -p "${HOME_DIR}/.board-superpowers"
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+host_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version: "0.2.0"
+EOF
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+    >/dev/null 2>&1
+RC_BOOT=$?
+set -e
+assert_eq 's1: bootstrap exit 0' '0' "${RC_BOOT}"
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+CONFIG_FILE="${REPO_ROOT}/.board-superpowers/config.yml"
+GITIGNORE="${REPO_ROOT}/.gitignore"
+
+check 's1: pre-rollback state.yml exists'   test -f "${STATE_FILE}"
+check 's1: pre-rollback config.yml exists'  test -f "${CONFIG_FILE}"
+check 's1: pre-rollback gitignore has entry' \
+    grep -Fxq '.board-superpowers/claims/' "${GITIGNORE}"
+check 's1: pre-rollback AGENTS.md has marker' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/AGENTS.md"
+check 's1: pre-rollback CLAUDE.md has marker' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/CLAUDE.md"
+
+# Default rollback (no flag) when no credentials.yml exists ⇒ no prompt
+# fires, treats as no-op for credentials. Pipe /dev/null to stdin to
+# avoid hanging in case prompt logic triggers anyway.
+set +e
+ROLL_OUT="$(run_rollback "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --repo-root "${REPO_ROOT}" --keep-credentials </dev/null 2>&1)"
+RC_ROLL=$?
+set -e
+assert_eq 's1: rollback exit 0' '0' "${RC_ROLL}"
+
+check_not 's1: post-rollback state.yml gone'  test -f "${STATE_FILE}"
+check_not 's1: post-rollback config.yml gone' test -f "${CONFIG_FILE}"
+check_not 's1: post-rollback gitignore entry gone' \
+    grep -Fxq '.board-superpowers/claims/' "${GITIGNORE}"
+check_not 's1: post-rollback AGENTS.md routing marker gone' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/AGENTS.md"
+check_not 's1: post-rollback CLAUDE.md routing marker gone' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/CLAUDE.md"
+
+# Manifest preserved (Scenario 2 inline check).
+check 's1: manifest.yml preserved' \
+    test -f "${HOME_DIR}/.board-superpowers/manifest.yml"
+
+# ROLL_OUT exists for diagnostic value if a check fails.
+: "${ROLL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: --keep-credentials keeps credentials.yml
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: --keep-credentials keeps credentials.yml\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Bootstrap with --audit-db-url so credentials.yml is created.
+SQLITE_DB_DIR="${TMP}/dbdir"
+mkdir -p "${SQLITE_DB_DIR}"
+DSN="sqlite:////${SQLITE_DB_DIR#/}/audit.db"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+    --audit-db-url "${DSN}" >/dev/null 2>&1
+RC_BOOT=$?
+set -e
+assert_eq 's3: bootstrap exit 0' '0' "${RC_BOOT}"
+
+CRED_FILE="${HOME_DIR}/.board-superpowers/credentials.yml"
+check 's3: pre-rollback credentials.yml exists' test -f "${CRED_FILE}"
+
+set +e
+run_rollback "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --repo-root "${REPO_ROOT}" --keep-credentials </dev/null >/dev/null 2>&1
+RC_ROLL=$?
+set -e
+assert_eq 's3: rollback exit 0' '0' "${RC_ROLL}"
+
+check 's3: --keep-credentials keeps credentials.yml' test -f "${CRED_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: --rm-credentials removes credentials.yml
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: --rm-credentials removes credentials.yml\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+SQLITE_DB_DIR="${TMP}/dbdir"
+mkdir -p "${SQLITE_DB_DIR}"
+DSN="sqlite:////${SQLITE_DB_DIR#/}/audit.db"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+    --audit-db-url "${DSN}" >/dev/null 2>&1
+RC_BOOT=$?
+set -e
+assert_eq 's4: bootstrap exit 0' '0' "${RC_BOOT}"
+
+CRED_FILE="${HOME_DIR}/.board-superpowers/credentials.yml"
+check 's4: pre-rollback credentials.yml exists' test -f "${CRED_FILE}"
+
+set +e
+run_rollback "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --repo-root "${REPO_ROOT}" --rm-credentials </dev/null >/dev/null 2>&1
+RC_ROLL=$?
+set -e
+assert_eq 's4: rollback exit 0' '0' "${RC_ROLL}"
+
+check_not 's4: --rm-credentials removed credentials.yml' test -f "${CRED_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Idempotent on a clean repo (nothing to undo)
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: idempotent on a clean repo (no F-B2 ever ran)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+run_rollback "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --repo-root "${REPO_ROOT}" --keep-credentials </dev/null >/dev/null 2>&1
+RC_ROLL=$?
+set -e
+assert_eq 's5: rollback exit 0 on clean repo (idempotent)' '0' "${RC_ROLL}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Routing block removal preserves surrounding content
+# ---------------------------------------------------------------------------
+printf 'Scenario 6: routing block removal preserves surrounding content\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-seed AGENTS.md with content BEFORE and AFTER the future markers.
+cat > "${REPO_ROOT}/AGENTS.md" <<'EOF'
+# Pre-existing project AGENTS.md
+
+PRE_BLOCK_SENTINEL_LINE — must survive rollback.
+
+## Other section
+Some prose.
+
+POST_BLOCK_SENTINEL_LINE — must also survive rollback.
+EOF
+ORIG_AGENTS="$(cat "${REPO_ROOT}/AGENTS.md")"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+    >/dev/null 2>&1
+RC_BOOT=$?
+set -e
+assert_eq 's6: bootstrap exit 0' '0' "${RC_BOOT}"
+
+# After bootstrap the file has the marker block appended.
+check 's6: marker injected post-bootstrap' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/AGENTS.md"
+check 's6: pre-block sentinel still in file post-bootstrap' \
+    grep -Fq 'PRE_BLOCK_SENTINEL_LINE' "${REPO_ROOT}/AGENTS.md"
+
+set +e
+run_rollback "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --repo-root "${REPO_ROOT}" --keep-credentials </dev/null >/dev/null 2>&1
+RC_ROLL=$?
+set -e
+assert_eq 's6: rollback exit 0' '0' "${RC_ROLL}"
+
+check 's6: pre-block sentinel preserved post-rollback' \
+    grep -Fq 'PRE_BLOCK_SENTINEL_LINE' "${REPO_ROOT}/AGENTS.md"
+check 's6: post-block sentinel preserved post-rollback' \
+    grep -Fq 'POST_BLOCK_SENTINEL_LINE' "${REPO_ROOT}/AGENTS.md"
+check_not 's6: routing markers gone post-rollback' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/AGENTS.md"
+
+# Suppress unused-var warnings.
+: "${ORIG_AGENTS:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: Partial bootstrap rollback (orphan markers — clean what's there)
+# ---------------------------------------------------------------------------
+printf 'Scenario 7: partial bootstrap rollback (orphan markers OK)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+
+# Manually craft a half-bootstrapped repo:
+# - config.yml present (step 2c ran)
+# - .gitignore entry present (step 2d ran)
+# - AGENTS.md has ORPHAN opening marker only (step 4 aborted before
+#   matching close marker landed)
+# - state.yml NOT written (per F-B2 contract — pre-bootstrap state)
+mkdir -p "${REPO_ROOT}/.board-superpowers"
+cat > "${REPO_ROOT}/.board-superpowers/config.yml" <<EOF
+project: "foo/1"
+wip_limit: 5
+EOF
+cat > "${REPO_ROOT}/.gitignore" <<EOF
+# board-superpowers local state (claim markers are per-session)
+.board-superpowers/claims/
+EOF
+cat > "${REPO_ROOT}/AGENTS.md" <<'EOF'
+# Half-bootstrapped AGENTS.md
+
+PRE_LINE
+
+<!-- board-superpowers:routing -->
+Half-injected content with no closing marker.
+
+POST_LINE
+EOF
+# CLAUDE.md absent entirely.
+
+set +e
+ROLL_OUT="$(run_rollback "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --repo-root "${REPO_ROOT}" --keep-credentials </dev/null 2>&1)"
+RC_ROLL=$?
+set -e
+assert_eq 's7: rollback exit 0 on partial bootstrap' '0' "${RC_ROLL}"
+
+check_not 's7: config.yml gone'  test -f "${REPO_ROOT}/.board-superpowers/config.yml"
+check_not 's7: gitignore entry gone' \
+    grep -Fxq '.board-superpowers/claims/' "${REPO_ROOT}/.gitignore"
+# Pre-line + post-line preserved despite orphan-marker block scrubbed.
+check 's7: pre-line preserved' grep -Fq 'PRE_LINE' "${REPO_ROOT}/AGENTS.md"
+check 's7: post-line preserved' grep -Fq 'POST_LINE' "${REPO_ROOT}/AGENTS.md"
+# Diagnostic value if anything fails.
+: "${ROLL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n— TOTALS —\nPASS: %d\nFAIL: %d\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/tests/test-bootstrapping-repo-skill.sh
+++ b/tests/test-bootstrapping-repo-skill.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# tests/test-bootstrapping-repo-skill.sh — assert the
+# skills/bootstrapping-repo/ molecular skill ships with a complete,
+# spec-conformant set of files: SKILL.md frontmatter + body, the three
+# reference files (intro, first-time-user-guide, changelog/v0.2.0),
+# and a valid .skill-meta.yaml.
+#
+# This is a content / contract check on the skill directory (the SKILL
+# is consumed by the model at runtime — no executable to drive).
+# Pragmatic grep-based assertions cover the load-bearing claims.
+#
+# Spec under test:
+#   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+#     § 1.5.1 F-B1 + § 1.5.2 F-B2 (the orchestrated procedures)
+#   SKILL_DEVELOPMENT.md § "Three-tier frontmatter discipline"
+#     (no Tier 3 fields; Tier 1 + Tier 2 only)
+#   SKILLS.md § "bootstrapping-repo" catalog row
+#     (must mention the skill in a #### heading for verify-skill-metadata)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SKILL_DIR="${PLUGIN_ROOT_REAL}/skills/bootstrapping-repo"
+SKILL_FILE="${SKILL_DIR}/SKILL.md"
+META_FILE="${SKILL_DIR}/.skill-meta.yaml"
+INTRO_FILE="${SKILL_DIR}/references/intro.md"
+GUIDE_FILE="${SKILL_DIR}/references/first-time-user-guide.md"
+CHANGELOG_FILE="${SKILL_DIR}/references/changelog/v0.2.0.md"
+
+if [ ! -d "${SKILL_DIR}" ]; then
+    printf 'FATAL: %s not found\n' "${SKILL_DIR}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. File presence
+# ---------------------------------------------------------------------------
+printf 'File presence\n'
+
+check 'SKILL.md exists' \
+    test -f "${SKILL_FILE}"
+check '.skill-meta.yaml exists' \
+    test -f "${META_FILE}"
+check 'references/intro.md exists' \
+    test -f "${INTRO_FILE}"
+check 'references/first-time-user-guide.md exists' \
+    test -f "${GUIDE_FILE}"
+check 'references/changelog/v0.2.0.md exists' \
+    test -f "${CHANGELOG_FILE}"
+
+# Bail out early if SKILL.md or .skill-meta.yaml is missing — the
+# remaining checks would just produce noise.
+if [ ! -f "${SKILL_FILE}" ] || [ ! -f "${META_FILE}" ]; then
+    printf '\nResults: %d passed, %d failed (early bail — required files missing)\n' \
+        "${PASS}" "${FAIL}"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Frontmatter — Tier 1 portable subset (name + description) + Tier 2
+#    (when_to_use). NO Tier 3 fields.
+# ---------------------------------------------------------------------------
+printf 'Frontmatter discipline\n'
+
+check 'frontmatter has name: bootstrapping-repo' \
+    grep -qE '^name: bootstrapping-repo$' "${SKILL_FILE}"
+check 'frontmatter has description (Tier 1)' \
+    grep -qE '^description: ' "${SKILL_FILE}"
+check 'frontmatter has when_to_use (Tier 2)' \
+    grep -qE '^when_to_use: ' "${SKILL_FILE}"
+
+# Anti-pattern A4: NO Tier 3 fields. The CC spec set is in
+# verify-skill-frontmatter.sh; here we just assert the four most-common
+# project-metadata leaks are NOT in the frontmatter (they belong in
+# .skill-meta.yaml, not SKILL.md).
+check 'frontmatter does NOT contain version: (Tier 3 leak guard)' \
+    bash -c "! awk '/^---\$/{c++; next} c==1{print}' '${SKILL_FILE}' | grep -qE '^version:'"
+check 'frontmatter does NOT contain layer: (Tier 3 leak guard)' \
+    bash -c "! awk '/^---\$/{c++; next} c==1{print}' '${SKILL_FILE}' | grep -qE '^layer:'"
+check 'frontmatter does NOT contain type: (Tier 3 leak guard)' \
+    bash -c "! awk '/^---\$/{c++; next} c==1{print}' '${SKILL_FILE}' | grep -qE '^type:'"
+check 'frontmatter does NOT contain bounded-context: (Tier 3 leak guard)' \
+    bash -c "! awk '/^---\$/{c++; next} c==1{print}' '${SKILL_FILE}' | grep -qE '^bounded-context:'"
+
+# ---------------------------------------------------------------------------
+# 3. .skill-meta.yaml — five required fields with valid enum values.
+# ---------------------------------------------------------------------------
+printf '.skill-meta.yaml schema\n'
+
+check 'meta has version' \
+    grep -qE '^version: ' "${META_FILE}"
+check 'meta version is semver-shaped' \
+    grep -qE '^version: v?[0-9]+\.[0-9]+\.[0-9]+' "${META_FILE}"
+check 'meta has layer: molecular' \
+    grep -qE '^layer: molecular$' "${META_FILE}"
+check 'meta has type (one of pattern/technique/reference/discipline)' \
+    grep -qE '^type: (pattern|technique|reference|discipline)$' "${META_FILE}"
+check 'meta has mode: both' \
+    grep -qE '^mode: both$' "${META_FILE}"
+check 'meta has bounded-context: bootstrap' \
+    grep -qE '^bounded-context: bootstrap$' "${META_FILE}"
+
+# ---------------------------------------------------------------------------
+# 4. Body — load-bearing procedures (F-B1, F-B2, action ID catalog,
+#    R-class, audit log, idempotency).
+# ---------------------------------------------------------------------------
+printf 'Body — load-bearing procedures\n'
+
+check 'body mentions F-B1 (host bootstrap)' \
+    grep -qE 'F-B1' "${SKILL_FILE}"
+check 'body mentions F-B2 (per-repo bootstrap)' \
+    grep -qE 'F-B2' "${SKILL_FILE}"
+check 'body invokes bootstrap-host.sh script' \
+    grep -q 'bootstrap-host\.sh' "${SKILL_FILE}"
+check 'body invokes bootstrap-project.sh script' \
+    grep -q 'bootstrap-project\.sh' "${SKILL_FILE}"
+check 'body references the 5 F-B2 sub-steps (2a..2e)' \
+    grep -qE '2a.*labels|2b.*Status|2c.*config|2d.*\.gitignore|2e.*credential' "${SKILL_FILE}"
+check 'body references step 4 routing injection' \
+    grep -qE 'routing.*inject|step 4.*routing' "${SKILL_FILE}"
+check 'body mentions CLAUDE.md AND AGENTS.md as routing targets' \
+    bash -c "grep -q 'CLAUDE\\.md' '${SKILL_FILE}' && grep -q 'AGENTS\\.md' '${SKILL_FILE}'"
+check 'body mentions state.yml host-local path' \
+    grep -qE 'state\.yml' "${SKILL_FILE}"
+
+printf 'Body — action catalog\n'
+
+check 'body contains action ID catalog block' \
+    grep -qE 'Bootstrap actions:|action_id catalog|Action ID catalog' "${SKILL_FILE}"
+check 'catalog names bootstrap-host action' \
+    grep -q 'bootstrap-host' "${SKILL_FILE}"
+check 'catalog names bootstrap-project-2a..2e actions' \
+    bash -c "grep -q 'bootstrap-project-2a' '${SKILL_FILE}' && grep -q 'bootstrap-project-2e' '${SKILL_FILE}'"
+check 'catalog names bootstrap-project-4 routing action' \
+    grep -q 'bootstrap-project-4' "${SKILL_FILE}"
+
+printf 'Body — R-class default + audit log\n'
+
+check 'body declares v1-minimum R-class default' \
+    grep -qE 'R-class' "${SKILL_FILE}"
+check 'body describes propose -> ack -> act -> audit discipline' \
+    grep -qiE 'propose.*ack.*act|propose.*acknowledge|propose.*architect.*await' "${SKILL_FILE}"
+check 'body references bsp_audit_local_write helper' \
+    grep -q 'bsp_audit_local_write' "${SKILL_FILE}"
+check 'body references audit-local.jsonl interim trace' \
+    grep -q 'audit-local\.jsonl' "${SKILL_FILE}"
+
+printf 'Body — idempotency + failure paths\n'
+
+check 'body asserts re-running is a no-op on bootstrapped repo' \
+    grep -qiE 'idempot|no-op|already.*bootstrapped' "${SKILL_FILE}"
+check 'body documents --force escape hatch' \
+    grep -qE -- '--force' "${SKILL_FILE}"
+check 'body has a failure-paths section' \
+    grep -qiE '^## Failure paths|## Failure path' "${SKILL_FILE}"
+check 'body documents Status field drift recovery (exit 2)' \
+    grep -qE 'exit 2|Status.*drift' "${SKILL_FILE}"
+
+printf 'Body — anti-pattern guard\n'
+
+check 'body has anti-pattern: bootstrapping without consent' \
+    grep -qiE 'anti-pattern.*consent|without consent|never run.*silently|MUST NOT.*silent' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# 5. References — content sanity checks.
+# ---------------------------------------------------------------------------
+printf 'References — intro.md\n'
+
+check 'intro.md mentions two-role mental model' \
+    grep -qiE 'two-role|Producer.*Consumer|Manager.*Implementer' "${INTRO_FILE}"
+check 'intro.md mentions superpowers + gstack composition' \
+    bash -c "grep -q 'superpowers' '${INTRO_FILE}' && grep -q 'gstack' '${INTRO_FILE}'"
+check 'intro.md addresses BYO-RDBMS opt-out question' \
+    grep -qiE 'opt[- ]out|do I need.*postgres|byo-rdbms.*decline' "${INTRO_FILE}"
+
+printf 'References — first-time-user-guide.md\n'
+
+check 'guide.md mentions Manager session intake path' \
+    grep -qE 'managing-board|intake routine' "${GUIDE_FILE}"
+check 'guide.md mentions GitHub UI card-paste path' \
+    grep -qiE 'paste.*card|paste.*github|github UI.*card' "${GUIDE_FILE}"
+check 'guide.md documents [board-card:#N] claim trigger' \
+    grep -qE '\[board-card:#N\]' "${GUIDE_FILE}"
+check 'guide.md lists state file paths' \
+    bash -c "grep -q 'manifest\\.yml' '${GUIDE_FILE}' && grep -q 'state\\.yml' '${GUIDE_FILE}' && grep -q 'config\\.yml' '${GUIDE_FILE}'"
+
+printf 'References — changelog/v0.2.0.md\n'
+
+check "changelog has \"What's new for the host\" section" \
+    grep -qiE "What'?s new for the host" "${CHANGELOG_FILE}"
+check "changelog has \"What's new ... every repo\" section" \
+    grep -qiE "What'?s new.*every repo|affects every repo" "${CHANGELOG_FILE}"
+check 'changelog has breaking-changes section' \
+    grep -qiE 'Breaking changes' "${CHANGELOG_FILE}"
+check 'changelog mentions migration from v0.1.1' \
+    grep -qE 'v0\.1\.1|0\.1\.1' "${CHANGELOG_FILE}"
+check 'changelog references F-B4 hash-recording' \
+    grep -qE 'F-B4|hash.*record|block_hash' "${CHANGELOG_FILE}"
+
+# ---------------------------------------------------------------------------
+# 6. SKILLS.md catalog mention (required by verify-skill-metadata.sh).
+# ---------------------------------------------------------------------------
+printf 'SKILLS.md catalog\n'
+
+SKILLS_MD="${PLUGIN_ROOT_REAL}/SKILLS.md"
+# shellcheck disable=SC2016 # backticks are markdown literals here, not command substitution
+check 'SKILLS.md mentions bootstrapping-repo as a #### heading' \
+    grep -qE '^#### `bootstrapping-repo`' "${SKILLS_MD}"
+
+# ---------------------------------------------------------------------------
+# 7. Body length budget — molecular = 250-450 lines target. We let the
+#    actual body bracket the looser practiced range (~150-450) since
+#    other v1-minimum molecular skills (managing-board, consuming-card)
+#    landed under 250 too. Just guard against absurdly short / long.
+# ---------------------------------------------------------------------------
+printf 'Body length sanity\n'
+
+LINES="$(wc -l < "${SKILL_FILE}" | tr -d ' ')"
+check 'SKILL.md has at least 100 lines (molecular floor)' \
+    test "${LINES}" -ge 100
+check 'SKILL.md has at most 500 lines (molecular ceiling)' \
+    test "${LINES}" -le 500
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/test-entry-skill-marker-consumption.sh
+++ b/tests/test-entry-skill-marker-consumption.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# tests/test-entry-skill-marker-consumption.sh — assert
+# skills/using-board-superpowers/SKILL.md consumes the
+# INVOKE: bootstrapping-repo marker, references the F-B1 / F-B2
+# scripts and skill names, and preserves the post-bootstrap routing
+# table.
+#
+# This is a content / contract check on a Markdown file (the SKILL
+# is consumed by the model at runtime — no executable to drive).
+# Pragmatic grep-based assertions cover the load-bearing claims.
+#
+# Spec under test:
+#   docs/architecture/0005-contracts/02-hook-contracts.md § "Intent-injection markers"
+#     (Step 2 — entry skill consumes the marker)
+#   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+#     § "three-layer alert + intent-injection strategy" (Layer 2)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SKILL_FILE="${PLUGIN_ROOT_REAL}/skills/using-board-superpowers/SKILL.md"
+
+if [ ! -f "${SKILL_FILE}" ]; then
+    printf 'FATAL: %s not found\n' "${SKILL_FILE}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 contract: re-runs check-deps.sh in --machine mode and probes
+# the host + per-repo state files.
+# ---------------------------------------------------------------------------
+printf 'Step 1 — Layer 2 reliable gate references\n'
+
+check 'mentions check-deps.sh in --machine mode' \
+    grep -qE 'check-deps\.sh.*--machine' "${SKILL_FILE}"
+check 'mentions MISSING= key' \
+    grep -qE 'MISSING=' "${SKILL_FILE}"
+check 'mentions ROUTING_INJECTED= key' \
+    grep -qE 'ROUTING_INJECTED=' "${SKILL_FILE}"
+check 'mentions manifest.yml as a probed state file' \
+    grep -q 'manifest\.yml' "${SKILL_FILE}"
+check 'mentions per-repo state.yml as a probed state file' \
+    grep -q 'state\.yml' "${SKILL_FILE}"
+check 'mentions normalized path layout' \
+    grep -qE 'repos/<normalized>' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# Step 2 contract: consume INVOKE: bootstrapping-repo marker.
+# ---------------------------------------------------------------------------
+printf 'Step 2 — INVOKE marker consumption\n'
+
+check 'mentions INVOKE: marker grammar' \
+    grep -q 'INVOKE: bootstrapping-repo' "${SKILL_FILE}"
+check 'mentions REASON: line' \
+    grep -qE 'REASON:' "${SKILL_FILE}"
+check 'declares Layer 2 reliable-gate semantics (does not depend on hook)' \
+    grep -qiE 'reliable.*gate|reliability|do NOT depend on the hook|layer 2' "${SKILL_FILE}"
+check 'handles unrecognized skill name in marker' \
+    grep -qiE 'unrecognized.*hook intent|unknown skill' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# Step 3 contract: chain F-B1 → F-B2.
+# ---------------------------------------------------------------------------
+printf 'Step 3 — F-B1 / F-B2 chain references\n'
+
+check 'invokes bootstrap-host.sh for F-B1' \
+    grep -q 'bootstrap-host\.sh' "${SKILL_FILE}"
+check 'mentions bootstrapping-repo skill for F-B2' \
+    grep -q 'bootstrapping-repo' "${SKILL_FILE}"
+check 'mentions bootstrap-project.sh as F-B2 driver' \
+    grep -q 'bootstrap-project\.sh' "${SKILL_FILE}"
+check 'declares F-B1 → F-B2 chain order' \
+    grep -qiE 'F-B1.*F-B2|F-B1 first|chain.*F-B2|then chain' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# Post-bootstrap routing table preserved.
+# ---------------------------------------------------------------------------
+printf 'Post-bootstrap routing table preserved\n'
+
+check 'preserves [board-card:#N] routing to consuming-card' \
+    grep -qE '\[board-card:#N\].*consuming-card' "${SKILL_FILE}"
+check 'preserves "claim card" routing to consuming-card' \
+    grep -qE 'claim card N.*consuming-card' "${SKILL_FILE}"
+check 'preserves morning briefing → managing-board (daily)' \
+    grep -qE 'morning briefing.*managing-board' "${SKILL_FILE}"
+check 'preserves review-the-PRs → managing-board (review-queue)' \
+    grep -qE 'review the PRs.*managing-board' "${SKILL_FILE}"
+check 'preserves intake routing → managing-board' \
+    grep -qE 'new requirement.*managing-board|intake.*managing-board' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# Frontmatter contract — name + description + when_to_use unchanged
+# ---------------------------------------------------------------------------
+printf 'Frontmatter integrity\n'
+
+check 'frontmatter has name: using-board-superpowers' \
+    grep -qE '^name: using-board-superpowers$' "${SKILL_FILE}"
+check 'frontmatter has description' \
+    grep -qE '^description: ' "${SKILL_FILE}"
+check 'frontmatter mentions INVOKE marker via when_to_use' \
+    grep -qE '^when_to_use: .*INVOKE' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# Self-containment / anti-pattern guard
+# ---------------------------------------------------------------------------
+printf 'Anti-pattern guards\n'
+
+check 'preserves anti-pattern: routing that becomes work' \
+    grep -qiE 'routing that becomes work|MUST NOT do real work' "${SKILL_FILE}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/test-fb1-host-bootstrap.sh
+++ b/tests/test-fb1-host-bootstrap.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# tests/test-fb1-host-bootstrap.sh — assert scripts/bootstrap-host.sh
+# satisfies the F-B1 host bootstrap contract per
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § 1.5.1 and 07-path-conventions.md "Per-host layout".
+#
+# Contracts under test:
+#   - Cold start: writes ~/.board-superpowers/manifest.yml with
+#     schema_version: 1 + ISO-8601 host_bootstrapped_at + plugin version
+#     last_seen_version. Directory mode 0700; file mode 0644.
+#   - Idempotent re-run: same version, manifest already valid → no
+#     overwrite (mtime preserved), exit 0.
+#   - Version refresh: manifest exists with older last_seen_version →
+#     last_seen_version updated; host_bootstrapped_at preserved.
+#   - --force flag: overwrite even when manifest is already correct.
+#   - Bad --plugin-root: exit 1, helpful error.
+#   - Atomic write: half-written temp file never lingers; mv-failure
+#     leaves no .tmp file behind.
+#
+# Hermeticity: every scenario uses a fresh tmp HOME plus a fresh tmp
+# plugin-root containing a stub .claude-plugin/plugin.json. Nothing
+# touches the real ~/.board-superpowers.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_UNDER_TEST="${PLUGIN_ROOT_REAL}/scripts/bootstrap-host.sh"
+
+if [ ! -f "${SCRIPT_UNDER_TEST}" ]; then
+    printf 'FATAL: %s not found\n' "${SCRIPT_UNDER_TEST}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Make a stub plugin root containing only .claude-plugin/plugin.json
+# with the requested version. Returns the path on stdout.
+make_stub_plugin_root() {
+    local version="$1"
+    local target_dir="$2"
+    mkdir -p "${target_dir}/.claude-plugin"
+    cat > "${target_dir}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+}
+
+# Cross-platform "stat -c %a path" — macOS uses -f %A, GNU uses -c %a.
+file_mode() {
+    local path="$1"
+    if stat -f '%A' "${path}" >/dev/null 2>&1; then
+        stat -f '%A' "${path}"
+    else
+        stat -c '%a' "${path}"
+    fi
+}
+
+run_bootstrap() {
+    local home_dir="$1"; shift
+    local plugin_root="$1"; shift
+    HOME="${home_dir}" bash "${SCRIPT_UNDER_TEST}" --plugin-root "${plugin_root}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: cold start writes manifest with correct schema + perms
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: cold start (manifest absent)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+MANIFEST="${HOME_DIR}/.board-superpowers/manifest.yml"
+STATE_DIR="${HOME_DIR}/.board-superpowers"
+
+# Capture stdout — should print the manifest path on success.
+STDOUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" 2>/dev/null)"
+RC=$?
+
+assert_eq 'cold start exit 0' '0' "$(printf '%d' "${RC}")"
+check 'manifest file created' test -f "${MANIFEST}"
+assert_eq 'stdout is the manifest path' "${MANIFEST}" "${STDOUT}"
+
+# Permissions
+assert_eq 'state dir mode 0700' '700' "$(file_mode "${STATE_DIR}")"
+assert_eq 'manifest file mode 0644' '644' "$(file_mode "${MANIFEST}")"
+
+# Content shape
+check 'schema_version: 1 present' \
+    grep -Fxq 'schema_version: 1' "${MANIFEST}"
+check 'last_seen_version: "0.2.0" present' \
+    grep -Fxq 'last_seen_version: "0.2.0"' "${MANIFEST}"
+check 'host_bootstrapped_at present + ISO-8601 shape' \
+    grep -Eq '^host_bootstrapped_at: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "${MANIFEST}"
+
+# Atomic write: no leftover .tmp file
+check_not 'no leftover manifest.yml.tmp' test -f "${MANIFEST}.tmp"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: idempotent re-run (same version) — no overwrite
+# ---------------------------------------------------------------------------
+printf 'Scenario 2: idempotent re-run (same version)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+# First write
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" >/dev/null 2>&1
+
+MANIFEST="${HOME_DIR}/.board-superpowers/manifest.yml"
+
+# Capture mtime before re-run (use stat — portable form covered above).
+mtime_before() {
+    if stat -f '%m' "${MANIFEST}" >/dev/null 2>&1; then
+        stat -f '%m' "${MANIFEST}"
+    else
+        stat -c '%Y' "${MANIFEST}"
+    fi
+}
+BEFORE="$(mtime_before)"
+
+# Sleep 1.1s so any rewrite would change mtime (mtime resolution = 1s on
+# many filesystems). Necessary because Scenario 2 must DETECT a no-op.
+sleep 1.1
+
+# Re-run with same version
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+AFTER="$(mtime_before)"
+
+assert_eq 'idempotent re-run exit 0' '0' "${RC}"
+assert_eq 'manifest mtime unchanged (no overwrite)' "${BEFORE}" "${AFTER}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: version refresh — older last_seen_version, bump to current
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: version refresh (older last_seen_version)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+MANIFEST="${HOME_DIR}/.board-superpowers/manifest.yml"
+ORIGINAL_TS='2026-01-15T08:00:00Z'
+cat > "${MANIFEST}" <<EOF
+schema_version: 1
+host_bootstrapped_at: "${ORIGINAL_TS}"
+last_seen_version: "0.1.0"
+EOF
+chmod 0644 "${MANIFEST}"
+chmod 0700 "${HOME_DIR}/.board-superpowers"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'version refresh exit 0' '0' "${RC}"
+check 'last_seen_version updated to "0.2.0"' \
+    grep -Fxq 'last_seen_version: "0.2.0"' "${MANIFEST}"
+check_not 'old last_seen_version: "0.1.0" gone' \
+    grep -Fxq 'last_seen_version: "0.1.0"' "${MANIFEST}"
+check 'host_bootstrapped_at preserved (NOT overwritten)' \
+    grep -Fxq "host_bootstrapped_at: \"${ORIGINAL_TS}\"" "${MANIFEST}"
+
+# Atomic write: no leftover .tmp file after refresh
+check_not 'no leftover manifest.yml.tmp after refresh' test -f "${MANIFEST}.tmp"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: --force overwrites even when manifest is already correct
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: --force flag overwrites manifest\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+MANIFEST="${HOME_DIR}/.board-superpowers/manifest.yml"
+ORIGINAL_TS='2026-01-15T08:00:00Z'
+cat > "${MANIFEST}" <<EOF
+schema_version: 1
+host_bootstrapped_at: "${ORIGINAL_TS}"
+last_seen_version: "0.2.0"
+EOF
+chmod 0644 "${MANIFEST}"
+chmod 0700 "${HOME_DIR}/.board-superpowers"
+
+# Sleep so timestamps differ if --force regenerates
+sleep 1.1
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" --force >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq '--force exit 0' '0' "${RC}"
+check 'last_seen_version remains "0.2.0"' \
+    grep -Fxq 'last_seen_version: "0.2.0"' "${MANIFEST}"
+check_not 'host_bootstrapped_at was overwritten by --force' \
+    grep -Fxq "host_bootstrapped_at: \"${ORIGINAL_TS}\"" "${MANIFEST}"
+check 'host_bootstrapped_at retains ISO-8601 shape after --force' \
+    grep -Eq '^host_bootstrapped_at: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "${MANIFEST}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: bad --plugin-root → exit 1 with helpful error
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: bad --plugin-root path\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+mkdir -p "${HOME_DIR}"
+NONEXISTENT="${TMP}/no-such-plugin-root"
+
+set +e
+ERR_OUT="$(HOME="${HOME_DIR}" bash "${SCRIPT_UNDER_TEST}" --plugin-root "${NONEXISTENT}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'bad --plugin-root exit 1' '1' "${RC}"
+check 'stderr mentions plugin root or plugin.json problem' \
+    bash -c "printf '%s' \"\${1}\" | grep -Eqi 'plugin.?root|plugin\\.json'" _ "${ERR_OUT}"
+check_not 'no manifest written under bad plugin root' \
+    test -f "${HOME_DIR}/.board-superpowers/manifest.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: atomic write — mv failure leaves no half-written file
+# ---------------------------------------------------------------------------
+# Simulate by pre-creating the manifest path as a directory so mv fails.
+# (After --force the script tries to overwrite; mv into a directory will
+# error.) We assert: no .tmp file lingers; exit non-zero.
+printf 'Scenario 6: atomic write — mv failure leaves no .tmp\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+# Make the manifest path a DIRECTORY (not a file) so the atomic mv
+# encounters a non-overwritable target.
+mkdir -p "${HOME_DIR}/.board-superpowers/manifest.yml"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" --force >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'mv-failure exit 1' '1' "${RC}"
+check_not 'no leftover manifest.yml.tmp after mv failure' \
+    test -f "${HOME_DIR}/.board-superpowers/manifest.yml.tmp"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/test-fb1-host-bootstrap.sh
+++ b/tests/test-fb1-host-bootstrap.sh
@@ -14,8 +14,13 @@
 #     last_seen_version updated; host_bootstrapped_at preserved.
 #   - --force flag: overwrite even when manifest is already correct.
 #   - Bad --plugin-root: exit 1, helpful error.
-#   - Atomic write: half-written temp file never lingers; mv-failure
-#     leaves no .tmp file behind.
+#   - Defensive guard: target manifest path is unexpectedly a
+#     directory → exit 1, no .tmp file lingers.
+#   - Concurrent runs: two parallel invocations both succeed, exactly
+#     one manifest.yml exists, no .tmp leaks (proves per-process
+#     mktemp scratch files plus rename(2) atomicity).
+#   - YAML whitespace tolerance: `key : "value"` (extra space before
+#     colon) parses correctly during version-refresh detection.
 #
 # Hermeticity: every scenario uses a fresh tmp HOME plus a fresh tmp
 # plugin-root containing a stub .claude-plugin/plugin.json. Nothing
@@ -288,12 +293,19 @@ check_not 'no manifest written under bad plugin root' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
-# Scenario 6: atomic write — mv failure leaves no half-written file
+# Scenario 6: manifest path is unexpectedly a directory
 # ---------------------------------------------------------------------------
-# Simulate by pre-creating the manifest path as a directory so mv fails.
-# (After --force the script tries to overwrite; mv into a directory will
-# error.) We assert: no .tmp file lingers; exit non-zero.
-printf 'Scenario 6: atomic write — mv failure leaves no .tmp\n'
+# A bare `mv source dir/` succeeds on POSIX (moves source INTO dir),
+# which would silently land manifest.yml.tmp inside a directory named
+# manifest.yml and corrupt the layout. The script's defensive guard
+# (refuse-if-target-is-a-directory) must short-circuit before the mv
+# is attempted. We assert: exit 1, no scratch .tmp file leaks behind.
+#
+# (Honest naming: this scenario is NOT a generic mv-failure simulation
+# — true mv failures, e.g. read-only filesystem, are hard to fake
+# hermetically. This scenario locks in the dir-target gotcha guard,
+# which is the realistic failure mode.)
+printf 'Scenario 6: manifest path is unexpectedly a directory\n'
 
 TMP="$(mktemp -d)"
 HOME_DIR="${TMP}/home"
@@ -302,7 +314,7 @@ mkdir -p "${HOME_DIR}/.board-superpowers"
 make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
 
 # Make the manifest path a DIRECTORY (not a file) so the atomic mv
-# encounters a non-overwritable target.
+# would corrupt the layout if not guarded.
 mkdir -p "${HOME_DIR}/.board-superpowers/manifest.yml"
 
 set +e
@@ -310,9 +322,113 @@ run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" --force >/dev/null 2>&1
 RC=$?
 set -e
 
-assert_eq 'mv-failure exit 1' '1' "${RC}"
-check_not 'no leftover manifest.yml.tmp after mv failure' \
+assert_eq 'dir-target exit 1' '1' "${RC}"
+# Per-process mktemp scratch files use the pattern manifest.yml.tmp.<6>
+# (trailing-Xs constraint of BSD mktemp). Assert NONE exist, and ALSO
+# assert the legacy fixed-path manifest.yml.tmp does not leak.
+LEFTOVER_COUNT="$(find "${HOME_DIR}/.board-superpowers" \
+    -maxdepth 1 -name 'manifest.yml.tmp.*' 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq 'no leftover .tmp.* scratch files after dir-target guard' \
+    '0' "${LEFTOVER_COUNT}"
+check_not 'no legacy fixed-path manifest.yml.tmp leak' \
     test -f "${HOME_DIR}/.board-superpowers/manifest.yml.tmp"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: concurrent F-B1 invocations — both succeed, no .tmp leak
+# ---------------------------------------------------------------------------
+# Two CC sessions can hit first-run F-B1 on the same host at the same
+# time. Per-process mktemp scratch files mean neither writer races on
+# a shared scratch path; the final mv is rename(2)-atomic; both end up
+# with a valid manifest.yml (one overwrites the other; payload is
+# semantically equivalent). We assert: both exit 0, exactly one
+# manifest.yml exists at the end, no .tmp scratch files leak.
+printf 'Scenario 7: concurrent invocations (race-loser still clean)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+MANIFEST="${HOME_DIR}/.board-superpowers/manifest.yml"
+
+# Spawn two parallel invocations and wait. Each writes its own .tmp
+# via mktemp, then races on the rename(2). POSIX guarantees the
+# rename is atomic on a same-filesystem move, so one wins and the
+# other harmlessly overwrites with the same payload.
+set +e
+HOME="${HOME_DIR}" bash "${SCRIPT_UNDER_TEST}" \
+    --plugin-root "${PLUGIN_ROOT}" >/dev/null 2>&1 &
+PID_A=$!
+HOME="${HOME_DIR}" bash "${SCRIPT_UNDER_TEST}" \
+    --plugin-root "${PLUGIN_ROOT}" >/dev/null 2>&1 &
+PID_B=$!
+wait "${PID_A}"; RC_A=$?
+wait "${PID_B}"; RC_B=$?
+set -e
+
+assert_eq 'concurrent invocation A exit 0' '0' "${RC_A}"
+assert_eq 'concurrent invocation B exit 0' '0' "${RC_B}"
+
+MANIFEST_COUNT="$(find "${HOME_DIR}/.board-superpowers" \
+    -maxdepth 1 -name 'manifest.yml' -type f 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq 'exactly one manifest.yml after concurrent runs' \
+    '1' "${MANIFEST_COUNT}"
+
+TMP_LEAK_COUNT="$(find "${HOME_DIR}/.board-superpowers" \
+    -maxdepth 1 -name 'manifest.yml.tmp.*' 2>/dev/null | wc -l | tr -d ' ')"
+assert_eq 'no .tmp scratch leaks after concurrent runs' \
+    '0' "${TMP_LEAK_COUNT}"
+
+# Sanity: the surviving manifest is well-formed.
+check 'concurrent-survivor manifest has correct version' \
+    grep -Fxq 'last_seen_version: "0.2.0"' "${MANIFEST}"
+check 'concurrent-survivor manifest has ISO-8601 host_bootstrapped_at' \
+    grep -Eq '^host_bootstrapped_at: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "${MANIFEST}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 8: YAML whitespace tolerance — `key : "value"` parses
+# ---------------------------------------------------------------------------
+# A user hand-edits manifest.yml and adds an extra space before the
+# colon (`last_seen_version : "0.1.0"`). YAML allows this (whitespace
+# around the colon is non-significant for top-level scalars). The
+# version-refresh path must still detect the older version and bump
+# to the plugin's current version.
+printf 'Scenario 8: YAML whitespace tolerance (key<ws>:<ws>value)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+
+MANIFEST="${HOME_DIR}/.board-superpowers/manifest.yml"
+ORIGINAL_TS='2026-02-01T08:00:00Z'
+# Note the EXTRA SPACES around colons — both before and after.
+cat > "${MANIFEST}" <<EOF
+schema_version : 1
+host_bootstrapped_at  :  "${ORIGINAL_TS}"
+last_seen_version : "0.1.0"
+EOF
+chmod 0644 "${MANIFEST}"
+chmod 0700 "${HOME_DIR}/.board-superpowers"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'whitespace-tolerant refresh exit 0' '0' "${RC}"
+check 'last_seen_version bumped to "0.2.0" despite spaced colons' \
+    grep -Fxq 'last_seen_version: "0.2.0"' "${MANIFEST}"
+check_not 'old last_seen_version: "0.1.0" gone after whitespace-tolerant refresh' \
+    grep -Eq '^last_seen_version[[:space:]]*:[[:space:]]*"0\.1\.0"$' "${MANIFEST}"
+check 'host_bootstrapped_at preserved across whitespace-tolerant refresh' \
+    grep -Fxq "host_bootstrapped_at: \"${ORIGINAL_TS}\"" "${MANIFEST}"
 
 rm -rf "${TMP}"
 

--- a/tests/test-fb2-byo-rdbms.sh
+++ b/tests/test-fb2-byo-rdbms.sh
@@ -1,0 +1,699 @@
+#!/usr/bin/env bash
+# tests/test-fb2-byo-rdbms.sh — assert scripts/bootstrap-project.sh
+# step 2e (BYO-RDBMS credential UX) satisfies the contract per
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § 1.5.2 step 2e + 03-config-schemas.md credentials.yml schema +
+# adr/0009-allow-sqlite-as-byo-audit-db.md.
+#
+# Scope: Slice 3 of Card 2 — extend bootstrap-project.sh with three
+# step 2e paths + the --audit-db-url flag + BOARD_SP_AUDIT_DB_URL env
+# var handling. Step 2e runs AFTER 2a-2d but BEFORE the state.yml
+# write so abort cleanly leaves no half-state behind.
+#
+# Path A — env var present     → validate scheme, no credentials.yml.
+# Path B — credentials.yml     → re-use; warn on loose mode.
+# Path C — interactive prompt  → write credentials.yml chmod 0600,
+#                                or surface degradation.
+# CLI flag — --audit-db-url    → highest precedence; same scheme rules.
+#
+# Contracts under test (~10 scenarios):
+#   1. Path A — valid postgres env var: bootstrap silent on step 2e,
+#      no credentials.yml written, state.yml IS written.
+#   2. Path A — invalid scheme env var: exit 4, error lists the 6
+#      schemes, no state.yml written.
+#   3. Path B — pre-existing credentials.yml chmod 0600 + valid
+#      mysql DSN: step 2e re-uses; no warning; state.yml written.
+#   4. Path B — pre-existing credentials.yml chmod 0644: warning
+#      emitted, but bootstrap proceeds; file mode is NOT auto-tightened.
+#   5. Path C — interactive sqlite happy: pipe a sqlite:////tmp DSN
+#      pointing into a writable parent; credentials.yml written
+#      with chmod 0600, content matches.
+#   6. Path C — interactive sqlite parent dir unwritable: exit 4,
+#      error mentions parent dir, no credentials.yml written, no
+#      state.yml written.
+#   7. Path C — decline (empty input): degradation notice printed;
+#      no credentials.yml written; state.yml IS written.
+#   8. --audit-db-url flag: takes precedence; non-interactive;
+#      credentials.yml written with chmod 0600.
+#   9. CLI flag for non-sqlite postgres: bootstrap silent on
+#      step 2e, no credentials.yml written, state.yml IS written.
+#  10. Path A precedence vs pre-existing credentials.yml: env var
+#      wins, no credentials.yml mutation.
+#
+# Hermeticity: tmp HOME + tmp git repo + stub gh on PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_UNDER_TEST="${PLUGIN_ROOT_REAL}/scripts/bootstrap-project.sh"
+
+if [ ! -f "${SCRIPT_UNDER_TEST}" ]; then
+    printf 'FATAL: %s not found\n' "${SCRIPT_UNDER_TEST}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Cross-platform "stat" helper (BSD vs GNU).
+file_mode() {
+    local path="$1"
+    if stat -f '%A' "${path}" >/dev/null 2>&1; then
+        stat -f '%A' "${path}"
+    else
+        stat -c '%a' "${path}"
+    fi
+}
+
+# Replica of make_stub_plugin_root from test-fb2-per-repo.sh.
+make_stub_plugin_root() {
+    local version="$1"
+    local target_dir="$2"
+    mkdir -p "${target_dir}/.claude-plugin"
+    cat > "${target_dir}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+    mkdir -p "${target_dir}/scripts/lib"
+    cp "${PLUGIN_ROOT_REAL}/scripts/lib/common.sh" "${target_dir}/scripts/lib/common.sh"
+    cp "${PLUGIN_ROOT_REAL}/scripts/setup-labels.sh" "${target_dir}/scripts/setup-labels.sh"
+    cp "${SCRIPT_UNDER_TEST}" "${target_dir}/scripts/bootstrap-project.sh"
+    chmod +x "${target_dir}/scripts/setup-labels.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+}
+
+init_tmp_repo() {
+    local repo_root="$1"
+    local owner_name="$2"
+    mkdir -p "${repo_root}"
+    git -C "${repo_root}" init --quiet
+    git -C "${repo_root}" remote add origin "https://github.com/${owner_name}.git"
+    git -C "${repo_root}" config user.email "test@example.com"
+    git -C "${repo_root}" config user.name  "test"
+}
+
+# Stub gh — same shape as test-fb2-per-repo.sh; canonical Status field
+# always returned so step 2b is never the failing party here.
+stub_gh() {
+    local dir="$1"
+    cat > "${dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+LABELS_FILE="${STUB_DIR}/labels.json"
+STATUS_OPTS_FILE="${STUB_DIR}/status_opts"
+
+if [ ! -f "${LABELS_FILE}" ]; then
+    printf '[]\n' > "${LABELS_FILE}"
+fi
+
+case "${1:-}" in
+    label)
+        shift
+        case "${1:-}" in
+            list)
+                cat "${LABELS_FILE}"
+                exit 0
+                ;;
+            create)
+                shift
+                NAME="${1:?label create needs NAME}"
+                shift
+                EXISTS="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print('1' if any(l['name']==sys.argv[2] for l in data) else '0')
+" "${LABELS_FILE}" "${NAME}")"
+                if [ "${EXISTS}" = "1" ]; then
+                    printf 'error: name "%s" already used by another label\n' "${NAME}" >&2
+                    exit 1
+                fi
+                python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+data.append({'name': sys.argv[2]})
+with open(sys.argv[1], 'w') as f:
+    json.dump(data, f)
+" "${LABELS_FILE}" "${NAME}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    project)
+        shift
+        case "${1:-}" in
+            field-list)
+                python3 -c "
+import json, sys, os
+opts_path = sys.argv[1]
+options = []
+if os.path.exists(opts_path):
+    with open(opts_path) as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                options.append({'id': 'opt-' + line.replace(' ', '-').lower(),
+                                'name': line})
+fields = []
+if options:
+    fields.append({'id': 'fld-status', 'name': 'Status', 'options': options})
+print(json.dumps({'fields': fields}))
+" "${STATUS_OPTS_FILE}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+CANONICAL_STATUS="Backlog
+Ready
+In Progress
+In Review
+Done
+Blocked"
+
+# Run bootstrap with optional stdin redirected from a string.
+#   $1 — HOME dir
+#   $2 — plugin root
+#   $3 — stubs dir
+#   $4 — stdin payload (use empty string for /dev/null)
+#   $5 — env var line ("KEY=VALUE" or "")
+#   $@ — additional args to bootstrap-project.sh
+run_bootstrap_input() {
+    local home_dir="$1"; shift
+    local plugin_root="$1"; shift
+    local stubs_dir="$1"; shift
+    local stdin_payload="$1"; shift
+    local env_line="$1"; shift
+
+    local extra_env=()
+    if [ -n "${env_line}" ]; then
+        extra_env=("${env_line}")
+    fi
+
+    if [ -z "${stdin_payload}" ]; then
+        env -i HOME="${home_dir}" PATH="${stubs_dir}:/usr/bin:/bin" \
+            "${extra_env[@]+"${extra_env[@]}"}" \
+            bash "${plugin_root}/scripts/bootstrap-project.sh" \
+                --plugin-root "${plugin_root}" \
+                "$@" </dev/null
+    else
+        env -i HOME="${home_dir}" PATH="${stubs_dir}:/usr/bin:/bin" \
+            "${extra_env[@]+"${extra_env[@]}"}" \
+            bash "${plugin_root}/scripts/bootstrap-project.sh" \
+                --plugin-root "${plugin_root}" \
+                "$@" <<< "${stdin_payload}"
+    fi
+}
+
+normalized_state_dir() {
+    local home_dir="$1"
+    local repo_root="$2"
+    local canonical
+    canonical="$(cd "${repo_root}" && git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -z "${canonical}" ]; then
+        canonical="$(cd "${repo_root}" && pwd -P)"
+    fi
+    local stripped="${canonical#/}"
+    stripped="${stripped%/}"
+    local normalized="${stripped//\//-}"
+    printf '%s/.board-superpowers/repos/%s\n' "${home_dir}" "${normalized}"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Path A — env var present, valid postgres
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: Path A — env var valid postgres\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+ALL_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "BOARD_SP_AUDIT_DB_URL=postgresql://user:pwd@host:5432/db" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'envvar valid: exit 0' '0' "${RC}"
+check_not 'envvar valid: no credentials.yml written' \
+    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'envvar valid: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+check 'envvar valid: log mentions env var precedence' \
+    bash -c "printf '%s' \"\$1\" | grep -Eqi 'BOARD_SP_AUDIT_DB_URL|env var'" _ "${ALL_OUT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Path A — env var invalid scheme
+# ---------------------------------------------------------------------------
+printf 'Scenario 2: Path A — env var invalid scheme (mongodb)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+ERR_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "BOARD_SP_AUDIT_DB_URL=mongodb://localhost:27017/audit" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'envvar invalid: exit 4' '4' "${RC}"
+check 'envvar invalid: stderr mentions postgres scheme' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'postgresql://'" _ "${ERR_OUT}"
+check 'envvar invalid: stderr mentions sqlite scheme' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'sqlite://'" _ "${ERR_OUT}"
+check 'envvar invalid: stderr mentions mysql+pymysql scheme' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'mysql+pymysql://'" _ "${ERR_OUT}"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check_not 'envvar invalid: no state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+check_not 'envvar invalid: no credentials.yml written' \
+    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Path B — pre-existing credentials.yml chmod 0600
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: Path B — pre-existing credentials.yml chmod 0600\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Seed a properly-permissioned credentials.yml.
+mkdir -p "${HOME_DIR}/.board-superpowers"
+chmod 0700 "${HOME_DIR}/.board-superpowers"
+cat > "${HOME_DIR}/.board-superpowers/credentials.yml" <<'EOF'
+audit_db_url: "mysql://prod:secret@db.example.com:3306/audit"
+EOF
+chmod 0600 "${HOME_DIR}/.board-superpowers/credentials.yml"
+ORIG_CONTENT="$(cat "${HOME_DIR}/.board-superpowers/credentials.yml")"
+
+set +e
+ALL_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'pre-existing 0600: exit 0' '0' "${RC}"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'pre-existing 0600: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+assert_eq 'pre-existing 0600: credentials.yml unchanged' \
+    "${ORIG_CONTENT}" "$(cat "${HOME_DIR}/.board-superpowers/credentials.yml")"
+assert_eq 'pre-existing 0600: file mode still 0600' \
+    '600' "$(file_mode "${HOME_DIR}/.board-superpowers/credentials.yml")"
+check_not 'pre-existing 0600: NO loose-mode warning' \
+    bash -c "printf '%s' \"\$1\" | grep -Eqi 'mode|chmod|0600|0644|loose|permissions'" _ "${ALL_OUT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Path B — pre-existing credentials.yml chmod 0644
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: Path B — pre-existing credentials.yml looser mode\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+mkdir -p "${HOME_DIR}/.board-superpowers"
+chmod 0700 "${HOME_DIR}/.board-superpowers"
+cat > "${HOME_DIR}/.board-superpowers/credentials.yml" <<'EOF'
+audit_db_url: "postgresql://u:p@h:5432/d"
+EOF
+chmod 0644 "${HOME_DIR}/.board-superpowers/credentials.yml"
+
+set +e
+ALL_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'looser-mode: exit 0 (proceed)' '0' "${RC}"
+check 'looser-mode: WARN about file mode' \
+    bash -c "printf '%s' \"\$1\" | grep -Eqi 'WARN.*credentials\.yml.*(mode|0600|chmod|loose)'" _ "${ALL_OUT}"
+# Spec says we must NOT auto-tighten — file is user-managed.
+assert_eq 'looser-mode: file mode NOT auto-tightened (still 0644)' \
+    '644' "$(file_mode "${HOME_DIR}/.board-superpowers/credentials.yml")"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'looser-mode: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Path C — interactive sqlite happy path
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: Path C — interactive sqlite happy path\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+DB_PARENT="${TMP}/dbparent"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}" "${DB_PARENT}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+DSN="sqlite:////${DB_PARENT#/}/audit.db"
+
+set +e
+ALL_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "${DSN}
+" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'interactive sqlite: exit 0' '0' "${RC}"
+CRED="${HOME_DIR}/.board-superpowers/credentials.yml"
+check 'interactive sqlite: credentials.yml written' test -f "${CRED}"
+assert_eq 'interactive sqlite: credentials.yml mode 0600' \
+    '600' "$(file_mode "${CRED}")"
+check 'interactive sqlite: credentials.yml has audit_db_url' \
+    grep -Fq "audit_db_url:" "${CRED}"
+check 'interactive sqlite: credentials.yml has the DSN we entered' \
+    grep -Fq "${DSN}" "${CRED}"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'interactive sqlite: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Path C — interactive sqlite parent dir unwritable
+# ---------------------------------------------------------------------------
+printf 'Scenario 6: Path C — interactive sqlite parent dir unwritable\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+DB_PARENT="${TMP}/locked"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}" "${DB_PARENT}"
+chmod 0500 "${DB_PARENT}"  # readable + executable, but NOT writable
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+DSN="sqlite:////${DB_PARENT#/}/audit.db"
+
+set +e
+ERR_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "${DSN}
+" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+# Cleanup so mktemp's deleter can remove the dir.
+chmod 0700 "${DB_PARENT}" 2>/dev/null || true
+
+assert_eq 'unwritable parent: exit 4' '4' "${RC}"
+check 'unwritable parent: stderr mentions parent dir path' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq '${DB_PARENT}'" _ "${ERR_OUT}"
+check_not 'unwritable parent: NO credentials.yml leak' \
+    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check_not 'unwritable parent: NO state.yml leak' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: Path C — decline (empty input)
+# ---------------------------------------------------------------------------
+printf 'Scenario 7: Path C — decline (empty input)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+# Empty input: a single newline (so the read() consumes it but yields "").
+ALL_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "
+" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'decline: exit 0' '0' "${RC}"
+check_not 'decline: no credentials.yml written' \
+    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+check 'decline: degradation notice (R-class) printed' \
+    bash -c "printf '%s' \"\$1\" | grep -Eqi 'R-class|degrad'" _ "${ALL_OUT}"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'decline: state.yml IS written' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 8: --audit-db-url flag (sqlite happy)
+# ---------------------------------------------------------------------------
+printf 'Scenario 8: --audit-db-url flag (sqlite happy)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+DB_PARENT="${TMP}/flagdb"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}" "${DB_PARENT}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+FLAG_DSN="sqlite:////${DB_PARENT#/}/audit.db"
+
+set +e
+ALL_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+    --audit-db-url "${FLAG_DSN}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'flag sqlite: exit 0' '0' "${RC}"
+CRED="${HOME_DIR}/.board-superpowers/credentials.yml"
+check 'flag sqlite: credentials.yml written' test -f "${CRED}"
+assert_eq 'flag sqlite: mode 0600' '600' "$(file_mode "${CRED}")"
+check 'flag sqlite: contains the DSN we passed' \
+    grep -Fq "${FLAG_DSN}" "${CRED}"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'flag sqlite: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 9: --audit-db-url flag (postgres — does NOT write credentials.yml)
+# ---------------------------------------------------------------------------
+# Spec contract: when the architect supplies a DSN by --flag or env var
+# (Path A precedence), we honor it as a runtime override and do NOT
+# materialize credentials.yml on disk. Same as env-var precedence.
+printf 'Scenario 9: --audit-db-url flag (postgres — same as env)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" \
+    --audit-db-url "postgresql://u:p@h:5432/d" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'flag postgres: exit 0' '0' "${RC}"
+check_not 'flag postgres: NO credentials.yml written (precedence)' \
+    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'flag postgres: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 10: env var precedence over pre-existing credentials.yml
+# ---------------------------------------------------------------------------
+printf 'Scenario 10: env var precedence over pre-existing credentials.yml\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+mkdir -p "${HOME_DIR}/.board-superpowers"
+chmod 0700 "${HOME_DIR}/.board-superpowers"
+cat > "${HOME_DIR}/.board-superpowers/credentials.yml" <<'EOF'
+audit_db_url: "mysql://prod:secret@db.example.com:3306/audit"
+EOF
+chmod 0600 "${HOME_DIR}/.board-superpowers/credentials.yml"
+ORIG="$(cat "${HOME_DIR}/.board-superpowers/credentials.yml")"
+
+set +e
+run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "BOARD_SP_AUDIT_DB_URL=postgres://envuser:envpwd@envhost/d" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'envvar+file: exit 0' '0' "${RC}"
+assert_eq 'envvar+file: credentials.yml NOT mutated' \
+    "${ORIG}" "$(cat "${HOME_DIR}/.board-superpowers/credentials.yml")"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check 'envvar+file: state.yml written' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/test-fb2-byo-rdbms.sh
+++ b/tests/test-fb2-byo-rdbms.sh
@@ -123,6 +123,11 @@ EOF
     cp "${SCRIPT_UNDER_TEST}" "${target_dir}/scripts/bootstrap-project.sh"
     chmod +x "${target_dir}/scripts/setup-labels.sh"
     chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+    # Slice 4 — routing block injection source-of-truth (required by
+    # step 4 even though this test exercises step 2e).
+    mkdir -p "${target_dir}/skills/using-board-superpowers/references"
+    cp "${PLUGIN_ROOT_REAL}/skills/using-board-superpowers/references/agentsmd-routing.md" \
+       "${target_dir}/skills/using-board-superpowers/references/agentsmd-routing.md"
 }
 
 init_tmp_repo() {

--- a/tests/test-fb2-byo-rdbms.sh
+++ b/tests/test-fb2-byo-rdbms.sh
@@ -613,12 +613,14 @@ check 'flag sqlite: state.yml written' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
-# Scenario 9: --audit-db-url flag (postgres — does NOT write credentials.yml)
+# Scenario 9: --audit-db-url flag (postgres) PERSISTS to credentials.yml
 # ---------------------------------------------------------------------------
-# Spec contract: when the architect supplies a DSN by --flag or env var
-# (Path A precedence), we honor it as a runtime override and do NOT
-# materialize credentials.yml on disk. Same as env-var precedence.
-printf 'Scenario 9: --audit-db-url flag (postgres — same as env)\n'
+# Spec contract (per BLOCKER 1 fix): the --audit-db-url flag is the
+# non-interactive equivalent of typing the DSN at the interactive
+# prompt. It ALWAYS persists to credentials.yml at chmod 0600,
+# regardless of scheme. Use BOARD_SP_AUDIT_DB_URL for ephemeral /
+# runtime overrides that should NOT touch disk.
+printf 'Scenario 9: --audit-db-url flag (postgres) persists like sqlite\n'
 
 TMP="$(mktemp -d)"
 HOME_DIR="${TMP}/home"
@@ -633,17 +635,24 @@ stub_gh "${STUBS_DIR}"
 printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
 printf '[]\n' > "${STUBS_DIR}/labels.json"
 
+PG_DSN="postgresql://u:p@h:5432/d"
+
 set +e
 run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
     "" "" \
     --owner foo --project 1 --repo-root "${REPO_ROOT}" \
-    --audit-db-url "postgresql://u:p@h:5432/d" >/dev/null 2>&1
+    --audit-db-url "${PG_DSN}" >/dev/null 2>&1
 RC=$?
 set -e
 
 assert_eq 'flag postgres: exit 0' '0' "${RC}"
-check_not 'flag postgres: NO credentials.yml written (precedence)' \
-    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+CRED="${HOME_DIR}/.board-superpowers/credentials.yml"
+check 'flag postgres: credentials.yml written (flag persists)' \
+    test -f "${CRED}"
+assert_eq 'flag postgres: credentials.yml mode 0600' \
+    '600' "$(file_mode "${CRED}")"
+check 'flag postgres: credentials.yml has the DSN we passed' \
+    grep -Fq "${PG_DSN}" "${CRED}"
 STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
 check 'flag postgres: state.yml written' \
     test -f "${STATE_DIR}/state.yml"
@@ -691,6 +700,158 @@ check 'envvar+file: state.yml written' \
     test -f "${STATE_DIR}/state.yml"
 
 rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 11: structural DSN validation — malformed network DSNs reject
+# ---------------------------------------------------------------------------
+# Per BLOCKER 2 fix: scheme-prefix matching alone is insufficient. We
+# require urlparse(dsn).hostname for non-sqlite schemes, so loose
+# strings that happen to start with `postgres://` but have no host or
+# malformed authority are rejected with exit 4.
+printf 'Scenario 11: malformed network DSN rejected (no hostname)\n'
+
+run_validation_reject() {
+    local label="$1"
+    local dsn="$2"
+
+    local tmp home_dir plugin_root stubs_dir repo_root
+    tmp="$(mktemp -d)"
+    home_dir="${tmp}/home"
+    plugin_root="${tmp}/plugin"
+    stubs_dir="${tmp}/stubs"
+    repo_root="${tmp}/repo"
+
+    mkdir -p "${home_dir}" "${stubs_dir}"
+    make_stub_plugin_root "0.2.0" "${plugin_root}"
+    init_tmp_repo "${repo_root}" "foo/bar"
+    stub_gh "${stubs_dir}"
+    printf '%s\n' "${CANONICAL_STATUS}" > "${stubs_dir}/status_opts"
+    printf '[]\n' > "${stubs_dir}/labels.json"
+
+    set +e
+    local err_out rc
+    err_out="$(run_bootstrap_input "${home_dir}" "${plugin_root}" "${stubs_dir}" \
+        "" "BOARD_SP_AUDIT_DB_URL=${dsn}" \
+        --owner foo --project 1 --repo-root "${repo_root}" 2>&1 1>/dev/null)"
+    rc=$?
+    set -e
+
+    assert_eq "${label}: exit 4" '4' "${rc}"
+    local state_dir
+    state_dir="$(normalized_state_dir "${home_dir}" "${repo_root}")"
+    check_not "${label}: NO state.yml leak" \
+        test -f "${state_dir}/state.yml"
+    check_not "${label}: NO credentials.yml leak" \
+        test -f "${home_dir}/.board-superpowers/credentials.yml"
+    # Suppress unused-var warning for err_out — we keep it captured for
+    # ad-hoc print-on-failure debugging.
+    : "${err_out:-}"
+
+    rm -rf "${tmp}"
+}
+
+run_validation_accept() {
+    local label="$1"
+    local dsn="$2"
+
+    local tmp home_dir plugin_root stubs_dir repo_root
+    tmp="$(mktemp -d)"
+    home_dir="${tmp}/home"
+    plugin_root="${tmp}/plugin"
+    stubs_dir="${tmp}/stubs"
+    repo_root="${tmp}/repo"
+
+    mkdir -p "${home_dir}" "${stubs_dir}"
+    make_stub_plugin_root "0.2.0" "${plugin_root}"
+    init_tmp_repo "${repo_root}" "foo/bar"
+    stub_gh "${stubs_dir}"
+    printf '%s\n' "${CANONICAL_STATUS}" > "${stubs_dir}/status_opts"
+    printf '[]\n' > "${stubs_dir}/labels.json"
+
+    set +e
+    run_bootstrap_input "${home_dir}" "${plugin_root}" "${stubs_dir}" \
+        "" "BOARD_SP_AUDIT_DB_URL=${dsn}" \
+        --owner foo --project 1 --repo-root "${repo_root}" >/dev/null 2>&1
+    local rc=$?
+    set -e
+
+    assert_eq "${label}: exit 0" '0' "${rc}"
+    local state_dir
+    state_dir="$(normalized_state_dir "${home_dir}" "${repo_root}")"
+    check "${label}: state.yml written" \
+        test -f "${state_dir}/state.yml"
+
+    rm -rf "${tmp}"
+}
+
+# Rejects: malformed network forms.
+run_validation_reject 'malformed: postgres://user@host:5432:wrong/db' \
+    'postgres://user@host:5432:wrong/db'
+run_validation_reject 'malformed: mysql:// (no hostname)' \
+    'mysql://'
+run_validation_reject 'malformed: postgresql:/single-slash (no ://)' \
+    'postgresql:/single-slash'
+
+# ---------------------------------------------------------------------------
+# Scenario 12: 3-slash sqlite (relative path) is rejected
+# ---------------------------------------------------------------------------
+# Per ADR-0009 + BLOCKER 2: SQLite must use the 4-slash absolute form
+# (sqlite:////abs/path). The 3-slash form (sqlite:///rel/path) parses
+# to a relative path and is rejected; the error message must reference
+# ADR-0009's 4-slash convention so the architect knows the fix.
+printf 'Scenario 12: 3-slash sqlite (relative path) rejected; error references 4-slash convention\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+ERR_OUT="$(run_bootstrap_input "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    "" "BOARD_SP_AUDIT_DB_URL=sqlite:///relative/path/audit.db" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'sqlite 3-slash: exit 4' '4' "${RC}"
+check 'sqlite 3-slash: error references ADR-0009 4-slash convention' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq '4-slash'" _ "${ERR_OUT}"
+check 'sqlite 3-slash: error mentions ADR-0009' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'ADR-0009'" _ "${ERR_OUT}"
+check_not 'sqlite 3-slash: no state.yml' \
+    test -f "$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")/state.yml"
+check_not 'sqlite 3-slash: no credentials.yml' \
+    test -f "${HOME_DIR}/.board-superpowers/credentials.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 13: structural DSN validation — well-formed DSNs accept
+# ---------------------------------------------------------------------------
+# Per BLOCKER 2 fix: the validator must continue to accept the
+# canonical well-formed shapes. Sqlite 4-slash + postgres with full
+# auth/port/db/query + minimal postgres host-only.
+printf 'Scenario 13: well-formed DSNs accept (4-slash sqlite, full + minimal postgres)\n'
+
+# 4-slash sqlite (absolute path): accept. Use a writable parent.
+TMP_SQLITE_PARENT="$(mktemp -d)"
+run_validation_accept 'accept: 4-slash sqlite' \
+    "sqlite:////${TMP_SQLITE_PARENT#/}/audit.db"
+rm -rf "${TMP_SQLITE_PARENT}"
+
+run_validation_accept 'accept: postgres with auth+port+db+query' \
+    'postgresql://user:pwd@host:5432/db?ssl=true'
+
+run_validation_accept 'accept: postgres host-only (no port/auth)' \
+    'postgresql://localhost/db'
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test-fb2-per-repo.sh
+++ b/tests/test-fb2-per-repo.sh
@@ -1,0 +1,682 @@
+#!/usr/bin/env bash
+# tests/test-fb2-per-repo.sh — assert scripts/bootstrap-project.sh
+# satisfies the F-B2 per-repo bootstrap engine contract per
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § 1.5.2 (steps 2a-2d + initial state.yml write) and the
+# config / state schemas in 03-config-schemas.md.
+#
+# Scope: Slice 2 of Card 2 — F-B2 engine steps 2a-2d + initial
+# state.yml write. Step 2e (BYO-RDBMS) is slice 3, step 4 (routing
+# block injection) is slice 4 — both OUT of scope here. The state.yml
+# this slice writes contains `routing_blocks: []` (empty list);
+# slice 4 will populate it.
+#
+# Contracts under test (8 scenarios):
+#   1. Cold start: tmp HOME + tmp git repo. Stubbed gh returns
+#      canonical 6-option Status field. All 13 labels created;
+#      config.yml + state.yml + .gitignore written; exit 0.
+#   2. Status field drift: stubbed gh returns wrong option set.
+#      Exit 2 with stderr listing the canonical 6.
+#   3. Idempotent re-run: cold start, then re-run. config.yml
+#      mtime unchanged; state.yml not rewritten when version is
+#      already current; .gitignore not double-appended; labels
+#      still 13.
+#   4. --force overwrites config.yml: pre-existing config.yml with
+#      hand-edited wip_limit: 7. After --force, config.yml regenerated
+#      to wip_limit: 5.
+#   5. .gitignore append idempotent: pre-existing .gitignore already
+#      containing the canonical entry. Re-run leaves it unchanged.
+#   6. .gitignore creation: tmp git repo with NO .gitignore. F-B2
+#      creates it with the entries.
+#   7. state.yml initial write: assert all 5 schema fields present,
+#      routing_blocks is the empty list, file mode 0644, parent dir
+#      0700.
+#   8. Labels delegation failure: stub gh fails on label create.
+#      Exit 3; F-B2 aborts BEFORE writing state.yml (no state.yml
+#      lingers).
+#
+# Hermeticity: every scenario uses tmp HOME + tmp git repo + stubbed
+# gh on PATH. Nothing touches the real ~/.board-superpowers nor
+# real GitHub.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SCRIPT_UNDER_TEST="${PLUGIN_ROOT_REAL}/scripts/bootstrap-project.sh"
+
+if [ ! -f "${SCRIPT_UNDER_TEST}" ]; then
+    printf 'FATAL: %s not found\n' "${SCRIPT_UNDER_TEST}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Cross-platform "stat" helper (BSD vs GNU).
+file_mode() {
+    local path="$1"
+    if stat -f '%A' "${path}" >/dev/null 2>&1; then
+        stat -f '%A' "${path}"
+    else
+        stat -c '%a' "${path}"
+    fi
+}
+
+file_mtime() {
+    local path="$1"
+    if stat -f '%m' "${path}" >/dev/null 2>&1; then
+        stat -f '%m' "${path}"
+    else
+        stat -c '%Y' "${path}"
+    fi
+}
+
+# Make a stub plugin root with .claude-plugin/plugin.json + the real
+# scripts/lib/common.sh + the real scripts/setup-labels.sh + a copy of
+# the script under test. We need bootstrap-project.sh to find a real
+# setup-labels.sh sibling to delegate step 2a to.
+make_stub_plugin_root() {
+    local version="$1"
+    local target_dir="$2"
+    mkdir -p "${target_dir}/.claude-plugin"
+    cat > "${target_dir}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+    # Provide the real script directory so bootstrap-project.sh
+    # can locate setup-labels.sh + lib/common.sh as siblings.
+    mkdir -p "${target_dir}/scripts/lib"
+    cp "${PLUGIN_ROOT_REAL}/scripts/lib/common.sh" "${target_dir}/scripts/lib/common.sh"
+    cp "${PLUGIN_ROOT_REAL}/scripts/setup-labels.sh" "${target_dir}/scripts/setup-labels.sh"
+    cp "${SCRIPT_UNDER_TEST}" "${target_dir}/scripts/bootstrap-project.sh"
+    chmod +x "${target_dir}/scripts/setup-labels.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+}
+
+# Initialize a tmp git repo with origin pointing at owner/name.
+init_tmp_repo() {
+    local repo_root="$1"
+    local owner_name="$2"
+    mkdir -p "${repo_root}"
+    git -C "${repo_root}" init --quiet
+    git -C "${repo_root}" remote add origin "https://github.com/${owner_name}.git"
+    # Set a local user so commits (if any) don't fail; not used here
+    git -C "${repo_root}" config user.email "test@example.com"
+    git -C "${repo_root}" config user.name  "test"
+}
+
+# Build a `gh` stub that:
+#   - `gh label list --json name`          → emit current labels file
+#   - `gh label create NAME ...`            → append to labels file (or fail
+#                                             if MUST_FAIL_LABELS=1)
+#   - `gh project field-list NUM --owner OWNER --format json`
+#                                          → emit the configured Status
+#                                            field options JSON
+# State files used:
+#   ${stub_dir}/labels.json     — JSON array of {"name":...}
+#   ${stub_dir}/status_opts     — newline-separated Status option names
+#                                 (in order). Empty file → unknown
+#                                 Status field (will emit no fields).
+#   ${stub_dir}/must_fail_labels — if file exists, label create exits 1
+stub_gh() {
+    local dir="$1"
+    cat > "${dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+LABELS_FILE="${STUB_DIR}/labels.json"
+STATUS_OPTS_FILE="${STUB_DIR}/status_opts"
+MUST_FAIL_LABELS="${STUB_DIR}/must_fail_labels"
+
+if [ ! -f "${LABELS_FILE}" ]; then
+    printf '[]\n' > "${LABELS_FILE}"
+fi
+
+case "${1:-}" in
+    label)
+        shift
+        case "${1:-}" in
+            list)
+                cat "${LABELS_FILE}"
+                exit 0
+                ;;
+            create)
+                shift
+                NAME="${1:?label create needs NAME}"
+                shift
+                if [ -f "${MUST_FAIL_LABELS}" ]; then
+                    printf 'error: stubbed label create failure for %s\n' "${NAME}" >&2
+                    exit 1
+                fi
+                EXISTS="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print('1' if any(l['name']==sys.argv[2] for l in data) else '0')
+" "${LABELS_FILE}" "${NAME}")"
+                if [ "${EXISTS}" = "1" ]; then
+                    printf 'error: name "%s" already used by another label\n' "${NAME}" >&2
+                    exit 1
+                fi
+                python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+data.append({'name': sys.argv[2]})
+with open(sys.argv[1], 'w') as f:
+    json.dump(data, f)
+" "${LABELS_FILE}" "${NAME}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    project)
+        shift
+        case "${1:-}" in
+            field-list)
+                # Build a JSON document with a Status field whose
+                # options come from STATUS_OPTS_FILE (one per line).
+                python3 -c "
+import json, sys, os
+opts_path = sys.argv[1]
+options = []
+if os.path.exists(opts_path):
+    with open(opts_path) as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                options.append({'id': 'opt-' + line.replace(' ', '-').lower(),
+                                'name': line})
+fields = []
+if options:
+    fields.append({'id': 'fld-status', 'name': 'Status', 'options': options})
+print(json.dumps({'fields': fields}))
+" "${STATUS_OPTS_FILE}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+CANONICAL_STATUS="Backlog
+Ready
+In Progress
+In Review
+Done
+Blocked"
+
+# Run bootstrap-project.sh with stubs in place.
+#   $1 — HOME dir
+#   $2 — plugin root
+#   $3 — stubs dir (PATH first entry)
+#   $@ — additional args to bootstrap-project.sh
+run_bootstrap() {
+    local home_dir="$1"; shift
+    local plugin_root="$1"; shift
+    local stubs_dir="$1"; shift
+    HOME="${home_dir}" \
+    PATH="${stubs_dir}:/usr/bin:/bin" \
+        bash "${plugin_root}/scripts/bootstrap-project.sh" \
+            --plugin-root "${plugin_root}" \
+            "$@"
+}
+
+# Compute the host-state dir for a repo root, mirroring
+# bsp_normalize_repo_path: strip leading /, replace remaining / with -.
+# IMPORTANT: the script canonicalises the repo root via
+# `git rev-parse --show-toplevel`, which on macOS resolves /var → /private/var.
+# Mirror that here so the normalized path lines up with what the script
+# actually wrote.
+normalized_state_dir() {
+    local home_dir="$1"
+    local repo_root="$2"
+    local canonical
+    canonical="$(cd "${repo_root}" && git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -z "${canonical}" ]; then
+        canonical="$(cd "${repo_root}" && pwd -P)"
+    fi
+    local stripped="${canonical#/}"
+    stripped="${stripped%/}"
+    local normalized="${stripped//\//-}"
+    printf '%s/.board-superpowers/repos/%s\n' "${home_dir}" "${normalized}"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: cold start — labels, config.yml, state.yml, .gitignore
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: cold start (everything absent)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'cold start exit 0' '0' "${RC}"
+
+# Labels: 13 created
+LABEL_COUNT="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))
+" "${STUBS_DIR}/labels.json")"
+assert_eq 'cold start: 13 labels created' '13' "${LABEL_COUNT}"
+
+# config.yml: written with project: "foo/1" + wip_limit: 5
+CONFIG="${REPO_ROOT}/.board-superpowers/config.yml"
+check 'config.yml exists' test -f "${CONFIG}"
+check 'config.yml has project: "foo/1"' \
+    grep -Fxq 'project: "foo/1"' "${CONFIG}"
+check 'config.yml has wip_limit: 5' \
+    grep -Fxq 'wip_limit: 5' "${CONFIG}"
+
+# .gitignore: created with the canonical entries
+GITIGNORE="${REPO_ROOT}/.gitignore"
+check '.gitignore exists' test -f "${GITIGNORE}"
+check '.gitignore has comment header' \
+    grep -Fxq '# board-superpowers local state (claim markers are per-session)' \
+        "${GITIGNORE}"
+check '.gitignore has claims/ entry' \
+    grep -Fxq '.board-superpowers/claims/' "${GITIGNORE}"
+
+# state.yml: written under host-local normalized path
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE="${STATE_DIR}/state.yml"
+check 'state.yml exists' test -f "${STATE}"
+check 'state.yml has schema_version: 1' \
+    grep -Fxq 'schema_version: 1' "${STATE}"
+check 'state.yml has last_seen_version_in_repo: "0.2.0"' \
+    grep -Fxq 'last_seen_version_in_repo: "0.2.0"' "${STATE}"
+check 'state.yml has features_enabled list' \
+    grep -Fxq 'features_enabled:' "${STATE}"
+check 'state.yml has bootstrap.host item' \
+    grep -Fxq '  - bootstrap.host' "${STATE}"
+check 'state.yml has bootstrap.per_repo item' \
+    grep -Fxq '  - bootstrap.per_repo' "${STATE}"
+check 'state.yml has empty routing_blocks' \
+    grep -Fxq 'routing_blocks: []' "${STATE}"
+check 'state.yml has ISO-8601 repo_bootstrapped_at' \
+    grep -Eq '^repo_bootstrapped_at: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "${STATE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Status field drift — exit 2 with clear error
+# ---------------------------------------------------------------------------
+printf 'Scenario 2: Status field drift\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+# Wrong order (Ready and Backlog swapped) — must trigger drift.
+printf 'Ready\nBacklog\nIn Progress\nIn Review\nDone\nBlocked\n' \
+    > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+ERR_OUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'Status drift exit 2' '2' "${RC}"
+check 'Status drift stderr mentions Status field' \
+    bash -c "printf '%s' \"\$1\" | grep -Eqi 'status[[:space:]]+field|status[[:space:]]+option'" _ "${ERR_OUT}"
+check 'Status drift stderr mentions canonical order' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'Backlog'" _ "${ERR_OUT}"
+# state.yml MUST NOT be created when bootstrap aborts on Status drift
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check_not 'no state.yml after Status drift abort' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: idempotent re-run
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: idempotent re-run\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# First run
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+
+CONFIG="${REPO_ROOT}/.board-superpowers/config.yml"
+GITIGNORE="${REPO_ROOT}/.gitignore"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE="${STATE_DIR}/state.yml"
+
+CONFIG_MTIME_BEFORE="$(file_mtime "${CONFIG}")"
+GITIGNORE_LINES_BEFORE="$(wc -l < "${GITIGNORE}" | tr -d ' ')"
+STATE_MTIME_BEFORE="$(file_mtime "${STATE}")"
+LABELS_BEFORE="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))
+" "${STUBS_DIR}/labels.json")"
+
+# Sleep so any rewrite would change mtime.
+sleep 1.1
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'idempotent re-run exit 0' '0' "${RC}"
+assert_eq 'config.yml mtime unchanged on idempotent re-run' \
+    "${CONFIG_MTIME_BEFORE}" "$(file_mtime "${CONFIG}")"
+assert_eq '.gitignore line count unchanged on idempotent re-run' \
+    "${GITIGNORE_LINES_BEFORE}" "$(wc -l < "${GITIGNORE}" | tr -d ' ')"
+assert_eq 'state.yml mtime unchanged when version is current' \
+    "${STATE_MTIME_BEFORE}" "$(file_mtime "${STATE}")"
+LABELS_AFTER="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    print(len(json.load(f)))
+" "${STUBS_DIR}/labels.json")"
+assert_eq 'labels still 13 after idempotent re-run' "${LABELS_BEFORE}" "${LABELS_AFTER}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: --force overwrites config.yml
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: --force overwrites config.yml\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-existing config.yml with hand-edited wip_limit: 7
+mkdir -p "${REPO_ROOT}/.board-superpowers"
+cat > "${REPO_ROOT}/.board-superpowers/config.yml" <<'EOF'
+# hand-edited
+project: "foo/1"
+wip_limit: 7
+EOF
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" --force >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq '--force exit 0' '0' "${RC}"
+CONFIG="${REPO_ROOT}/.board-superpowers/config.yml"
+check '--force regenerated config.yml: wip_limit: 5' \
+    grep -Fxq 'wip_limit: 5' "${CONFIG}"
+check_not '--force erased hand-edited wip_limit: 7' \
+    grep -Fxq 'wip_limit: 7' "${CONFIG}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: .gitignore append idempotent
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: .gitignore append idempotent\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-existing .gitignore with the canonical entries already present.
+cat > "${REPO_ROOT}/.gitignore" <<'EOF'
+# user existing rule
+node_modules/
+
+# board-superpowers local state (claim markers are per-session)
+.board-superpowers/claims/
+EOF
+
+GITIGNORE_BYTES_BEFORE="$(wc -c < "${REPO_ROOT}/.gitignore" | tr -d ' ')"
+CLAIMS_LINES_BEFORE="$(grep -Fxc '.board-superpowers/claims/' "${REPO_ROOT}/.gitignore" || true)"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq '.gitignore-already-present exit 0' '0' "${RC}"
+assert_eq '.gitignore byte count unchanged (no double-append)' \
+    "${GITIGNORE_BYTES_BEFORE}" \
+    "$(wc -c < "${REPO_ROOT}/.gitignore" | tr -d ' ')"
+CLAIMS_LINES_AFTER="$(grep -Fxc '.board-superpowers/claims/' "${REPO_ROOT}/.gitignore" || true)"
+assert_eq 'claims/ entry count remains 1' "${CLAIMS_LINES_BEFORE}" "${CLAIMS_LINES_AFTER}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: .gitignore creation when absent
+# ---------------------------------------------------------------------------
+printf 'Scenario 6: .gitignore creation (absent file)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Make sure NO .gitignore exists.
+rm -f "${REPO_ROOT}/.gitignore"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'gitignore-creation exit 0' '0' "${RC}"
+check '.gitignore was created' test -f "${REPO_ROOT}/.gitignore"
+check '.gitignore has comment header' \
+    grep -Fxq '# board-superpowers local state (claim markers are per-session)' \
+        "${REPO_ROOT}/.gitignore"
+check '.gitignore has claims/ entry' \
+    grep -Fxq '.board-superpowers/claims/' "${REPO_ROOT}/.gitignore"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: state.yml initial write — schema, mode, parent dir mode
+# ---------------------------------------------------------------------------
+printf 'Scenario 7: state.yml initial write\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE="${STATE_DIR}/state.yml"
+
+assert_eq 'state.yml write exit 0' '0' "${RC}"
+check 'state.yml exists' test -f "${STATE}"
+assert_eq 'state.yml file mode 0644' '644' "$(file_mode "${STATE}")"
+# The repos/<normalized>/ parent dir should be 0700 (the ~/.board-superpowers
+# tree is mode 0700; new sub-dirs inherit through mkdir -p with the
+# umask, but bootstrap-host.sh chmods 0700 on the root. Here we only
+# require the per-(host, repo) dir is 0700 so secrets are protected.)
+check 'state-dir parent ~/.board-superpowers is mode 0700' \
+    test "$(file_mode "${HOME_DIR}/.board-superpowers")" = "700"
+check 'state-dir per-(host,repo) dir is mode 0700' \
+    test "$(file_mode "${STATE_DIR}")" = "700"
+
+# All five required schema fields present.
+check 'schema_version field' grep -Fxq 'schema_version: 1' "${STATE}"
+check 'repo_bootstrapped_at field' \
+    grep -Eq '^repo_bootstrapped_at: ' "${STATE}"
+check 'last_seen_version_in_repo field' \
+    grep -Fxq 'last_seen_version_in_repo: "0.2.0"' "${STATE}"
+check 'features_enabled field' grep -Eq '^features_enabled:' "${STATE}"
+check 'routing_blocks field — empty list' \
+    grep -Fxq 'routing_blocks: []' "${STATE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 8: labels delegation failure — exit 3, no state.yml leak
+# ---------------------------------------------------------------------------
+printf 'Scenario 8: labels delegation failure\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+# Force the gh stub to fail every label create.
+touch "${STUBS_DIR}/must_fail_labels"
+
+set +e
+run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" >/dev/null 2>&1
+RC=$?
+set -e
+
+assert_eq 'labels-delegation-failure exit 3' '3' "${RC}"
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+check_not 'no state.yml after labels failure' \
+    test -f "${STATE_DIR}/state.yml"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/test-fb2-per-repo.sh
+++ b/tests/test-fb2-per-repo.sh
@@ -7,9 +7,9 @@
 #
 # Scope: Slice 2 of Card 2 — F-B2 engine steps 2a-2d + initial
 # state.yml write. Step 2e (BYO-RDBMS) is slice 3, step 4 (routing
-# block injection) is slice 4 — both OUT of scope here. The state.yml
-# this slice writes contains `routing_blocks: []` (empty list);
-# slice 4 will populate it.
+# block injection) is slice 4 — both shipped now. The routing_blocks
+# assertions below were tightened in slice 4 once injection wiring
+# landed.
 #
 # Contracts under test (8 scenarios):
 #   1. Cold start: tmp HOME + tmp git repo. Stubbed gh returns
@@ -29,8 +29,8 @@
 #   6. .gitignore creation: tmp git repo with NO .gitignore. F-B2
 #      creates it with the entries.
 #   7. state.yml initial write: assert all 5 schema fields present,
-#      routing_blocks is the empty list, file mode 0644, parent dir
-#      0700.
+#      routing_blocks has 2 entries (one per target file — wired by
+#      slice 4), file mode 0644, parent dir 0700.
 #   8. Labels delegation failure: stub gh fails on label create.
 #      Exit 3; F-B2 aborts BEFORE writing state.yml (no state.yml
 #      lingers).
@@ -134,6 +134,12 @@ EOF
     cp "${SCRIPT_UNDER_TEST}" "${target_dir}/scripts/bootstrap-project.sh"
     chmod +x "${target_dir}/scripts/setup-labels.sh"
     chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+    # Slice 4 — routing block injection requires the source-of-truth
+    # file under the plugin tree. Copy it so bootstrap-project.sh
+    # step 4 finds it.
+    mkdir -p "${target_dir}/skills/using-board-superpowers/references"
+    cp "${PLUGIN_ROOT_REAL}/skills/using-board-superpowers/references/agentsmd-routing.md" \
+       "${target_dir}/skills/using-board-superpowers/references/agentsmd-routing.md"
 }
 
 # Initialize a tmp git repo with origin pointing at owner/name.
@@ -362,8 +368,8 @@ check 'state.yml has bootstrap.host item' \
     grep -Fxq '  - bootstrap.host' "${STATE}"
 check 'state.yml has bootstrap.per_repo item' \
     grep -Fxq '  - bootstrap.per_repo' "${STATE}"
-check 'state.yml has empty routing_blocks' \
-    grep -Fxq 'routing_blocks: []' "${STATE}"
+check 'state.yml has routing_blocks with 2 entries (slice 4 wired)' \
+    bash -c "grep -c '^  - target_file:' \"\$1\" | grep -Fxq '2'" _ "${STATE}"
 check 'state.yml has ISO-8601 repo_bootstrapped_at' \
     grep -Eq '^repo_bootstrapped_at: "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"$' "${STATE}"
 
@@ -637,8 +643,8 @@ check 'repo_bootstrapped_at field' \
 check 'last_seen_version_in_repo field' \
     grep -Fxq 'last_seen_version_in_repo: "0.2.0"' "${STATE}"
 check 'features_enabled field' grep -Eq '^features_enabled:' "${STATE}"
-check 'routing_blocks field — empty list' \
-    grep -Fxq 'routing_blocks: []' "${STATE}"
+check 'routing_blocks field populated with both target files (slice 4)' \
+    bash -c "grep -c '^  - target_file:' \"\$1\" | grep -Fxq '2'" _ "${STATE}"
 
 rm -rf "${TMP}"
 

--- a/tests/test-fb2-routing-injection.sh
+++ b/tests/test-fb2-routing-injection.sh
@@ -10,7 +10,7 @@
 # scripts/lib/common.sh + bootstrap-project.sh step 4 invocation +
 # state.yml routing_blocks[] population.
 #
-# Helper-level scenarios (1-10):
+# Helper-level scenarios (1-13):
 #   1. Fresh AGENTS.md (target absent): file created with marker-wrapped
 #      content, hash printed to stdout.
 #   2. Fresh CLAUDE.md too: both files created independently.
@@ -19,23 +19,30 @@
 #   4. AGENTS.md exists with BOTH markers: content between markers
 #      REPLACED, content outside markers preserved verbatim.
 #   5. AGENTS.md exists with OPENING marker but NO CLOSING: exit 5,
-#      verbatim error message printed to stderr (matches Card body),
-#      file unchanged.
+#      verbatim error message printed to stderr (with line number of
+#      the present marker), file unchanged.
 #   6. AGENTS.md exists with CLOSING marker but NO OPENING: exit 5,
-#      same orphan error, file unchanged.
-#   7. CRLF source-of-truth file: helper LF-normalizes for hashing AND
-#      for injection.
+#      same orphan error with the closing marker's actual line number
+#      printed (no `?` placeholder), file unchanged.
+#   7. CRLF source-of-truth file (with fence sentinels): helper
+#      LF-normalizes for hashing AND for injection.
 #   8. UTF-8 BOM at start of AGENTS.md: BOM preserved at byte 0 after
 #      injection; BOM NOT in the hashed region.
 #   9. Hash determinism: same source content → same hash across two
 #      independent target injections.
 #  10. Idempotent re-run: inject into AGENTS.md, then inject again
 #      with same source. Same hash; resulting bytes byte-identical.
+#  11. Source file MISSING fence markers: helper aborts with fatal
+#      error pointing at source file path (exit 1), no target written.
+#  12. Target file with TWO marker pairs: exit 5 with multi-pair error,
+#      file unchanged.
+#  13. Source file with literal target marker INSIDE the fence:
+#      helper aborts with fatal error pointing at source path (exit 1).
 #
-# End-to-end scenarios (11-12):
-#  11. Full F-B2 against tmp repo with no AGENTS.md / CLAUDE.md:
+# End-to-end scenarios (14-15):
+#  14. Full F-B2 against tmp repo with no AGENTS.md / CLAUDE.md:
 #      state.yml routing_blocks[] has 2 entries with correct hashes.
-#  12. Full F-B2 against tmp repo where AGENTS.md has orphan markers:
+#  15. Full F-B2 against tmp repo where AGENTS.md has orphan markers:
 #      F-B2 aborts non-zero; state.yml NOT written.
 #
 # Hermeticity: tmp dirs only; helper-level tests source common.sh
@@ -294,9 +301,9 @@ assert_eq 'orphan-open: file unchanged' "${ORIG}" "$(cat "${TARGET}")"
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
-# Scenario 6: Orphan closing marker — exit 5
+# Scenario 6: Orphan closing marker — exit 5, error names actual line number
 # ---------------------------------------------------------------------------
-printf 'Scenario 6: Orphan closing marker — exit 5\n'
+printf 'Scenario 6: Orphan closing marker — exit 5 with line number\n'
 
 TMP="$(mktemp -d)"
 TARGET="${TMP}/AGENTS.md"
@@ -311,6 +318,9 @@ Some content with a stray closing marker only.
 End of file.
 EOF
 
+# The closing marker is on line 5 of the file above.
+EXPECTED_LINE=5
+
 ORIG="$(cat "${TARGET}")"
 
 set +e
@@ -321,6 +331,14 @@ set -e
 assert_eq 'orphan-close: exit 5' '5' "${RC}"
 check 'orphan-close: error mentions "F-B2 step 4"' \
     bash -c "printf '%s' \"\$1\" | grep -Fq 'F-B2 step 4'" _ "${ERR_OUT}"
+check 'orphan-close: error names "closing" as the present marker kind' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq \"closing marker '<!-- /board-superpowers:routing -->'\"" _ "${ERR_OUT}"
+# shellcheck disable=SC2016  # backticks here are markdown, not command substitution
+check 'orphan-close: error prints actual line number (no `?` placeholder)' \
+    bash -c "printf '%s' \"\$1\" | grep -Eq \"present at line ${EXPECTED_LINE}\"" _ "${ERR_OUT}"
+# shellcheck disable=SC2016  # backticks here are markdown, not command substitution
+check_not 'orphan-close: error does NOT contain a `?` placeholder for line number' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'present at line ?'" _ "${ERR_OUT}"
 assert_eq 'orphan-close: file unchanged' "${ORIG}" "$(cat "${TARGET}")"
 
 rm -rf "${TMP}"
@@ -336,21 +354,31 @@ SOURCE_CRLF="${TMP}/source-crlf.md"
 TARGET_LF="${TMP}/AGENTS-lf.md"
 TARGET_CRLF="${TMP}/AGENTS-crlf.md"
 
-# LF source.
-printf 'line one\nline two\nline three\n' > "${SOURCE_LF}"
-# Same content with CRLF endings.
-printf 'line one\r\nline two\r\nline three\r\n' > "${SOURCE_CRLF}"
+# LF source — fence-bounded routing block content.
+printf '# header docstring\n\n<!-- routing-block:start -->\nline one\nline two\nline three\n<!-- routing-block:end -->\n\nfooter notes\n' > "${SOURCE_LF}"
+# Same content with CRLF endings everywhere.
+printf '# header docstring\r\n\r\n<!-- routing-block:start -->\r\nline one\r\nline two\r\nline three\r\n<!-- routing-block:end -->\r\n\r\nfooter notes\r\n' > "${SOURCE_CRLF}"
 
 set +e
 H_LF="$(inject_in_subshell "${TARGET_LF}" "${SOURCE_LF}" 2>/dev/null)"
 H_CRLF="$(inject_in_subshell "${TARGET_CRLF}" "${SOURCE_CRLF}" 2>/dev/null)"
 set -e
 
+check 'CRLF normalize: target_lf created' test -f "${TARGET_LF}"
+check 'CRLF normalize: target_crlf created' test -f "${TARGET_CRLF}"
 assert_eq 'CRLF normalize: hashes equal (LF-only contract)' \
     "${H_LF}" "${H_CRLF}"
 # Resulting target file must contain NO CR byte (LF-only).
 check_not 'CRLF normalize: target contains no CR bytes' \
     bash -c "tr -dc '\r' < \"\$1\" | grep -q '.'" _ "${TARGET_CRLF}"
+# Injected content must be exactly the three fence-bounded lines, NOT
+# the docstring header or footer notes (those live outside the fence).
+check_not 'CRLF normalize: docstring header NOT injected' \
+    grep -Fq 'header docstring' "${TARGET_LF}"
+check_not 'CRLF normalize: footer notes NOT injected' \
+    grep -Fq 'footer notes' "${TARGET_LF}"
+check 'CRLF normalize: fence-bounded line one IS injected' \
+    grep -Fq 'line one' "${TARGET_LF}"
 
 rm -rf "${TMP}"
 
@@ -421,6 +449,134 @@ set -e
 assert_eq 'idempotent: same hash returned both times' "${HA}" "${HB}"
 assert_eq 'idempotent: file bytes byte-identical after second inject' \
     "${SHA_A}" "${SHA_B}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 11: Source file MISSING fence markers — fatal error, exit 1
+# ---------------------------------------------------------------------------
+printf 'Scenario 11: Source missing fence markers — fatal error\n'
+
+TMP="$(mktemp -d)"
+SOURCE_NO_FENCE="${TMP}/no-fence.md"
+TARGET="${TMP}/AGENTS.md"
+
+# Source without any fence sentinels.
+cat > "${SOURCE_NO_FENCE}" <<'EOF'
+# Just a markdown file with no fence sentinels.
+
+Some routing-block-ish content but no fences anywhere.
+EOF
+
+set +e
+ERR_OUT="$(inject_in_subshell "${TARGET}" "${SOURCE_NO_FENCE}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'no-fence: exit 1' '1' "${RC}"
+check 'no-fence: error mentions "missing fence markers"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'missing fence markers'" _ "${ERR_OUT}"
+check 'no-fence: error names source file path' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq \"\$2\"" _ "${ERR_OUT}" "${SOURCE_NO_FENCE}"
+check 'no-fence: error mentions routing-block:start sentinel' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'routing-block:start'" _ "${ERR_OUT}"
+check 'no-fence: error mentions routing-block:end sentinel' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'routing-block:end'" _ "${ERR_OUT}"
+check_not 'no-fence: target file NOT created' test -f "${TARGET}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 12: Target file with TWO marker pairs — multi-pair detection, exit 5
+# ---------------------------------------------------------------------------
+printf 'Scenario 12: Target with two marker pairs — multi-pair error\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+cat > "${TARGET}" <<'EOF'
+# Existing AGENTS.md
+
+First copy of routing block:
+
+<!-- board-superpowers:routing -->
+Old content #1.
+<!-- /board-superpowers:routing -->
+
+Some intervening content.
+
+Second copy (oops, copy-paste duplication):
+
+<!-- board-superpowers:routing -->
+Old content #2.
+<!-- /board-superpowers:routing -->
+
+End of file.
+EOF
+
+ORIG="$(cat "${TARGET}")"
+
+set +e
+ERR_OUT="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'multi-pair: exit 5' '5' "${RC}"
+check 'multi-pair: error mentions "F-B2 step 4"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'F-B2 step 4'" _ "${ERR_OUT}"
+check 'multi-pair: error reports 2 opening markers' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq '2 opening markers'" _ "${ERR_OUT}"
+check 'multi-pair: error reports 2 closing markers' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq '2 closing markers'" _ "${ERR_OUT}"
+check 'multi-pair: error mentions "Expected exactly 0 or 1 of each"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'Expected exactly 0 or 1 of each'" _ "${ERR_OUT}"
+check 'multi-pair: error mentions Recovery options' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'Recovery options'" _ "${ERR_OUT}"
+check 'multi-pair: error names the target file path' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq \"\$2\"" _ "${ERR_OUT}" "${TARGET}"
+assert_eq 'multi-pair: file unchanged' "${ORIG}" "$(cat "${TARGET}")"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 13: Source has literal target marker INSIDE the fence — abort
+# ---------------------------------------------------------------------------
+printf 'Scenario 13: Source has nested target marker inside fence — abort\n'
+
+TMP="$(mktemp -d)"
+SOURCE_NESTED="${TMP}/source-nested.md"
+TARGET="${TMP}/AGENTS.md"
+
+# Build source where the fenced content includes a literal target
+# marker — this would otherwise inject nested markers.
+cat > "${SOURCE_NESTED}" <<'EOF'
+# Source-of-truth with a maintainer mistake.
+
+<!-- routing-block:start -->
+Some routing content.
+
+Oops, a literal target marker leaked into the body:
+<!-- board-superpowers:routing -->
+
+More content.
+<!-- routing-block:end -->
+
+Maintainer notes.
+EOF
+
+set +e
+ERR_OUT="$(inject_in_subshell "${TARGET}" "${SOURCE_NESTED}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'marker-in-source: exit 1' '1' "${RC}"
+check 'marker-in-source: error mentions "literal target-file marker"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'literal target-file marker'" _ "${ERR_OUT}"
+check 'marker-in-source: error names source file path' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq \"\$2\"" _ "${ERR_OUT}" "${SOURCE_NESTED}"
+check 'marker-in-source: error mentions a line number' \
+    bash -c "printf '%s' \"\$1\" | grep -Eq 'at line [0-9]+'" _ "${ERR_OUT}"
+check_not 'marker-in-source: target file NOT created' test -f "${TARGET}"
 
 rm -rf "${TMP}"
 
@@ -587,9 +743,9 @@ normalized_state_dir() {
 }
 
 # ---------------------------------------------------------------------------
-# Scenario 11: Full F-B2 — state.yml routing_blocks[] populated for both files
+# Scenario 14: Full F-B2 — state.yml routing_blocks[] populated for both files
 # ---------------------------------------------------------------------------
-printf 'Scenario 11: end-to-end F-B2 routing injection populates state.yml\n'
+printf 'Scenario 14: end-to-end F-B2 routing injection populates state.yml\n'
 
 TMP="$(mktemp -d)"
 HOME_DIR="${TMP}/home"
@@ -662,9 +818,9 @@ check 'e2e: state.yml mentions CLAUDE.md target' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
-# Scenario 12: Full F-B2 with orphan markers — abort, no state.yml written
+# Scenario 15: Full F-B2 with orphan markers — abort, no state.yml written
 # ---------------------------------------------------------------------------
-printf 'Scenario 12: end-to-end F-B2 with orphan markers — abort\n'
+printf 'Scenario 15: end-to-end F-B2 with orphan markers — abort\n'
 
 TMP="$(mktemp -d)"
 HOME_DIR="${TMP}/home"

--- a/tests/test-fb2-routing-injection.sh
+++ b/tests/test-fb2-routing-injection.sh
@@ -1,0 +1,713 @@
+#!/usr/bin/env bash
+# tests/test-fb2-routing-injection.sh — assert F-B2 step 4
+# (routing block injection + tamper hash) satisfies the contract per
+# docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+# § 1.5.2 step 4 + 02-hook-contracts.md § "Intent-injection markers"
+# (marker pair grammar) + 03-config-schemas.md (state.yml
+# routing_blocks[] schema).
+#
+# Scope: Slice 4 of Card 2 — bsp_inject_routing_block helper in
+# scripts/lib/common.sh + bootstrap-project.sh step 4 invocation +
+# state.yml routing_blocks[] population.
+#
+# Helper-level scenarios (1-10):
+#   1. Fresh AGENTS.md (target absent): file created with marker-wrapped
+#      content, hash printed to stdout.
+#   2. Fresh CLAUDE.md too: both files created independently.
+#   3. AGENTS.md exists with NO markers: block APPENDED with markers,
+#      original content preserved above the new block.
+#   4. AGENTS.md exists with BOTH markers: content between markers
+#      REPLACED, content outside markers preserved verbatim.
+#   5. AGENTS.md exists with OPENING marker but NO CLOSING: exit 5,
+#      verbatim error message printed to stderr (matches Card body),
+#      file unchanged.
+#   6. AGENTS.md exists with CLOSING marker but NO OPENING: exit 5,
+#      same orphan error, file unchanged.
+#   7. CRLF source-of-truth file: helper LF-normalizes for hashing AND
+#      for injection.
+#   8. UTF-8 BOM at start of AGENTS.md: BOM preserved at byte 0 after
+#      injection; BOM NOT in the hashed region.
+#   9. Hash determinism: same source content → same hash across two
+#      independent target injections.
+#  10. Idempotent re-run: inject into AGENTS.md, then inject again
+#      with same source. Same hash; resulting bytes byte-identical.
+#
+# End-to-end scenarios (11-12):
+#  11. Full F-B2 against tmp repo with no AGENTS.md / CLAUDE.md:
+#      state.yml routing_blocks[] has 2 entries with correct hashes.
+#  12. Full F-B2 against tmp repo where AGENTS.md has orphan markers:
+#      F-B2 aborts non-zero; state.yml NOT written.
+#
+# Hermeticity: tmp dirs only; helper-level tests source common.sh
+# directly; end-to-end tests use the same stub-gh / tmp HOME shape as
+# test-fb2-byo-rdbms.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMMON_LIB="${PLUGIN_ROOT_REAL}/scripts/lib/common.sh"
+SOURCE_FILE_REAL="${PLUGIN_ROOT_REAL}/skills/using-board-superpowers/references/agentsmd-routing.md"
+BOOTSTRAP_SCRIPT="${PLUGIN_ROOT_REAL}/scripts/bootstrap-project.sh"
+
+if [ ! -f "${COMMON_LIB}" ]; then
+    printf 'FATAL: %s not found\n' "${COMMON_LIB}" >&2
+    exit 99
+fi
+if [ ! -f "${SOURCE_FILE_REAL}" ]; then
+    printf 'FATAL: %s not found\n' "${SOURCE_FILE_REAL}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"; shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Source the helper into a subshell-style invocation. We can't just
+# source common.sh into THIS shell because it might pollute global
+# state; instead each call invokes a fresh subshell that sources it.
+inject_in_subshell() {
+    local target="$1"
+    local source="$2"
+    bash -c '
+        set -euo pipefail
+        SCRIPT_DIR="$(cd "$(dirname "$1")" && pwd)"
+        # shellcheck source=/dev/null
+        . "$1"
+        bsp_inject_routing_block "$2" "$3"
+    ' _ "${COMMON_LIB}" "${target}" "${source}"
+}
+
+# Cross-platform sha256 of a file
+sha256_of_file() {
+    python3 -c '
+import hashlib, sys
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())
+' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Fresh AGENTS.md — target absent, file created
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: Fresh AGENTS.md created from scratch\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+set +e
+HASH1="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>"${TMP}/err1")"
+RC=$?
+set -e
+
+assert_eq 'fresh AGENTS.md: exit 0' '0' "${RC}"
+check 'fresh AGENTS.md: file created' test -f "${TARGET}"
+check 'fresh AGENTS.md: opening marker present' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${TARGET}"
+check 'fresh AGENTS.md: closing marker present' \
+    grep -Fq '<!-- /board-superpowers:routing -->' "${TARGET}"
+check 'fresh AGENTS.md: stdout produced 64-char hex hash' \
+    bash -c "printf '%s' \"\$1\" | grep -Eq '^[0-9a-f]{64}$'" _ "${HASH1}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Fresh CLAUDE.md alongside AGENTS.md — both created independently
+# ---------------------------------------------------------------------------
+printf 'Scenario 2: Fresh CLAUDE.md alongside AGENTS.md\n'
+
+TMP="$(mktemp -d)"
+AGENTS="${TMP}/AGENTS.md"
+CLAUDE="${TMP}/CLAUDE.md"
+
+set +e
+HA="$(inject_in_subshell "${AGENTS}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+HC="$(inject_in_subshell "${CLAUDE}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+set -e
+
+check 'fresh both: AGENTS.md exists' test -f "${AGENTS}"
+check 'fresh both: CLAUDE.md exists' test -f "${CLAUDE}"
+assert_eq 'fresh both: hashes equal (same source)' "${HA}" "${HC}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: AGENTS.md exists, NO markers — APPEND with markers
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: AGENTS.md exists without markers — APPEND\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+cat > "${TARGET}" <<'EOF'
+# Existing AGENTS.md
+
+This is some pre-existing project content. It MUST be preserved.
+
+## A second section
+
+End of pre-existing content.
+EOF
+ORIG_BYTES="$(wc -c < "${TARGET}")"
+
+set +e
+HASH3="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'no-markers append: exit 0' '0' "${RC}"
+check 'no-markers append: original content preserved' \
+    grep -Fq 'This is some pre-existing project content' "${TARGET}"
+check 'no-markers append: original second section preserved' \
+    grep -Fq '## A second section' "${TARGET}"
+check 'no-markers append: opening marker present' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${TARGET}"
+check 'no-markers append: closing marker present' \
+    grep -Fq '<!-- /board-superpowers:routing -->' "${TARGET}"
+NEW_BYTES="$(wc -c < "${TARGET}")"
+check 'no-markers append: file grew (block was appended)' \
+    test "${NEW_BYTES}" -gt "${ORIG_BYTES}"
+# Markers must come AFTER the original content (append, not prepend).
+ORIG_LINE_NUM="$(grep -n 'A second section' "${TARGET}" | head -n1 | cut -d: -f1)"
+OPEN_LINE_NUM="$(grep -n '<!-- board-superpowers:routing -->' "${TARGET}" | head -n1 | cut -d: -f1)"
+check 'no-markers append: markers AFTER original content' \
+    test "${OPEN_LINE_NUM}" -gt "${ORIG_LINE_NUM}"
+check 'no-markers append: stdout is 64-char hex' \
+    bash -c "printf '%s' \"\$1\" | grep -Eq '^[0-9a-f]{64}$'" _ "${HASH3}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: AGENTS.md exists with BOTH markers — REPLACE between markers
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: AGENTS.md exists with both markers — REPLACE\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+cat > "${TARGET}" <<'EOF'
+# Existing AGENTS.md
+
+Pre-block content goes here.
+
+<!-- board-superpowers:routing -->
+This is a STALE routing block that MUST be replaced wholesale.
+Old plugin version v0.0.1.
+<!-- /board-superpowers:routing -->
+
+Post-block content goes here.
+EOF
+
+set +e
+HASH4="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'both-markers replace: exit 0' '0' "${RC}"
+check_not 'both-markers replace: stale content removed' \
+    grep -Fq 'STALE routing block' "${TARGET}"
+check_not 'both-markers replace: stale version string removed' \
+    grep -Fq 'v0.0.1' "${TARGET}"
+check 'both-markers replace: pre-block content preserved' \
+    grep -Fq 'Pre-block content goes here' "${TARGET}"
+check 'both-markers replace: post-block content preserved' \
+    grep -Fq 'Post-block content goes here' "${TARGET}"
+# Idempotency: hash3 (append) and hash4 (replace) should equal — same source.
+assert_eq 'both-markers replace: hash matches scenario-3 hash (same source)' \
+    "${HASH3}" "${HASH4}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: Orphan opening marker — exit 5
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: Orphan opening marker — exit 5\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+cat > "${TARGET}" <<'EOF'
+# Existing AGENTS.md
+
+Some content.
+
+<!-- board-superpowers:routing -->
+Routing content but no closing marker after this.
+
+End of file (no closing marker).
+EOF
+
+ORIG="$(cat "${TARGET}")"
+
+set +e
+ERR_OUT="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'orphan-open: exit 5' '5' "${RC}"
+check 'orphan-open: error mentions "F-B2 step 4"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'F-B2 step 4'" _ "${ERR_OUT}"
+check 'orphan-open: error mentions "cannot proceed"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'cannot proceed'" _ "${ERR_OUT}"
+check 'orphan-open: error names the target file path' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq \"\$2\"" _ "${ERR_OUT}" "${TARGET}"
+check 'orphan-open: error mentions Recovery options' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'Recovery options'" _ "${ERR_OUT}"
+check 'orphan-open: error mentions "state.yml" not written' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'state.yml'" _ "${ERR_OUT}"
+assert_eq 'orphan-open: file unchanged' "${ORIG}" "$(cat "${TARGET}")"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Orphan closing marker — exit 5
+# ---------------------------------------------------------------------------
+printf 'Scenario 6: Orphan closing marker — exit 5\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+cat > "${TARGET}" <<'EOF'
+# Existing AGENTS.md
+
+Some content with a stray closing marker only.
+
+<!-- /board-superpowers:routing -->
+
+End of file.
+EOF
+
+ORIG="$(cat "${TARGET}")"
+
+set +e
+ERR_OUT="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'orphan-close: exit 5' '5' "${RC}"
+check 'orphan-close: error mentions "F-B2 step 4"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'F-B2 step 4'" _ "${ERR_OUT}"
+assert_eq 'orphan-close: file unchanged' "${ORIG}" "$(cat "${TARGET}")"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: CRLF source — helper LF-normalizes for hashing AND injection
+# ---------------------------------------------------------------------------
+printf 'Scenario 7: CRLF source-of-truth file — LF normalization\n'
+
+TMP="$(mktemp -d)"
+SOURCE_LF="${TMP}/source-lf.md"
+SOURCE_CRLF="${TMP}/source-crlf.md"
+TARGET_LF="${TMP}/AGENTS-lf.md"
+TARGET_CRLF="${TMP}/AGENTS-crlf.md"
+
+# LF source.
+printf 'line one\nline two\nline three\n' > "${SOURCE_LF}"
+# Same content with CRLF endings.
+printf 'line one\r\nline two\r\nline three\r\n' > "${SOURCE_CRLF}"
+
+set +e
+H_LF="$(inject_in_subshell "${TARGET_LF}" "${SOURCE_LF}" 2>/dev/null)"
+H_CRLF="$(inject_in_subshell "${TARGET_CRLF}" "${SOURCE_CRLF}" 2>/dev/null)"
+set -e
+
+assert_eq 'CRLF normalize: hashes equal (LF-only contract)' \
+    "${H_LF}" "${H_CRLF}"
+# Resulting target file must contain NO CR byte (LF-only).
+check_not 'CRLF normalize: target contains no CR bytes' \
+    bash -c "tr -dc '\r' < \"\$1\" | grep -q '.'" _ "${TARGET_CRLF}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 8: UTF-8 BOM at byte 0 of target — preserved; not hashed
+# ---------------------------------------------------------------------------
+printf 'Scenario 8: UTF-8 BOM at start of AGENTS.md — preserved\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+# Build a target with BOM + both markers + stale content between.
+python3 - "${TARGET}" <<'PY'
+import sys
+p = sys.argv[1]
+data = b'\xef\xbb\xbf' + b"# Title\n\n<!-- board-superpowers:routing -->\nold\n<!-- /board-superpowers:routing -->\n\nMore content.\n"
+open(p, "wb").write(data)
+PY
+
+set +e
+HASH8="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'BOM preserve: exit 0' '0' "${RC}"
+# Verify byte 0..2 are still EF BB BF.
+BOM_HEX="$(python3 -c "import sys; b=open(sys.argv[1],'rb').read(3); print(b.hex())" "${TARGET}")"
+assert_eq 'BOM preserve: bytes 0-2 are EF BB BF' 'efbbbf' "${BOM_HEX}"
+# Hash must equal scenario-3 hash (same source-of-truth file).
+assert_eq 'BOM preserve: hash equals canonical source hash' \
+    "${HASH3}" "${HASH8}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 9: Hash determinism across two independent injections
+# ---------------------------------------------------------------------------
+printf 'Scenario 9: Hash determinism across two injections\n'
+
+TMP="$(mktemp -d)"
+T1="${TMP}/A.md"
+T2="${TMP}/B.md"
+
+set +e
+H1="$(inject_in_subshell "${T1}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+H2="$(inject_in_subshell "${T2}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+set -e
+
+assert_eq 'hash determinism: H1 == H2' "${H1}" "${H2}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 10: Idempotent re-run (inject twice; bytes identical)
+# ---------------------------------------------------------------------------
+printf 'Scenario 10: Idempotent re-run produces byte-identical output\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+set +e
+HA="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+SHA_A="$(sha256_of_file "${TARGET}")"
+HB="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+SHA_B="$(sha256_of_file "${TARGET}")"
+set -e
+
+assert_eq 'idempotent: same hash returned both times' "${HA}" "${HB}"
+assert_eq 'idempotent: file bytes byte-identical after second inject' \
+    "${SHA_A}" "${SHA_B}"
+
+rm -rf "${TMP}"
+
+# ===========================================================================
+# End-to-end: full F-B2 invocation populates state.yml routing_blocks[]
+# ===========================================================================
+
+# Replicate the make_stub_plugin_root + stub_gh + canonical Status helpers
+# from test-fb2-byo-rdbms.sh / test-fb2-per-repo.sh.
+
+make_stub_plugin_root() {
+    local version="$1"
+    local target_dir="$2"
+    mkdir -p "${target_dir}/.claude-plugin"
+    cat > "${target_dir}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+    mkdir -p "${target_dir}/scripts/lib"
+    cp "${PLUGIN_ROOT_REAL}/scripts/lib/common.sh" "${target_dir}/scripts/lib/common.sh"
+    cp "${PLUGIN_ROOT_REAL}/scripts/setup-labels.sh" "${target_dir}/scripts/setup-labels.sh"
+    cp "${BOOTSTRAP_SCRIPT}" "${target_dir}/scripts/bootstrap-project.sh"
+    chmod +x "${target_dir}/scripts/setup-labels.sh"
+    chmod +x "${target_dir}/scripts/bootstrap-project.sh"
+
+    # The injection source-of-truth file MUST live at the canonical
+    # path inside the plugin tree. Copy it.
+    mkdir -p "${target_dir}/skills/using-board-superpowers/references"
+    cp "${SOURCE_FILE_REAL}" \
+       "${target_dir}/skills/using-board-superpowers/references/agentsmd-routing.md"
+}
+
+init_tmp_repo() {
+    local repo_root="$1"
+    local owner_name="$2"
+    mkdir -p "${repo_root}"
+    git -C "${repo_root}" init --quiet
+    git -C "${repo_root}" remote add origin "https://github.com/${owner_name}.git"
+    git -C "${repo_root}" config user.email "test@example.com"
+    git -C "${repo_root}" config user.name  "test"
+}
+
+stub_gh() {
+    local dir="$1"
+    cat > "${dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -eu
+
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+LABELS_FILE="${STUB_DIR}/labels.json"
+STATUS_OPTS_FILE="${STUB_DIR}/status_opts"
+
+if [ ! -f "${LABELS_FILE}" ]; then
+    printf '[]\n' > "${LABELS_FILE}"
+fi
+
+case "${1:-}" in
+    label)
+        shift
+        case "${1:-}" in
+            list)
+                cat "${LABELS_FILE}"
+                exit 0
+                ;;
+            create)
+                shift
+                NAME="${1:?label create needs NAME}"
+                shift
+                EXISTS="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print('1' if any(l['name']==sys.argv[2] for l in data) else '0')
+" "${LABELS_FILE}" "${NAME}")"
+                if [ "${EXISTS}" = "1" ]; then
+                    printf 'error: name "%s" already used by another label\n' "${NAME}" >&2
+                    exit 1
+                fi
+                python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+data.append({'name': sys.argv[2]})
+with open(sys.argv[1], 'w') as f:
+    json.dump(data, f)
+" "${LABELS_FILE}" "${NAME}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    project)
+        shift
+        case "${1:-}" in
+            field-list)
+                python3 -c "
+import json, sys, os
+opts_path = sys.argv[1]
+options = []
+if os.path.exists(opts_path):
+    with open(opts_path) as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line:
+                options.append({'id': 'opt-' + line.replace(' ', '-').lower(),
+                                'name': line})
+fields = []
+if options:
+    fields.append({'id': 'fld-status', 'name': 'Status', 'options': options})
+print(json.dumps({'fields': fields}))
+" "${STATUS_OPTS_FILE}"
+                exit 0
+                ;;
+            *)
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "${dir}/gh"
+}
+
+CANONICAL_STATUS="Backlog
+Ready
+In Progress
+In Review
+Done
+Blocked"
+
+# Run bootstrap-project.sh against a tmp env. Stdin is /dev/null so
+# the BYO-RDBMS interactive prompt declines (Path C decline).
+run_bootstrap() {
+    local home_dir="$1"; shift
+    local plugin_root="$1"; shift
+    local stubs_dir="$1"; shift
+    env -i HOME="${home_dir}" PATH="${stubs_dir}:/usr/bin:/bin" \
+        bash "${plugin_root}/scripts/bootstrap-project.sh" \
+            --plugin-root "${plugin_root}" \
+            "$@" </dev/null
+}
+
+normalized_state_dir() {
+    local home_dir="$1"
+    local repo_root="$2"
+    local canonical
+    canonical="$(cd "${repo_root}" && git rev-parse --show-toplevel 2>/dev/null)"
+    if [ -z "${canonical}" ]; then
+        canonical="$(cd "${repo_root}" && pwd -P)"
+    fi
+    local stripped="${canonical#/}"
+    stripped="${stripped%/}"
+    local normalized="${stripped//\//-}"
+    printf '%s/.board-superpowers/repos/%s\n' "${home_dir}" "${normalized}"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 11: Full F-B2 — state.yml routing_blocks[] populated for both files
+# ---------------------------------------------------------------------------
+printf 'Scenario 11: end-to-end F-B2 routing injection populates state.yml\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+set +e
+ALL_OUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'e2e: bootstrap exit 0' '0' "${RC}"
+check 'e2e: AGENTS.md created in repo' test -f "${REPO_ROOT}/AGENTS.md"
+check 'e2e: CLAUDE.md created in repo' test -f "${REPO_ROOT}/CLAUDE.md"
+check 'e2e: AGENTS.md has marker pair' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\" && grep -Fq '<!-- /board-superpowers:routing -->' \"\$1\"" _ "${REPO_ROOT}/AGENTS.md"
+check 'e2e: CLAUDE.md has marker pair' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\" && grep -Fq '<!-- /board-superpowers:routing -->' \"\$1\"" _ "${REPO_ROOT}/CLAUDE.md"
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+check 'e2e: state.yml created' test -f "${STATE_FILE}"
+
+# Parse routing_blocks count via python (flat YAML).
+COUNT="$(python3 -c "
+import sys
+data = open(sys.argv[1]).read()
+# Simple YAML-ish scan: count list items under 'routing_blocks:'.
+lines = data.splitlines()
+in_rb = False
+n = 0
+for line in lines:
+    if line.startswith('routing_blocks:'):
+        in_rb = True
+        continue
+    if in_rb:
+        if line.startswith('  - target_file:'):
+            n += 1
+        elif line and not line.startswith(' '):
+            break
+print(n)
+" "${STATE_FILE}")"
+assert_eq 'e2e: state.yml has 2 routing_blocks entries' '2' "${COUNT}"
+
+# Verify the recorded hashes use sha256: prefix and 64 hex chars.
+HASH_LINES="$(grep -E 'block_hash:' "${STATE_FILE}" || true)"
+HASH_COUNT="$(printf '%s\n' "${HASH_LINES}" | grep -c '^' || true)"
+assert_eq 'e2e: state.yml has 2 block_hash entries' '2' "${HASH_COUNT}"
+check 'e2e: every block_hash is sha256:<64-hex>' \
+    bash -c "printf '%s\n' \"\$1\" | grep -Eq 'sha256:[0-9a-f]{64}'" _ "${HASH_LINES}"
+
+# Verify state.yml also lists target_file: AGENTS.md and CLAUDE.md.
+check 'e2e: state.yml mentions AGENTS.md target' \
+    bash -c "grep -Eq 'target_file:.*AGENTS\\.md' \"\$1\"" _ "${STATE_FILE}"
+check 'e2e: state.yml mentions CLAUDE.md target' \
+    bash -c "grep -Eq 'target_file:.*CLAUDE\\.md' \"\$1\"" _ "${STATE_FILE}"
+
+# Suppress warnings about unused vars
+: "${ALL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 12: Full F-B2 with orphan markers — abort, no state.yml written
+# ---------------------------------------------------------------------------
+printf 'Scenario 12: end-to-end F-B2 with orphan markers — abort\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-seed AGENTS.md with orphan opening marker.
+cat > "${REPO_ROOT}/AGENTS.md" <<'EOF'
+# Existing project AGENTS.md
+
+<!-- board-superpowers:routing -->
+Half a routing block — closing marker missing.
+
+Some other content.
+EOF
+
+set +e
+ERR_OUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1 1>/dev/null)"
+RC=$?
+set -e
+
+# Bootstrap should abort non-zero.
+check 'orphan e2e: exit non-zero' bash -c "[ \"\$1\" != '0' ]" _ "${RC}"
+check 'orphan e2e: stderr mentions "F-B2 step 4"' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'F-B2 step 4'" _ "${ERR_OUT}"
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+check_not 'orphan e2e: state.yml NOT written' test -f "${STATE_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n— TOTALS —\nPASS: %d\nFAIL: %d\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/tests/test-hook-invoke-marker.sh
+++ b/tests/test-hook-invoke-marker.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+# tests/test-hook-invoke-marker.sh — assert hooks/session-start.sh
+# emits the right INVOKE: marker (or none) per state-file presence,
+# stays self-contained, sanitizes inputs, and never blocks on failure.
+#
+# Spec under test:
+#   docs/architecture/0005-contracts/02-hook-contracts.md
+#     § "Intent-injection markers" — marker grammar + at-most-one rule.
+#   docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+#     § "three-layer alert + intent-injection strategy" — Layer 1 role.
+#
+# Hermeticity: every scenario uses a fresh tmp HOME, a fresh tmp git
+# repo as PWD, a stub plugin root with a controllable plugin.json,
+# and no reach-through to the real ~/.board-superpowers.
+#
+# shellcheck disable=SC2016
+# Single-quoted bash -c bodies are intentional throughout: the literal
+# `$1` must reach the inner shell, not be expanded by this one. The
+# context value travels via the trailing positional arg.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${PLUGIN_ROOT_REAL}/hooks/session-start.sh"
+
+if [ ! -f "${HOOK}" ]; then
+    printf 'FATAL: %s not found\n' "${HOOK}" >&2
+    exit 99
+fi
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+check_not() {
+    local label="$1"
+    shift
+    if "$@"; then
+        printf '  FAIL — %s\n' "${label}" >&2
+        FAIL=$((FAIL + 1))
+    else
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_eq() {
+    local label="$1"; local expected="$2"; local actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s\n    expected: %q\n    actual:   %q\n' \
+            "${label}" "${expected}" "${actual}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Build a tmp plugin-root tree containing the real check-deps.sh +
+# session-start.sh + lib (we WILL NOT source it from the hook, but
+# the dep-check script imports nothing). plugin.json carries a stub
+# version. Returns path on stdout.
+make_plugin_root() {
+    local target="$1"
+    local version="$2"
+    mkdir -p "${target}/.claude-plugin"
+    mkdir -p "${target}/hooks"
+    mkdir -p "${target}/scripts/lib"
+    cat > "${target}/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "board-superpowers",
+  "version": "${version}",
+  "description": "stub for tests",
+  "license": "MIT"
+}
+EOF
+    cp "${PLUGIN_ROOT_REAL}/hooks/session-start.sh" "${target}/hooks/session-start.sh"
+    cp "${PLUGIN_ROOT_REAL}/scripts/check-deps.sh" "${target}/scripts/check-deps.sh"
+    # common.sh is referenced by other scripts, but NOT by the hook.
+    # Copy it for parity even though we won't load it from the hook.
+    cp "${PLUGIN_ROOT_REAL}/scripts/lib/common.sh" "${target}/scripts/lib/common.sh"
+    chmod +x "${target}/hooks/session-start.sh" "${target}/scripts/check-deps.sh"
+}
+
+# Initialize a hermetic git repo with a routing-block-bearing
+# AGENTS.md so check-deps.sh in --machine mode emits empty stdout
+# (i.e. "all good") under default conditions. Caller may override.
+make_repo() {
+    local repo_dir="$1"
+    mkdir -p "${repo_dir}"
+    (
+        cd "${repo_dir}"
+        git init -q
+        git config user.email test@example.com
+        git config user.name 'test'
+        cat > AGENTS.md <<'EOF'
+# Test repo AGENTS.md
+
+## board-superpowers session routing
+
+Routing block contents.
+EOF
+        cat > CLAUDE.md <<'EOF'
+# Test repo CLAUDE.md
+
+## board-superpowers session routing
+
+Routing block contents.
+EOF
+        git add . >/dev/null 2>&1
+        git commit -q -m initial >/dev/null 2>&1 || true
+    )
+}
+
+# Run the hook from a hermetic environment. Args:
+#   $1 = plugin_root, $2 = home, $3 = repo (becomes PWD).
+run_hook() {
+    local plugin_root="$1"; local home_dir="$2"; local repo_dir="$3"
+    (
+        cd "${repo_dir}"
+        HOME="${home_dir}" \
+        CLAUDE_PLUGIN_ROOT="${plugin_root}" \
+        bash "${plugin_root}/hooks/session-start.sh"
+    )
+}
+
+# Extract additionalContext text from the JSON stdout payload.
+extract_additional_context() {
+    local payload="$1"
+    PAYLOAD="${payload}" python3 -c '
+import json, os, sys
+data = json.loads(os.environ["PAYLOAD"])
+sys.stdout.write(data["hookSpecificOutput"]["additionalContext"])
+'
+}
+
+# Verify the payload parses as valid JSON.
+assert_valid_json() {
+    local label="$1"; local payload="$2"
+    if PAYLOAD="${payload}" python3 -c '
+import json, os, sys
+json.loads(os.environ["PAYLOAD"])
+' >/dev/null 2>&1; then
+        printf '  PASS — %s\n' "${label}"
+        PASS=$((PASS + 1))
+    else
+        printf '  FAIL — %s (invalid JSON)\n' "${label}" >&2
+        printf '    payload: %s\n' "${payload}" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Resolve the normalized directory name for a repo path the same way
+# the hook does (and the way bsp_normalize_repo_path in common.sh
+# does). Used to write the per-repo state.yml under the right path.
+normalize_for_test() {
+    local p="$1"
+    p="${p%/}"
+    p="${p#/}"
+    printf '%s\n' "${p//\//-}"
+}
+
+# A "clean" check-deps stub that emits empty output (everything OK) —
+# used to capture happy-path fixtures whose dep-alert section stays
+# silent. Hermetic-HOME real check-deps.sh otherwise flags `gh` as
+# unauthenticated under the tmp HOME (its credential store is at
+# $HOME/.config/gh/), which is a test artifact, not the user-facing
+# steady state we want pinned in the fixture.
+install_clean_check_deps() {
+    local target_root="$1"
+    cat > "${target_root}/scripts/check-deps.sh" <<'EOF'
+#!/usr/bin/env bash
+# Clean stub for fixture capture. Emits nothing in --machine mode
+# (caller-side `[ -z "$output" ]` interprets this as "all good").
+exit 0
+EOF
+    chmod +x "${target_root}/scripts/check-deps.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: both state files present → no INVOKE marker
+# ---------------------------------------------------------------------------
+printf 'Scenario 1: both state files present (no INVOKE marker)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+install_clean_check_deps "${PLUGIN_ROOT}"
+make_repo "${REPO_DIR}"
+
+# Write manifest.yml
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+host_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version: "0.2.0"
+EOF
+
+# Write per-repo state.yml at the normalized path. The repo's git
+# toplevel may differ from REPO_DIR (e.g. macOS /private/var symlink
+# resolution), so we have to use what the hook will actually compute.
+NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+cat > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml" <<EOF
+schema_version: 1
+repo_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version_in_repo: "0.2.0"
+EOF
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON shape valid' "${PAYLOAD}"
+
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check 'version banner present' \
+    bash -c 'printf "%s" "$1" | grep -q "board-superpowers v0.2.0 loaded."' _ "${CONTEXT}"
+check_not 'no INVOKE marker' \
+    bash -c 'printf "%s" "$1" | grep -q "^INVOKE:"' _ "${CONTEXT}"
+check_not 'no dep alert (clean check-deps stub)' \
+    bash -c 'printf "%s" "$1" | grep -q "dependency check or routing-block"' _ "${CONTEXT}"
+
+# Capture this payload as the post-bootstrap fixture.
+mkdir -p "${PLUGIN_ROOT_REAL}/tests/fixtures"
+printf '%s\n' "${PAYLOAD}" > "${PLUGIN_ROOT_REAL}/tests/fixtures/session-start-v0.2.0-post-bootstrap.txt"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 2: manifest absent → INVOKE: bootstrapping-repo with manifest reason
+# ---------------------------------------------------------------------------
+printf 'Scenario 2: manifest absent (INVOKE: bootstrapping-repo)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+install_clean_check_deps "${PLUGIN_ROOT}"
+make_repo "${REPO_DIR}"
+
+# manifest.yml absent. state.yml absent. Per spec, manifest-absent
+# wins the REASON line.
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON shape valid' "${PAYLOAD}"
+
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check 'INVOKE: bootstrapping-repo present' \
+    bash -c 'printf "%s" "$1" | grep -qE "^INVOKE: bootstrapping-repo$"' _ "${CONTEXT}"
+check 'REASON mentions manifest.yml' \
+    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*manifest\\.yml"' _ "${CONTEXT}"
+
+# At-most-one rule: only one INVOKE line in the payload.
+INVOKE_COUNT="$(printf '%s' "${CONTEXT}" | grep -cE "^INVOKE:" || true)"
+assert_eq 'exactly one INVOKE line' '1' "${INVOKE_COUNT}"
+
+# Capture this payload as the pre-bootstrap fixture.
+printf '%s\n' "${PAYLOAD}" > "${PLUGIN_ROOT_REAL}/tests/fixtures/session-start-v0.2.0-pre-bootstrap.txt"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 3: state.yml absent (manifest present)
+# ---------------------------------------------------------------------------
+printf 'Scenario 3: per-repo state.yml absent (manifest present)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+make_repo "${REPO_DIR}"
+
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+host_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version: "0.2.0"
+EOF
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0' '0' "$(printf '%d' "${RC}")"
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check 'INVOKE: bootstrapping-repo present' \
+    bash -c 'printf "%s" "$1" | grep -qE "^INVOKE: bootstrapping-repo$"' _ "${CONTEXT}"
+check 'REASON mentions state.yml' \
+    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*state\\.yml"' _ "${CONTEXT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 4: both state files absent → exactly one marker emitted
+# ---------------------------------------------------------------------------
+printf 'Scenario 4: both state files absent (single marker)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+make_repo "${REPO_DIR}"
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0' '0' "$(printf '%d' "${RC}")"
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+INVOKE_COUNT="$(printf '%s' "${CONTEXT}" | grep -cE "^INVOKE:" || true)"
+REASON_COUNT="$(printf '%s' "${CONTEXT}" | grep -cE "^REASON:" || true)"
+assert_eq 'exactly one INVOKE line (no double-emit)' '1' "${INVOKE_COUNT}"
+assert_eq 'exactly one REASON line' '1' "${REASON_COUNT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 5: dep-check failure (gh missing) → warning included, exit still 0
+# ---------------------------------------------------------------------------
+printf 'Scenario 5: dep-check missing dep (non-blocking warning)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+make_repo "${REPO_DIR}"
+
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+host_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version: "0.2.0"
+EOF
+NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+cat > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml" <<EOF
+schema_version: 1
+last_seen_version_in_repo: "0.2.0"
+EOF
+
+# Drop gh from PATH for this invocation. Build a sanitized PATH that
+# excludes any directory containing `gh`.
+SANITIZED_PATH=""
+IFS=':' read -ra PATH_PARTS <<< "${PATH}"
+for p in "${PATH_PARTS[@]}"; do
+    [ -z "${p}" ] && continue
+    if [ -x "${p}/gh" ]; then
+        continue
+    fi
+    if [ -z "${SANITIZED_PATH}" ]; then
+        SANITIZED_PATH="${p}"
+    else
+        SANITIZED_PATH="${SANITIZED_PATH}:${p}"
+    fi
+done
+
+set +e
+PAYLOAD="$(cd "${REPO_DIR}" && \
+    HOME="${HOME_DIR}" \
+    CLAUDE_PLUGIN_ROOT="${PLUGIN_ROOT}" \
+    PATH="${SANITIZED_PATH}" \
+    bash "${PLUGIN_ROOT}/hooks/session-start.sh")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0 even with missing gh' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON shape valid with dep failure' "${PAYLOAD}"
+
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check 'dep alert line present' \
+    bash -c 'printf "%s" "$1" | grep -qE "dependency check or routing-block issue"' _ "${CONTEXT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6: hook exits 0 even when check-deps.sh is missing
+# ---------------------------------------------------------------------------
+printf 'Scenario 6: check-deps.sh missing (hook still exits 0)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+make_repo "${REPO_DIR}"
+
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+host_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version: "0.2.0"
+EOF
+NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+cat > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml" <<EOF
+schema_version: 1
+EOF
+
+# Remove check-deps.sh entirely.
+rm -f "${PLUGIN_ROOT}/scripts/check-deps.sh"
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0 with missing check-deps.sh' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON still valid' "${PAYLOAD}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 7: payload always parses as JSON
+# ---------------------------------------------------------------------------
+printf 'Scenario 7: JSON validity across permutations\n'
+
+for manifest_state in present absent; do
+    for state_yml in present absent; do
+        TMP="$(mktemp -d)"
+        HOME_DIR="${TMP}/home"
+        PLUGIN_ROOT="${TMP}/plugin"
+        REPO_DIR="${TMP}/repo"
+        mkdir -p "${HOME_DIR}/.board-superpowers"
+        make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+        make_repo "${REPO_DIR}"
+
+        if [ "${manifest_state}" = "present" ]; then
+            cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+last_seen_version: "0.2.0"
+EOF
+        fi
+        NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+        NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+        if [ "${state_yml}" = "present" ]; then
+            mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+            printf 'schema_version: 1\n' > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml"
+        fi
+
+        set +e
+        PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+        set -e
+        assert_valid_json "JSON valid (manifest=${manifest_state}, state=${state_yml})" "${PAYLOAD}"
+        rm -rf "${TMP}"
+    done
+done
+
+# ---------------------------------------------------------------------------
+# Scenario 8: pathological dep-name input is sanitized before interpolation
+# ---------------------------------------------------------------------------
+printf 'Scenario 8: sanitization of pathological dep-name characters\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+make_repo "${REPO_DIR}"
+
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+last_seen_version: "0.2.0"
+EOF
+NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+printf 'schema_version: 1\n' > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml"
+
+# Replace the real check-deps.sh in the stub plugin root with a fake
+# that emits hostile MISSING= contents. The hook must sanitize them
+# before they hit additionalContext.
+cat > "${PLUGIN_ROOT}/scripts/check-deps.sh" <<'EOF'
+#!/usr/bin/env bash
+# Fake check-deps emitting pathological characters.
+printf 'MISSING=gh<script>alert(1)</script>,$(rm -rf /),python3\n'
+printf 'ROUTING_INJECTED=yes\n'
+printf 'PROJECT=/tmp/test\n'
+exit 0
+EOF
+chmod +x "${PLUGIN_ROOT}/scripts/check-deps.sh"
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0 with pathological dep names' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON valid with pathological input' "${PAYLOAD}"
+
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check_not 'no <script> tag survives sanitization' \
+    bash -c 'printf "%s" "$1" | grep -q "<script>"' _ "${CONTEXT}"
+check_not 'no $( substring survives sanitization' \
+    bash -c 'printf "%s" "$1" | grep -qF "\$("' _ "${CONTEXT}"
+check_not 'no </script> closing tag survives' \
+    bash -c 'printf "%s" "$1" | grep -q "</script>"' _ "${CONTEXT}"
+check 'sanitized python3 token survives (alnum content kept)' \
+    bash -c 'printf "%s" "$1" | grep -q "python3"' _ "${CONTEXT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 9: version banner reads from plugin.json (stub override)
+# ---------------------------------------------------------------------------
+printf 'Scenario 9: version banner reflects plugin.json version\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "9.9.9-test"
+make_repo "${REPO_DIR}"
+
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+last_seen_version: "9.9.9-test"
+EOF
+NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+printf 'schema_version: 1\n' > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml"
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+set -e
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check 'banner reflects plugin.json version 9.9.9-test' \
+    bash -c 'printf "%s" "$1" | grep -q "board-superpowers v9.9.9-test loaded."' _ "${CONTEXT}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 10: hook does not source common.sh (self-contained invariant)
+# ---------------------------------------------------------------------------
+printf 'Scenario 10: hook is self-contained (does not source lib/common.sh)\n'
+
+# Static check: the hook source MUST NOT contain a `. .../common.sh`
+# or `source .../common.sh` line (allowing for whitespace variance).
+check_not 'hook does not source common.sh' \
+    grep -qE '^[[:space:]]*(\.|source)[[:space:]]+.*common\.sh' "${HOOK}"
+
+# Runtime check: a hermetic invocation where lib/common.sh is REMOVED
+# must still succeed and emit valid JSON.
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+make_repo "${REPO_DIR}"
+
+# Delete the lib entirely.
+rm -rf "${PLUGIN_ROOT}/scripts/lib"
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0 with lib/ removed' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON valid with lib/ removed' "${PAYLOAD}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/tests/test-hook-invoke-marker.sh
+++ b/tests/test-hook-invoke-marker.sh
@@ -272,8 +272,13 @@ assert_valid_json 'JSON shape valid' "${PAYLOAD}"
 CONTEXT="$(extract_additional_context "${PAYLOAD}")"
 check 'INVOKE: bootstrapping-repo present' \
     bash -c 'printf "%s" "$1" | grep -qE "^INVOKE: bootstrapping-repo$"' _ "${CONTEXT}"
-check 'REASON mentions manifest.yml' \
-    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*manifest\\.yml"' _ "${CONTEXT}"
+# REASON content is whitelist-constrained (no `/`, no `~`); the new
+# wording is "host bootstrap pending; ..." — assert host-bootstrap
+# semantics rather than a literal path mention.
+check 'REASON declares host bootstrap pending' \
+    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*host bootstrap pending"' _ "${CONTEXT}"
+check 'REASON mentions manifest (no path chars)' \
+    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*manifest"' _ "${CONTEXT}"
 
 # At-most-one rule: only one INVOKE line in the payload.
 INVOKE_COUNT="$(printf '%s' "${CONTEXT}" | grep -cE "^INVOKE:" || true)"
@@ -312,8 +317,12 @@ assert_eq 'hook exit 0' '0' "$(printf '%d' "${RC}")"
 CONTEXT="$(extract_additional_context "${PAYLOAD}")"
 check 'INVOKE: bootstrapping-repo present' \
     bash -c 'printf "%s" "$1" | grep -qE "^INVOKE: bootstrapping-repo$"' _ "${CONTEXT}"
-check 'REASON mentions state.yml' \
-    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*state\\.yml"' _ "${CONTEXT}"
+# Whitelist-constrained REASON: per-repo path uses
+# "per-repo bootstrap pending; state file is absent."
+check 'REASON declares per-repo bootstrap pending' \
+    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*per-repo bootstrap pending"' _ "${CONTEXT}"
+check 'REASON mentions state file (no path chars)' \
+    bash -c 'printf "%s" "$1" | grep -qE "^REASON: .*state file"' _ "${CONTEXT}"
 
 rm -rf "${TMP}"
 
@@ -595,6 +604,204 @@ set -e
 assert_eq 'hook exit 0 with lib/ removed' '0' "$(printf '%d' "${RC}")"
 assert_valid_json 'JSON valid with lib/ removed' "${PAYLOAD}"
 
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 11: worktree-launched session does NOT false-emit INVOKE
+#              when the canonical state.yml exists at the PRIMARY repo
+#              root's normalized path.
+# ---------------------------------------------------------------------------
+printf 'Scenario 11: worktree resolution (primary repo state.yml found)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+PRIMARY_REPO="${TMP}/primary"
+WORKTREE_DIR="${TMP}/worktrees/feature-x"
+mkdir -p "${HOME_DIR}/.board-superpowers"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+install_clean_check_deps "${PLUGIN_ROOT}"
+make_repo "${PRIMARY_REPO}"
+
+# Write the manifest (host bootstrapped) and the per-repo state.yml
+# at the CANONICAL path — i.e. derived from the PRIMARY repo's git
+# toplevel, not the worktree's.
+cat > "${HOME_DIR}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+host_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version: "0.2.0"
+EOF
+
+CANONICAL_PRIMARY="$(cd "${PRIMARY_REPO}" && git rev-parse --show-toplevel)"
+CANONICAL_PRIMARY="$(cd "${CANONICAL_PRIMARY}" && pwd -P)"
+NORM="$(normalize_for_test "${CANONICAL_PRIMARY}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+cat > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml" <<EOF
+schema_version: 1
+repo_bootstrapped_at: "2026-01-01T00:00:00Z"
+last_seen_version_in_repo: "0.2.0"
+EOF
+
+# Cut a worktree from the primary onto a feature branch.
+(
+    cd "${PRIMARY_REPO}"
+    git worktree add -q -b feature-x "${WORKTREE_DIR}" >/dev/null 2>&1
+)
+
+# Sanity: confirm the worktree's git toplevel differs from primary's,
+# so the test would otherwise demonstrate the bug if the hook still
+# used --show-toplevel.
+WORKTREE_TOPLEVEL="$(cd "${WORKTREE_DIR}" && git rev-parse --show-toplevel)"
+WORKTREE_TOPLEVEL="$(cd "${WORKTREE_TOPLEVEL}" && pwd -P)"
+if [ "${WORKTREE_TOPLEVEL}" = "${CANONICAL_PRIMARY}" ]; then
+    printf '  SKIP — worktree toplevel equals primary toplevel; setup did not exercise worktree path\n'
+else
+    printf '  (worktree toplevel: %s)\n' "${WORKTREE_TOPLEVEL}"
+    printf '  (primary  toplevel: %s)\n' "${CANONICAL_PRIMARY}"
+fi
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${WORKTREE_DIR}")"
+RC=$?
+set -e
+
+assert_eq 'hook exit 0 from worktree' '0' "$(printf '%d' "${RC}")"
+assert_valid_json 'JSON valid from worktree' "${PAYLOAD}"
+
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+check_not 'no INVOKE marker (canonical state.yml found via primary-repo-root resolution)' \
+    bash -c 'printf "%s" "$1" | grep -q "^INVOKE:"' _ "${CONTEXT}"
+check 'version banner still present' \
+    bash -c 'printf "%s" "$1" | grep -q "board-superpowers v0.2.0 loaded."' _ "${CONTEXT}"
+
+# Cleanup the worktree before rm -rf so git worktree's metadata is
+# consistent (otherwise rm leaves dangling pointers in primary's
+# .git/worktrees/, which is harmless but noisy in logs).
+(cd "${PRIMARY_REPO}" && git worktree remove -f "${WORKTREE_DIR}" >/dev/null 2>&1 || true)
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 12: REASON line conforms to the spec whitelist
+#   plain ASCII, punctuation only `. , ; : - ( )` — no `~`, no `/`,
+#   no markup.
+# ---------------------------------------------------------------------------
+printf 'Scenario 12: REASON whitelist conformance\n'
+
+# Helper closure: run a fresh hermetic hook with given manifest /
+# state presence, capture the REASON line, return it on stdout.
+capture_reason_line() {
+    local manifest_present="$1"; local state_present="$2"
+    local tmp; tmp="$(mktemp -d)"
+    local home_dir="${tmp}/home"
+    local plugin_root="${tmp}/plugin"
+    local repo_dir="${tmp}/repo"
+    mkdir -p "${home_dir}/.board-superpowers"
+    make_plugin_root "${plugin_root}" "0.2.0"
+    install_clean_check_deps "${plugin_root}"
+    make_repo "${repo_dir}"
+
+    if [ "${manifest_present}" = "yes" ]; then
+        cat > "${home_dir}/.board-superpowers/manifest.yml" <<EOF
+schema_version: 1
+last_seen_version: "0.2.0"
+EOF
+    fi
+    if [ "${state_present}" = "yes" ]; then
+        local norm_repo norm
+        norm_repo="$(cd "${repo_dir}" && git rev-parse --show-toplevel)"
+        norm_repo="$(cd "${norm_repo}" && pwd -P)"
+        norm="$(normalize_for_test "${norm_repo}")"
+        mkdir -p "${home_dir}/.board-superpowers/repos/${norm}"
+        printf 'schema_version: 1\n' > "${home_dir}/.board-superpowers/repos/${norm}/state.yml"
+    fi
+
+    local payload context reason
+    payload="$(run_hook "${plugin_root}" "${home_dir}" "${repo_dir}")"
+    context="$(extract_additional_context "${payload}")"
+    reason="$(printf '%s\n' "${context}" | grep -E '^REASON:' | head -n 1 || true)"
+    rm -rf "${tmp}"
+    printf '%s' "${reason}"
+}
+
+assert_reason_whitelist() {
+    local label="$1"; local reason="$2"
+    # Strip the "REASON: " prefix; check that the value contains only
+    # whitelisted chars (a-zA-Z0-9 + space + . , ; : - ( )).
+    local value="${reason#REASON: }"
+    if [ -z "${value}" ] || [ "${value}" = "${reason}" ]; then
+        printf '  FAIL — %s (no REASON line captured: %q)\n' "${label}" "${reason}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if printf '%s' "${value}" | LC_ALL=C grep -qE '[^a-zA-Z0-9 .,;:()-]'; then
+        printf '  FAIL — %s (out-of-whitelist char in: %q)\n' "${label}" "${value}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if printf '%s' "${value}" | grep -qE '~|/|<|>'; then
+        printf '  FAIL — %s (forbidden char in: %q)\n' "${label}" "${value}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [ "${#value}" -gt 120 ]; then
+        printf '  FAIL — %s (length %d > 120: %q)\n' "${label}" "${#value}" "${value}" >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    printf '  PASS — %s\n' "${label}"
+    PASS=$((PASS + 1))
+}
+
+# Manifest absent (state also absent → "both absent" path).
+REASON_BOTH="$(capture_reason_line no no)"
+printf '  captured REASON (manifest=absent, state=absent): %s\n' "${REASON_BOTH}"
+assert_reason_whitelist 'both-absent REASON in whitelist' "${REASON_BOTH}"
+check 'both-absent REASON mentions both' \
+    bash -c 'printf "%s" "$1" | grep -qE "both manifest and per-repo state files"' _ "${REASON_BOTH}"
+
+# Manifest absent (state present is impossible without manifest in
+# practice, but the hook still classifies; we only test the OR-path
+# where manifest absent dominates).
+
+# Manifest present, state.yml absent — per-repo path.
+REASON_STATE="$(capture_reason_line yes no)"
+printf '  captured REASON (manifest=present, state=absent): %s\n' "${REASON_STATE}"
+assert_reason_whitelist 'state-absent REASON in whitelist' "${REASON_STATE}"
+check 'state-absent REASON mentions per-repo' \
+    bash -c 'printf "%s" "$1" | grep -qE "per-repo bootstrap"' _ "${REASON_STATE}"
+
+# Manifest absent, state present — manifest-absent path (state
+# presence is moot when manifest missing; the hook routes on manifest
+# first per spec ordering).
+# The capture helper as constructed leaves state absent when
+# manifest=no implies host-not-bootstrapped, so we recreate manually:
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+REPO_DIR="${TMP}/repo"
+mkdir -p "${HOME_DIR}"
+make_plugin_root "${PLUGIN_ROOT}" "0.2.0"
+install_clean_check_deps "${PLUGIN_ROOT}"
+make_repo "${REPO_DIR}"
+NORM_REPO_DIR="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel)"
+NORM_REPO_DIR="$(cd "${NORM_REPO_DIR}" && pwd -P)"
+NORM="$(normalize_for_test "${NORM_REPO_DIR}")"
+mkdir -p "${HOME_DIR}/.board-superpowers/repos/${NORM}"
+printf 'schema_version: 1\n' > "${HOME_DIR}/.board-superpowers/repos/${NORM}/state.yml"
+
+set +e
+PAYLOAD="$(run_hook "${PLUGIN_ROOT}" "${HOME_DIR}" "${REPO_DIR}")"
+set -e
+CONTEXT="$(extract_additional_context "${PAYLOAD}")"
+REASON_MANIFEST="$(printf '%s\n' "${CONTEXT}" | grep -E '^REASON:' | head -n 1 || true)"
+printf '  captured REASON (manifest=absent, state=present): %s\n' "${REASON_MANIFEST}"
+assert_reason_whitelist 'manifest-absent REASON in whitelist' "${REASON_MANIFEST}"
+check 'manifest-absent REASON mentions host bootstrap' \
+    bash -c 'printf "%s" "$1" | grep -qE "host bootstrap pending"' _ "${REASON_MANIFEST}"
+check 'manifest-absent REASON does NOT contain "~"' \
+    bash -c '! printf "%s" "$1" | grep -q "~"' _ "${REASON_MANIFEST}"
+check 'manifest-absent REASON does NOT contain "/"' \
+    bash -c '! printf "%s" "$1" | grep -q "/"' _ "${REASON_MANIFEST}"
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Minor release `v0.2.0` ships the complete bootstrap mechanism:

- **F-B1 host bootstrap** (`scripts/bootstrap-host.sh`) — writes `~/.board-superpowers/manifest.yml` once per host.
- **F-B2 per-repo bootstrap** (`scripts/bootstrap-project.sh`) — five sub-capabilities (2a labels, 2b Status validation, 2c config.yml, 2d .gitignore, 2e BYO-RDBMS UX) + step 4 dual-file routing block injection with SHA256 tamper hash + step 3 state.yml init.
- **Intent injection** (`hooks/session-start.sh` rewrite) — emits `INVOKE: bootstrapping-repo` marker when state files absent. Hook stays self-contained per spec.
- **Entry-skill rework** (`skills/using-board-superpowers/SKILL.md` Steps 1-3) — Layer-2 reliable gate that re-runs dep + state probe regardless of hook delivery.
- **New molecular skill** (`skills/bootstrapping-repo/`) — orchestrates F-B1 → F-B2; SKILL.md + 3 references + .skill-meta.yaml.
- **`scripts/bootstrap-rollback.sh`** — symmetric F-B2 undo (per A2 decision).
- **ADR-0009** (`docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md`) — SQLite added to BYO audit DB scheme allowlist (6 schemes total: postgresql, postgres, mysql, mysql+pymysql, sqlite, sqlite3). Partially supersedes ADR-0006 §5.

Closes #25.

Card body archived in `docs/plans/bootstrap/card-2-bootstrap.md` (gitignored).

## Automated Verification

All 14 test suites + 2 verify gates green. shellcheck clean.

```
$ bash tests/check-deps-exit-codes.sh         # 7
$ bash tests/check-deps-machine-mode.sh       # 38
$ bash tests/setup-labels-idempotent.sh       # 8
$ bash tests/common-helpers.sh                # 22
$ bash tests/audit-local-migration.sh         # 29
$ bash tests/test-fb1-host-bootstrap.sh       # 36
$ bash tests/test-fb2-per-repo.sh             # 47
$ bash tests/test-fb2-byo-rdbms.sh            # 66
$ bash tests/test-fb2-routing-injection.sh    # 81
$ bash tests/test-hook-invoke-marker.sh       # 49
$ bash tests/test-entry-skill-marker-consumption.sh  # 23
$ bash tests/test-bootstrapping-repo-skill.sh # 54
$ bash tests/test-bootstrap-rollback.sh       # 34
$ bash tests/test-bootstrap-end-to-end.sh     # 39
$ bash scripts/verify-skill-metadata.sh       # OK (6 skills checked)
$ bash scripts/verify-skill-frontmatter.sh    # OK
$ shellcheck -x scripts/*.sh hooks/*.sh tests/*.sh   # exit 0
```

Total: ~530 assertions across 14 suites, all green. Hermetic — every test stubs `gh`, scrubs `env -i`, uses tmp HOME + tmp git repo. CI-portable.

The end-to-end smoke (`tests/test-bootstrap-end-to-end.sh`) wires F-B1 + F-B2 (a-e + 4 + 3) + idempotent re-run + rollback in one hermetic flow — gold-standard sanity check.

## Human Verification TODO

- [ ] Post-merge: orchestrator runs `bash scripts/bootstrap-host.sh` against this repo (real `$HOME`) → manifest.yml written.
- [ ] Post-merge: orchestrator runs `bash scripts/bootstrap-project.sh --owner PanQiWei --project 4 --repo-root .` against this repo → state.yml written; routing block injected into THIS repo's AGENTS.md + CLAUDE.md (replacing the manually-curated block); state.yml records 2 routing_blocks entries with sha256 hashes.
- [ ] Verify `~/.board-superpowers/credentials.yml` (if created during F-B2 step 2e) has chmod 600 (`ls -la` shows `-rw-------`). Slice 3 covers this in automated test; manual eyeball confirms host filesystem reality.
- [ ] Idempotent re-run on this repo: re-invoke F-B2 → `git status` shows no changes (config.yml, AGENTS.md/CLAUDE.md byte-identical, state.yml untouched).
- [ ] Secondary clean-repo bootstrap walkthrough — out of scope for this autonomous orchestration; user can do this manually post-merge to validate F-B1 fires INVOKE marker on a fresh `(host, repo)`.

## Retro Notes

Reusable lessons from the 17-commit TDD cadence (Phases 0-7 + 4 review-driven fix-up rounds):

1. **Spec-vs-card precedence**. Card body had several drafting bugs: SQLite DSN slash count (3 vs 4), `--machine` mode key enum (yes/no vs true/false), pre-existing "SQLite forbidden" claims in 5 spec pages contradicting new ADR-0009. **Spec wins**; cards in `docs/plans/` are gitignored scaffolding. Card decompositions for future features should cross-check `docs/architecture/` before pinning acceptance language.

2. **Source-of-truth file pollution via simple-find injection**. The agentsmd-routing.md source initially had a docstring header that ALSO ended up in user repos because `bsp_inject_routing_block` treated whole-file = block. **Fence pattern** (`<!-- routing-block:start -->` / `<!-- routing-block:end -->` distinct from target marker pair) cleanly separates plugin-internal docs from injectable content. Sanity check: source must NOT contain literal target marker strings.

3. **Worktree resolution gotcha**. `git rev-parse --show-toplevel` returns the WORKTREE path, not the canonical primary repo path. For state-file lookups (where state is per-repo, not per-worktree), use `dirname $(git rev-parse --git-common-dir)` instead. Added `bsp_primary_repo_root` helper + inline duplication in hook (per self-containment spec).

4. **REASON line whitelist**. `02-hook-contracts.md` line 206-215 specifies `[a-zA-Z0-9 .,;:\-()]` only for INVOKE marker REASON lines — no `~` or `/`. Easy to violate with a "natural" path-mentioning REASON. Sanitize before emission.

5. **Concurrency: per-process .tmp via mktemp**. Two parallel sessions doing first-run F-B1 race on `manifest.yml.tmp` if shared. `mktemp ${target}.tmp.XXXXXX` is the right answer. macOS BSD `mktemp` requires TRAILING Xs; middle-of-template Xs become literal. Apply across all atomic-write helpers.

6. **Boil-the-lake symmetry enforcement (A2 decision)**. Shipping `bootstrap-rollback.sh` alongside the bootstrap mechanism (instead of deferring) means future F-B2 step additions MUST add a matching rollback step. Symmetry rule documented in script header. The symmetry isn't strict-reverse-of-forward — the rollback script's order is what the card body specifies, which is closer to "user-visible files first, host-local state last". Skipping label deletion is intentional (per card spec).

7. **Two-reviewer dispatch is the right pattern**. Opus + Codex disagreed on 5 of 8 review rounds. Codex caught: SQLite DSN slash form, scheme validation prefix-only weakness, source-file docstring leak, worktree resolution bug, REASON whitelist violation. Opus caught: ADR-0006 status format hybrid, source-file fence pattern reasoning, idempotency invariants. Each model has different blindspots. Cost is small relative to defects-caught rate.

8. **TDD compounded**. 14 hermetic test suites with ~530 assertions makes each subsequent fix-up trivially safe — every change runs the entire chain. The investment in stubbed-gh + tmp-HOME + env-scrubbing patterns paid off across 17 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)