### PR TITLE
fix(bootstrap): recognize stub-redirect targets in routing injection

### DIFF
--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
@@ -61,11 +61,17 @@ The four user scenarios this matrix covers (see §2.1 / §2.2 /
   taste presets — no canned lint config, no canned PR section
   bodies, no canned retro template.
 - **Dual-platform parity.** Per `PLUGIN_DEVELOPMENT.md`, the
-  routing block lands in **both** `CLAUDE.md` (Claude Code
-  auto-loads) AND `AGENTS.md` (Codex CLI auto-loads). The marker
-  pair `<!-- board-superpowers:routing -->` /
+  routing block lands in `CLAUDE.md` (Claude Code auto-loads) AND
+  `AGENTS.md` (Codex CLI auto-loads). The marker pair
+  `<!-- board-superpowers:routing -->` /
   `<!-- /board-superpowers:routing -->` is identical in both;
-  `check-deps.sh` matches in either.
+  `check-deps.sh` matches in either. **Stub-redirect exception**:
+  when one of the two files is a deliberate stub redirect (≤ 30
+  lines AND contains a `^@<file>.md$` line, e.g. `@AGENTS.md`),
+  F-B2 step 4 silently skips it — the routing block lands in the
+  other (non-stub) file only, and CC's `@-include` resolution +
+  Codex's native AGENTS.md auto-load both pick it up via the
+  redirect.
 - **Plugin-owned vs user-owned region split** (see I-11). State
   files written by these features (`manifest.yml`, `state.yml`)
   are plugin-managed; `config.yml` is user-editable; routing
@@ -387,6 +393,17 @@ needs its config.
      the injected block (everything between the marker pair,
      excluding the markers themselves) — what F-B4 later uses to
      detect user modifications before auto-updating.
+
+     **Stub-redirect target — no-op.** A target file recognized as
+     a *stub redirect* (file ≤ 30 lines AND contains a Claude Code
+     `@-include` line of shape `^@<file>.md$`, e.g.
+     `@AGENTS.md`) is left byte-identical and DOES NOT receive a
+     `routing_blocks[]` entry. The architect's intent for such
+     files is "redirect, not authoritative content"; injecting a
+     routing block would defeat the single-source-of-truth purpose
+     of the pointed-to file. The skip is silent (a `bsp_log` line
+     records the decision); F-B2 still proceeds and writes the
+     other file's `routing_blocks[]` entry normally.
   5. **First-card pointer delivery** — show the architect the
      "what now" surface: how to create their first card via the
      Manager session (or by pasting a card via the GitHub UI and

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
@@ -528,6 +528,20 @@ needs its config.
      default, opt-out per-extension).
   4. **Routing-block re-injection** — for each of `CLAUDE.md`
      and `AGENTS.md`:
+     - **Stub-redirect filter (must precede everything else
+       below).** F-B4 inherits F-B2 step 4's stub-redirect rule
+       (target ≤ 30 lines AND contains a CC `@-include` line of
+       shape `^@<file>.md$`). When the on-disk target file
+       matches the stub-redirect predicate, F-B4 MUST treat it
+       as out-of-scope: no hash compute, no `routing_blocks[]`
+       comparison, no architect prompt. The stub is the
+       architect's deliberate redirect; F-B4 must never propose
+       to "restore" a routing block on it (doing so would defeat
+       the single-source-of-truth purpose the stub exists to
+       serve). Symmetrically, if a `state.yml:routing_blocks[]`
+       entry exists for a file that has since become a stub,
+       F-B4 silently drops the entry (state ↔ disk
+       reconciliation in the safe direction).
      - Read the current on-disk block (between the marker pair).
      - Compute its SHA256.
      - Find the matching `target_file` element in

--- a/docs/architecture/0005-contracts/03-config-schemas.md
+++ b/docs/architecture/0005-contracts/03-config-schemas.md
@@ -140,7 +140,7 @@ routing_blocks:
 | `repo_bootstrapped_at` | string (ISO 8601, UTC) | yes | Set once at F-B2 firing on this host |
 | `last_seen_version_in_repo` | string (semver) | yes | Updated by F-B4 at every per-host repo version transition |
 | `features_enabled` | list of strings | yes | Feature IDs in dotted form (`bootstrap.host`, `bootstrap.per_repo`, …). At v1 a list (on/off only); future migration converts list → map of `feature_id` → config blob |
-| `routing_blocks` | list of objects | yes | One element per file the plugin tracks: at minimum `CLAUDE.md` and `AGENTS.md`. List form (not map keyed by filename) so adding a new target file is an append, not a schema change |
+| `routing_blocks` | list of objects | yes | One element per file the plugin successfully injected into. F-B2 attempts both `CLAUDE.md` and `AGENTS.md`; either may be a stub-redirect target (≤ 30 lines + contains a `^@<file>.md$` line) in which case it is skipped silently and DOES NOT appear in the list. Empty list `[]` is permitted only when both files are stub-redirect (degenerate; would also leave the routing block uninjected anywhere — flagged elsewhere). List form (not map keyed by filename) so adding a new target file is an append, not a schema change |
 | `routing_blocks[].target_file` | string (repo-relative path) | yes | E.g. `CLAUDE.md`, `AGENTS.md`, future `.cursorrules` |
 | `routing_blocks[].block_hash` | string `sha256:<64 hex>` | yes | SHA256 (lowercase hex) of bytes between the marker pair, **excluding** the markers themselves |
 | `routing_blocks[].injected_at` | string (ISO 8601, UTC) | yes | Updated each time F-B4 re-injects this entry |

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -532,6 +532,13 @@ bsp_pick_worktree_dir() {
 #
 # Target-file rules:
 #   - Absent: create with marker pair wrapping the block content.
+#   - Existing, recognized as STUB-REDIRECT (file ≤ 30 lines AND
+#     contains a Claude Code @-include line `@<file>.md`): no-op. The
+#     file is left byte-identical, NO hash is printed to stdout, exit
+#     0. Caller's `[ -n "${hash}" ]` guard at write_state_yml elides
+#     the routing_blocks[] entry. Per
+#     docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+#     § 1.5.2 step 4 "Stub-redirect target".
 #   - Existing, exactly 1 OPEN + exactly 1 CLOSE: replace bytes
 #     between markers with normalized block content. Bytes OUTSIDE
 #     markers (including BOM at byte 0, original line endings) are
@@ -546,12 +553,13 @@ bsp_pick_worktree_dir() {
 #     be updated, second would silently rot) and return exit 5.
 #
 # Stdout on success: the hex SHA256 hash (no "sha256:" prefix), one
-# line. Caller is expected to prepend "sha256:" when recording into
-# state.yml.
+# line — OR empty (no hash) when the target is a stub redirect. Caller
+# is expected to prepend "sha256:" when recording into state.yml, and
+# to skip the routing_blocks[] entry on empty stdout.
 #
 # Args: <target_file> <source_file>
 # Exit codes:
-#   0  success — hash printed to stdout
+#   0  success — hash printed to stdout (OR empty for stub-redirect)
 #   1  bad args / source file unreadable / source missing fences /
 #      source has nested target markers / target write failure
 #   5  target has orphan marker (one but not both) OR multiple marker
@@ -563,6 +571,24 @@ bsp_inject_routing_block() {
 
     if [ ! -f "${source}" ]; then
         bsp_die "bsp_inject_routing_block: source file not found: ${source}"
+    fi
+
+    # Stub-redirect early-out. A target file that is short (≤ 30 lines)
+    # AND carries a CC @-include line of shape `@<file>.md` is a
+    # deliberate redirect (e.g. board-superpowers' own CLAUDE.md →
+    # @AGENTS.md). Injecting a routing block would defeat its
+    # single-source-of-truth purpose. No write, no stdout, exit 0; the
+    # caller's `[ -n "${hash}" ]` guard then elides the routing_blocks
+    # entry for this target.
+    if [ -f "${target}" ]; then
+        local _bsp_line_count
+        _bsp_line_count="$(wc -l < "${target}" | tr -d ' ')"
+        if [ "${_bsp_line_count}" -le 30 ]; then
+            if grep -Eq '^@[A-Za-z0-9./_-]+\.md[[:space:]]*$' "${target}"; then
+                bsp_log "skipping routing injection: ${target} is a stub redirect (≤30 lines + @<file>.md)"
+                return 0
+            fi
+        fi
     fi
 
     bsp_require_cmd python3 "macOS / Linux ship python3 by default"

--- a/skills/bootstrapping-repo/SKILL.md
+++ b/skills/bootstrapping-repo/SKILL.md
@@ -81,7 +81,7 @@ The script handles the five F-B2 sub-steps + step 4 (routing injection) + step 3
 | 2c — config.yml write | Renders `<repo>/.board-superpowers/config.yml` with `project: "OWNER/NUM"` and `wip_limit: 5`. Skipped when present unless `--force`. |
 | 2d — .gitignore append | Appends an idempotent block ignoring `.board-superpowers/claims/`. |
 | 2e — credentials.yml | Walks BYO-RDBMS DSN setup. Accepts the 6-scheme allowlist (`postgresql://`, `postgres://`, `mysql://`, `mysql+pymysql://`, `sqlite://`, `sqlite3://` per ADR-0009). Architect can decline → all A-class actions degrade to R-class until they reconfigure. |
-| step 4 — routing injection | Appends the canonical routing block to BOTH `CLAUDE.md` and `AGENTS.md` between the marker pair `<!-- board-superpowers:routing -->` / `<!-- /board-superpowers:routing -->`. Records each block's SHA256 hash for F-B4 tamper detection. |
+| step 4 — routing injection | Appends the canonical routing block to `CLAUDE.md` AND `AGENTS.md` between the marker pair `<!-- board-superpowers:routing -->` / `<!-- /board-superpowers:routing -->`. Records each block's SHA256 hash for F-B4 tamper detection. **Stub-redirect targets are silently skipped** — a target file ≤ 30 lines containing a Claude Code `@-include` line of shape `^@<file>.md$` (e.g. `@AGENTS.md`) is treated as a deliberate redirect; the file is left byte-identical and DOES NOT receive a `routing_blocks[]` entry. |
 | step 3 — state.yml write | Writes `~/.board-superpowers/repos/<normalized>/state.yml` with `schema_version: 1`, `repo_bootstrapped_at`, `last_seen_version_in_repo`, `features_enabled: [bootstrap.host, bootstrap.per_repo]`, and the `routing_blocks[]` array recorded during step 4. |
 
 **Surface to the architect** after each F-B2 sub-step completes:
@@ -132,7 +132,8 @@ Bootstrap actions:
   bootstrap-project-2c    — config.yml write (project + wip_limit)
   bootstrap-project-2d    — .gitignore append (idempotent block)
   bootstrap-project-2e    — credentials.yml write (chmod 0600; DSN allowlist)
-  bootstrap-project-4     — routing block injection (CLAUDE.md + AGENTS.md)
+  bootstrap-project-4     — routing block injection (CLAUDE.md + AGENTS.md;
+                                                      stub-redirect targets skipped)
   bootstrap-project-3     — state.yml write (host-local per-repo)
 ```
 
@@ -182,4 +183,4 @@ If the architect declines BYO-RDBMS at step 2e, the bootstrap completes and the 
 
 This skill works on both Claude Code and Codex CLI. Both `bootstrap-host.sh` and `bootstrap-project.sh` resolve their plugin root via `bsp_plugin_root` (Claude uses `${CLAUDE_PLUGIN_ROOT}`, Codex uses path-derivation) so the architect's invocation works without platform-specific argument shaping.
 
-Routing block injection is dual-target by design — `CLAUDE.md` (for Claude Code's auto-load) and `AGENTS.md` (for Codex CLI's auto-load) both receive the same content, which is why the architect's session lands cleanly regardless of which platform they next open in this repo.
+Routing block injection is dual-target by design — `CLAUDE.md` (for Claude Code's auto-load) and `AGENTS.md` (for Codex CLI's auto-load) both receive the same content, which is why the architect's session lands cleanly regardless of which platform they next open in this repo. **Exception**: when one of the two files is a *stub redirect* (≤ 30 lines AND contains a `^@<file>.md$` line), F-B2 silently skips injecting that file. The architect's intent for such files is "redirect to the other one", and injecting a routing block would defeat that single-source-of-truth purpose; both platforms still receive the routing block via the other, non-stub file (CC's `@AGENTS.md` resolution and Codex's native AGENTS.md auto-load both pick it up from AGENTS.md when CLAUDE.md is the stub).

--- a/skills/bootstrapping-repo/references/changelog/v0.2.0.md
+++ b/skills/bootstrapping-repo/references/changelog/v0.2.0.md
@@ -28,13 +28,15 @@ F-B2 (per-repo bootstrap) writes / updates the following on first visit to each 
    ```
    Note the narrow scope — only `claims/` is gitignored (per-session forensic state). `config.yml` is intentionally tracked. `state.yml` does not live in the repo at all (it is host-local).
 5. **BYO-RDBMS credential setup** — interactive at F-B2 step 2e. Allowlisted DSN schemes per ADR-0009: `postgresql://`, `postgres://`, `mysql://`, `mysql+pymysql://`, `sqlite://`, `sqlite3://`. Decline path is supported (sets degraded R-class default).
-6. **Routing block injection** into BOTH `CLAUDE.md` AND `AGENTS.md`, between the marker pair:
+6. **Routing block injection** into `CLAUDE.md` AND `AGENTS.md`, between the marker pair:
    ```
    <!-- board-superpowers:routing -->
    ...
    <!-- /board-superpowers:routing -->
    ```
    The block content is mirrored verbatim from `skills/using-board-superpowers/references/agentsmd-routing.md`. Each file's block content is hashed (SHA256) and the hash recorded in `state.yml` for tamper detection on future plugin upgrades.
+
+   **Stub-redirect targets are silently skipped** (added during v0.2.0 self-hosting dogfood). A target file ≤ 30 lines containing a Claude Code `@-include` line of shape `^@<file>.md$` (e.g. `@AGENTS.md`) is treated as a deliberate redirect — the file is left byte-identical and DOES NOT receive a `routing_blocks[]` entry. This unblocks the "AGENTS.md is the single source of truth, CLAUDE.md is `@AGENTS.md`" pattern that board-superpowers itself uses (and that downstream consumer repos may adopt).
 7. **`~/.board-superpowers/repos/<normalized>/state.yml`** — host-local per-repo state. Contains `schema_version`, `repo_bootstrapped_at`, `last_seen_version_in_repo: 0.2.0`, `features_enabled: [bootstrap.host, bootstrap.per_repo]`, and the per-file `routing_blocks[]` with SHA256 hashes.
 
 The routing block is what allows fresh CC / Codex sessions in the repo to find the right entry skill on session start. The `<!-- board-superpowers:routing -->` markers are the source-of-truth boundary — the plugin owns content between them, the architect owns content outside them.

--- a/skills/bootstrapping-repo/references/first-time-user-guide.md
+++ b/skills/bootstrapping-repo/references/first-time-user-guide.md
@@ -98,6 +98,8 @@ The block content is plugin-owned within the marker pair, user-owned outside. Th
 
 Do not edit anything **between** the markers by hand — your edits will be overwritten by the next auto-update. If you need to customize the routing, edit content **outside** the markers (CLAUDE.md / AGENTS.md are otherwise yours).
 
+**Stub-redirect targets are skipped.** If your `CLAUDE.md` or `AGENTS.md` is a *stub redirect* (≤ 30 lines AND contains a Claude Code `@-include` line of shape `^@<file>.md$`, e.g. `@AGENTS.md`), F-B2 leaves it byte-identical and DOES NOT add a `routing_blocks[]` entry for it in `state.yml`. The other (non-stub) file still receives the routing block and the architect's session lands cleanly via the redirect. You can sanity-check this by `grep -c 'board-superpowers:routing' state.yml` — a stub-redirect setup shows fewer than two markers across the two files (typically one in AGENTS.md only).
+
 ## When to invoke each skill
 
 This skill (`bootstrapping-repo`) does NOT fire again unless one of the state files goes missing. From here on:
@@ -122,8 +124,9 @@ ls ~/.board-superpowers/repos/
 # Project config in the repo is committed.
 cat .board-superpowers/config.yml
 
-# Routing block injected into CLAUDE.md.
-grep -A1 'board-superpowers:routing' CLAUDE.md | head -5
+# Routing block injected into AGENTS.md (and CLAUDE.md unless it is
+# a stub redirect — in that case grep AGENTS.md only).
+grep -A1 'board-superpowers:routing' AGENTS.md | head -5
 
 # Dependency check passes (the same check that runs on every session start).
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh"

--- a/skills/using-board-superpowers/references/agentsmd-routing.md
+++ b/skills/using-board-superpowers/references/agentsmd-routing.md
@@ -49,6 +49,8 @@ also rejects source content with literal target markers nested inside
 the fence.
 
 <!-- routing-block:start -->
+## board-superpowers session routing
+
 This project uses the `board-superpowers` plugin (v0.2.0).
 Any Claude Code session in this project plays one of two roles:
 
@@ -161,3 +163,16 @@ When updating the routing block content above, remember:
   changes whenever the bytes between the fences change. F-B4 tamper
   detection treats a hash mismatch as plausible user edit; document
   the change in the v0.x release notes.
+- The block intentionally opens with a `## board-superpowers session
+  routing` H2 heading so consumer repos' AGENTS.md / CLAUDE.md get a
+  visible section title where the block lands. Removing the heading
+  changes the hash and breaks visual structure in long target files.
+- The injection helper recognises *stub-redirect* target files (≤ 30
+  lines AND containing `^@<file>.md$`, e.g. `@AGENTS.md`) and skips
+  them silently — `routing_blocks[]` for that target is omitted. This
+  is what lets the "AGENTS.md is the SoT, CLAUDE.md is `@AGENTS.md`"
+  pattern coexist with dual-file injection. See
+  `scripts/lib/common.sh:bsp_inject_routing_block` (Stub-redirect
+  early-out section) and
+  `docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md`
+  § 1.5.2 step 4 "Stub-redirect target".

--- a/tests/test-fb2-routing-injection.sh
+++ b/tests/test-fb2-routing-injection.sh
@@ -863,6 +863,210 @@ check_not 'orphan e2e: state.yml NOT written' test -f "${STATE_FILE}"
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
+# Scenario 16: Stub-redirect target — helper skips, prints empty stdout, exit 0
+# ---------------------------------------------------------------------------
+# A target file that is a stub redirect (short + contains `@<file>.md`
+# CC @-include line) should NOT receive routing-block injection. The
+# helper recognizes the stub shape and:
+#   - leaves the target file byte-identical
+#   - prints NOTHING to stdout (no hash)
+#   - exits 0 (not an error — the architect's intent is "redirect")
+# Caller (bootstrap-project.sh) interprets empty stdout as "skip this
+# target's routing_blocks[] entry" via existing `[ -n "${hash}" ]`
+# guard at write_state_yml.
+#
+# Stub definition (per scripts/lib/common.sh:bsp_inject_routing_block):
+#   - File total line count ≤ 30
+#   - File contains at least one line matching `^@[A-Za-z0-9./_-]+\.md$`
+#     (Claude Code @-include syntax for another markdown file)
+# Both conditions required.
+printf 'Scenario 16: Stub-redirect target — skip + empty stdout + exit 0\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/CLAUDE.md"
+
+# Build a representative stub redirect identical in shape to
+# board-superpowers' own CLAUDE.md (13 lines, ends with `@AGENTS.md`).
+cat > "${TARGET}" <<'EOF'
+# CLAUDE.md (redirect to AGENTS.md)
+
+This file exists only so **Claude Code** auto-loads the project's
+canonical instructions, which live in **`AGENTS.md`** — a single
+source of truth for both Claude Code and OpenAI Codex CLI sessions.
+
+> **Make all edits in `AGENTS.md`, not here.**
+> Claude Code resolves the `@` reference below and pulls AGENTS.md
+> into context automatically. Codex CLI loads AGENTS.md natively per
+> its own auto-load convention (see `PLUGIN_DEVELOPMENT.md` for the
+> exact lookup order).
+
+@AGENTS.md
+EOF
+
+ORIG_BYTES="$(sha256_of_file "${TARGET}")"
+
+set +e
+STDOUT_OUT="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'stub-redirect: exit 0' '0' "${RC}"
+assert_eq 'stub-redirect: stdout is empty (no hash)' '' "${STDOUT_OUT}"
+NEW_BYTES="$(sha256_of_file "${TARGET}")"
+assert_eq 'stub-redirect: file bytes unchanged' "${ORIG_BYTES}" "${NEW_BYTES}"
+check_not 'stub-redirect: opening marker NOT injected' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${TARGET}"
+check_not 'stub-redirect: closing marker NOT injected' \
+    grep -Fq '<!-- /board-superpowers:routing -->' "${TARGET}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 16b: Negative — short file WITHOUT @-include is NOT a stub
+# ---------------------------------------------------------------------------
+# A file can be short (≤ 30 lines) without being a stub redirect; it
+# might be a near-empty template the architect intends to populate.
+# Without an `@<file>.md` line the helper MUST proceed with normal
+# injection (case-C: append marker-wrapped block).
+printf 'Scenario 16b: short file without @-include is NOT a stub — normal append\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+cat > "${TARGET}" <<'EOF'
+# AGENTS.md
+
+Project notes go here.
+EOF
+
+set +e
+HASH16B="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'short-no-include: exit 0' '0' "${RC}"
+check 'short-no-include: stdout produced 64-char hex hash (NOT empty)' \
+    bash -c "printf '%s' \"\$1\" | grep -Eq '^[0-9a-f]{64}$'" _ "${HASH16B}"
+check 'short-no-include: opening marker present (block was appended)' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${TARGET}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 16c: Negative — long file WITH @-include is NOT a stub
+# ---------------------------------------------------------------------------
+# Similarly, a substantive file (> 30 lines) that happens to mention an
+# `@<file>.md` line for legitimate cross-reference reasons should NOT
+# be classified as a stub. Normal injection proceeds.
+printf 'Scenario 16c: long file containing @-include is NOT a stub — normal append\n'
+
+TMP="$(mktemp -d)"
+TARGET="${TMP}/AGENTS.md"
+
+{
+    printf '# AGENTS.md\n\n'
+    for i in $(seq 1 35); do
+        printf 'Long-form content line %d. The full project guide.\n' "${i}"
+    done
+    printf '\nSee also @ARCHITECTURE.md for architecture details.\n'
+    printf '\nMore content.\n'
+} > "${TARGET}"
+
+set +e
+HASH16C="$(inject_in_subshell "${TARGET}" "${SOURCE_FILE_REAL}" 2>/dev/null)"
+RC=$?
+set -e
+
+assert_eq 'long-with-include: exit 0' '0' "${RC}"
+check 'long-with-include: stdout produced 64-char hex hash (NOT empty)' \
+    bash -c "printf '%s' \"\$1\" | grep -Eq '^[0-9a-f]{64}$'" _ "${HASH16C}"
+check 'long-with-include: opening marker present (block was appended)' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${TARGET}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 17: end-to-end F-B2 with stub CLAUDE.md — only 1 routing_blocks entry
+# ---------------------------------------------------------------------------
+printf 'Scenario 17: end-to-end F-B2 with stub CLAUDE.md — 1 entry only\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-seed CLAUDE.md as a stub redirect (matches board-superpowers'
+# own CLAUDE.md form). AGENTS.md is absent — created fresh by F-B2.
+cat > "${REPO_ROOT}/CLAUDE.md" <<'EOF'
+# CLAUDE.md (redirect to AGENTS.md)
+
+This file exists only so **Claude Code** auto-loads the project's
+canonical instructions, which live in **`AGENTS.md`** — a single
+source of truth for both Claude Code and OpenAI Codex CLI sessions.
+
+> **Make all edits in `AGENTS.md`, not here.**
+
+@AGENTS.md
+EOF
+
+CLAUDE_ORIG_SHA="$(sha256_of_file "${REPO_ROOT}/CLAUDE.md")"
+
+set +e
+ALL_OUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'stub-e2e: bootstrap exit 0' '0' "${RC}"
+check 'stub-e2e: AGENTS.md created with marker pair' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\" && grep -Fq '<!-- /board-superpowers:routing -->' \"\$1\"" _ "${REPO_ROOT}/AGENTS.md"
+check_not 'stub-e2e: stub CLAUDE.md NOT given marker pair' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/CLAUDE.md"
+CLAUDE_NEW_SHA="$(sha256_of_file "${REPO_ROOT}/CLAUDE.md")"
+assert_eq 'stub-e2e: stub CLAUDE.md bytes byte-identical (untouched)' \
+    "${CLAUDE_ORIG_SHA}" "${CLAUDE_NEW_SHA}"
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+check 'stub-e2e: state.yml created' test -f "${STATE_FILE}"
+
+# routing_blocks should have ONLY AGENTS.md (1 entry). CLAUDE.md skipped.
+COUNT="$(python3 -c "
+import sys
+data = open(sys.argv[1]).read()
+lines = data.splitlines()
+in_rb = False
+n = 0
+for line in lines:
+    if line.startswith('routing_blocks:'):
+        in_rb = True
+        continue
+    if in_rb:
+        if line.startswith('  - target_file:'):
+            n += 1
+        elif line and not line.startswith(' '):
+            break
+print(n)
+" "${STATE_FILE}")"
+assert_eq 'stub-e2e: state.yml has exactly 1 routing_blocks entry (AGENTS.md only)' '1' "${COUNT}"
+check 'stub-e2e: state.yml mentions AGENTS.md target' \
+    bash -c "grep -Eq 'target_file:.*AGENTS\\.md' \"\$1\"" _ "${STATE_FILE}"
+check_not 'stub-e2e: state.yml does NOT mention CLAUDE.md target' \
+    bash -c "grep -Eq 'target_file:.*CLAUDE\\.md' \"\$1\"" _ "${STATE_FILE}"
+
+: "${ALL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\n— TOTALS —\nPASS: %d\nFAIL: %d\n' "${PASS}" "${FAIL}"

--- a/tests/test-fb2-routing-injection.sh
+++ b/tests/test-fb2-routing-injection.sh
@@ -1067,6 +1067,192 @@ check_not 'stub-e2e: state.yml does NOT mention CLAUDE.md target' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
+# Scenario 18: end-to-end with substantive (non-stub) CLAUDE.md preserved
+# ---------------------------------------------------------------------------
+# The TODO in PR #29 asked to verify F-B2 still injects normally when
+# CLAUDE.md is a substantive (non-stub) file. Hermetic version: pre-seed
+# CLAUDE.md as a 50-line developer-doc-style file (no @-include), run
+# F-B2, expect (1) markers injected after the existing content, (2)
+# state.yml routing_blocks contains both AGENTS.md AND CLAUDE.md, (3)
+# original CLAUDE.md content preserved verbatim above the markers.
+printf 'Scenario 18: end-to-end F-B2 with substantive CLAUDE.md — both files injected\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-seed CLAUDE.md as a substantive developer guide. > 30 lines so
+# the line-count predicate trips, no @-include line so the stub
+# predicate fails — must NOT be classified as stub.
+{
+    printf '# Project CLAUDE.md\n\n'
+    for i in $(seq 1 50); do
+        printf 'Substantive developer guidance line %d.\n' "${i}"
+    done
+    printf '\n## Architecture overview\n\nMore content here.\n'
+} > "${REPO_ROOT}/CLAUDE.md"
+
+CLAUDE_PRE_SHA="$(sha256_of_file "${REPO_ROOT}/CLAUDE.md")"
+
+set +e
+ALL_OUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'substantive-CLAUDE: bootstrap exit 0' '0' "${RC}"
+check 'substantive-CLAUDE: AGENTS.md created with marker pair' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\"" _ "${REPO_ROOT}/AGENTS.md"
+check 'substantive-CLAUDE: CLAUDE.md HAS marker pair (substantive → injected)' \
+    bash -c "grep -Fq '<!-- board-superpowers:routing -->' \"\$1\" && grep -Fq '<!-- /board-superpowers:routing -->' \"\$1\"" _ "${REPO_ROOT}/CLAUDE.md"
+check 'substantive-CLAUDE: original "Substantive developer guidance" content preserved' \
+    grep -Fq 'Substantive developer guidance line 25' "${REPO_ROOT}/CLAUDE.md"
+check 'substantive-CLAUDE: original "## Architecture overview" heading preserved' \
+    grep -Fq '## Architecture overview' "${REPO_ROOT}/CLAUDE.md"
+# File grew (because the routing block was appended).
+CLAUDE_POST_BYTES="$(wc -c < "${REPO_ROOT}/CLAUDE.md" | tr -d ' ')"
+CLAUDE_PRE_BYTES="$(wc -c <<< "${CLAUDE_PRE_SHA}")"  # placeholder; we want pre-file size
+# Recompute pre size from the seeded content cleanly.
+PRE_SIZE_FILE="${TMP}/pre-claude.txt"
+{
+    printf '# Project CLAUDE.md\n\n'
+    for i in $(seq 1 50); do
+        printf 'Substantive developer guidance line %d.\n' "${i}"
+    done
+    printf '\n## Architecture overview\n\nMore content here.\n'
+} > "${PRE_SIZE_FILE}"
+CLAUDE_PRE_BYTES="$(wc -c < "${PRE_SIZE_FILE}" | tr -d ' ')"
+check 'substantive-CLAUDE: file grew (block appended, content NOT replaced)' \
+    test "${CLAUDE_POST_BYTES}" -gt "${CLAUDE_PRE_BYTES}"
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+
+COUNT="$(python3 -c "
+import sys
+data = open(sys.argv[1]).read()
+lines = data.splitlines()
+in_rb = False
+n = 0
+for line in lines:
+    if line.startswith('routing_blocks:'):
+        in_rb = True
+        continue
+    if in_rb:
+        if line.startswith('  - target_file:'):
+            n += 1
+        elif line and not line.startswith(' '):
+            break
+print(n)
+" "${STATE_FILE}")"
+assert_eq 'substantive-CLAUDE: state.yml has 2 routing_blocks entries' '2' "${COUNT}"
+check 'substantive-CLAUDE: state.yml mentions AGENTS.md target' \
+    bash -c "grep -Eq 'target_file:.*AGENTS\\.md' \"\$1\"" _ "${STATE_FILE}"
+check 'substantive-CLAUDE: state.yml mentions CLAUDE.md target' \
+    bash -c "grep -Eq 'target_file:.*CLAUDE\\.md' \"\$1\"" _ "${STATE_FILE}"
+
+: "${ALL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 19: dual stub redirects — routing_blocks empty + check-deps warns
+# ---------------------------------------------------------------------------
+# The TODO in PR #29 asked to verify the degenerate case where BOTH
+# AGENTS.md AND CLAUDE.md are stub redirects (mutually pointing). F-B2
+# must produce routing_blocks: [] (no injection happened anywhere) and
+# check-deps must warn that the routing block is missing — because
+# functionally the routing IS missing: neither file carries the markers.
+printf 'Scenario 19: dual stub redirects — empty routing_blocks + check-deps warns\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+PLUGIN_ROOT="${TMP}/plugin"
+STUBS_DIR="${TMP}/stubs"
+REPO_ROOT="${TMP}/repo"
+
+mkdir -p "${HOME_DIR}" "${STUBS_DIR}"
+make_stub_plugin_root "0.2.0" "${PLUGIN_ROOT}"
+init_tmp_repo "${REPO_ROOT}" "foo/bar"
+stub_gh "${STUBS_DIR}"
+printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
+printf '[]\n' > "${STUBS_DIR}/labels.json"
+
+# Pre-seed BOTH files as stub redirects pointing at each other.
+cat > "${REPO_ROOT}/AGENTS.md" <<'EOF'
+# AGENTS.md (stub redirect)
+
+This file is a stub redirect. The substantive content lives elsewhere.
+
+@CLAUDE.md
+EOF
+
+cat > "${REPO_ROOT}/CLAUDE.md" <<'EOF'
+# CLAUDE.md (stub redirect)
+
+This file is a stub redirect. The substantive content lives elsewhere.
+
+@AGENTS.md
+EOF
+
+AGENTS_PRE_SHA="$(sha256_of_file "${REPO_ROOT}/AGENTS.md")"
+CLAUDE_PRE_SHA="$(sha256_of_file "${REPO_ROOT}/CLAUDE.md")"
+
+set +e
+ALL_OUT="$(run_bootstrap "${HOME_DIR}" "${PLUGIN_ROOT}" "${STUBS_DIR}" \
+    --owner foo --project 1 --repo-root "${REPO_ROOT}" 2>&1)"
+RC=$?
+set -e
+
+assert_eq 'dual-stub: bootstrap exit 0' '0' "${RC}"
+AGENTS_POST_SHA="$(sha256_of_file "${REPO_ROOT}/AGENTS.md")"
+CLAUDE_POST_SHA="$(sha256_of_file "${REPO_ROOT}/CLAUDE.md")"
+assert_eq 'dual-stub: AGENTS.md untouched (stub preserved)' \
+    "${AGENTS_PRE_SHA}" "${AGENTS_POST_SHA}"
+assert_eq 'dual-stub: CLAUDE.md untouched (stub preserved)' \
+    "${CLAUDE_PRE_SHA}" "${CLAUDE_POST_SHA}"
+check_not 'dual-stub: AGENTS.md has NO routing markers' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/AGENTS.md"
+check_not 'dual-stub: CLAUDE.md has NO routing markers' \
+    grep -Fq '<!-- board-superpowers:routing -->' "${REPO_ROOT}/CLAUDE.md"
+
+STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
+STATE_FILE="${STATE_DIR}/state.yml"
+check 'dual-stub: state.yml created' test -f "${STATE_FILE}"
+check 'dual-stub: state.yml has routing_blocks: []' \
+    bash -c "grep -Fq 'routing_blocks: []' \"\$1\"" _ "${STATE_FILE}"
+check_not 'dual-stub: state.yml mentions NO target_file entries' \
+    bash -c "grep -Eq 'target_file:' \"\$1\"" _ "${STATE_FILE}"
+
+# Now run check-deps.sh against this repo and verify it reports
+# "routing block missing" (the dual-stub case is functionally a repo
+# without injected routing — the asymmetric rule MUST trip, since at
+# least one of AGENTS.md / CLAUDE.md exists but neither carries the
+# canonical heading).
+# Use the real plugin root for check-deps.sh — make_stub_plugin_root
+# only copies the bootstrap-related scripts. check-deps.sh is plugin-
+# version-agnostic and only inspects CLAUDE_PROJECT_DIR's repo state.
+CHECK_DEPS_OUT="$(env -i HOME="${HOME_DIR}" \
+    PATH="${STUBS_DIR}:/usr/bin:/bin" \
+    CLAUDE_PROJECT_DIR="${REPO_ROOT}" \
+    bash "${PLUGIN_ROOT_REAL}/scripts/check-deps.sh" --machine 2>&1 || true)"
+check 'dual-stub: check-deps machine mode emits ROUTING_INJECTED=no' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'ROUTING_INJECTED=no'" _ "${CHECK_DEPS_OUT}"
+
+: "${ALL_OUT:-}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\n— TOTALS —\nPASS: %d\nFAIL: %d\n' "${PASS}" "${FAIL}"


### PR DESCRIPTION
## Summary

`bsp_inject_routing_block` previously attempted to write the routing
block to every target it was handed. When CLAUDE.md (or AGENTS.md) is
a stub redirect — short file ending with `@<file>.md` CC @-include
syntax — the helper would either overwrite the stub or, after a sibling
commit turned the file into a stub, leave state.yml claiming an entry
that no longer existed on disk. board-superpowers' own CLAUDE.md (a
13-line `@AGENTS.md` redirect since 25f72e2) was exactly this case.

This PR teaches the helper to recognize stub-redirect targets as a
deliberate no-op pattern, updates the spec / SKILL.md / changelog to
reflect, and fixes the long-standing SoT-vs-AGENTS.md hash drift (the
SoT was missing the H2 heading that AGENTS.md has carried since v0.2.0).

## Automated Verification

- `bash tests/*.sh` → 14/14 test files PASS, zero regression
- `bash tests/test-fb2-routing-injection.sh` → 100/100 assertions PASS
  (96 pre-existing + 4 new scenarios with 22 assertions covering
  stub detection, negative cases, end-to-end skip)
- `shellcheck -x scripts/lib/common.sh scripts/bootstrap-*.sh scripts/check-deps.sh tests/test-fb2-routing-injection.sh` → 0 warnings
- SoT hash now matches board-superpowers' own AGENTS.md routing block
  hash (`b07c6a70...`): no more state.yml ↔ disk drift

## Human Verification TODO

- [ ] On a downstream consumer repo whose CLAUDE.md is a substantive
      (non-stub) file, re-run dep check — verify F-B2 still injects
      normally and state.yml records both `routing_blocks[]` entries.
- [ ] Construct a tmp repo where BOTH AGENTS.md and CLAUDE.md are
      stub redirects pointing at each other — verify F-B2 produces
      `routing_blocks: []` and `check_routing_block` warns.
- [ ] When F-B4 lands (deferred to v1-complete `migrating-repo-version`),
      confirm tamper detection treats stub-redirect targets as
      out-of-scope (never proposes to "restore" a routing block on
      a stub target).

## Retro Notes

This dogfood session surfaced three layered drifts at once:

1. **State ↔ disk hash drift** — `state.yml` AGENTS.md hash didn't
   match disk. Root cause: F-B4 tamper detection (designed for this)
   is deferred; routing block was hand-edited to add an H2 heading
   without re-running F-B2.
2. **State ↔ disk file existence drift** — `state.yml` recorded a
   CLAUDE.md `routing_blocks` entry but CLAUDE.md was a stub (commit
   25f72e2 overwrote markers when stubifying).
3. **Spec ↔ implementation drift** — spec assumed substantive
   CLAUDE.md + AGENTS.md everywhere; the SPOT pattern (one
   substantive file + redirect stub) wasn't a recognized contract.

**Lesson**: when a deferred mechanism (here F-B4) is the system's
primary defense against a class of drift, every other v1-minimum
mechanism that *could* detect the drift incidentally is worth checking.
The bootstrap helper had no fallback for "target is a stub" because
the spec assumed it never would be — but the design pattern the spec
endorses (single SoT + redirects) is exactly the pattern that produces
stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)