### PR TITLE
fix(common): bsp_audit_local_write migrates 3-level legacy paths (#27)

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -287,18 +287,29 @@ sys.exit(1)
 #
 # Inline legacy migration:
 #   Before computing the new path, this function checks whether the
-#   canonical new path exists. If not, it scans the legacy
-#   ~/.board-superpowers/<host>/<repo>/audit-local.jsonl layout
-#   (excluding paths under ~/.board-superpowers/repos/) for a match.
+#   canonical new path exists. If not, it scans for legacy paths
+#   (excluding the new ~/.board-superpowers/repos/ subtree). Two legacy
+#   layouts are recognized:
 #
-#   Match heuristic:
-#     - The legacy path's last directory segment (the "<repo>" part)
-#       must equal the basename of the supplied <repo_root>.
+#     2-level:  ~/.board-superpowers/<host>/<repo>/audit-local.jsonl
+#                  (v0.1.0+ caller signature: <repo> = bare basename)
+#     3-level:  ~/.board-superpowers/<host>/<owner>/<name>/audit-local.jsonl
+#                  (v0.1.0-minimum caller that passed <repo>=<owner>/<name>;
+#                  per issue #27 this layout was previously unmatched and
+#                  silently lost during migration)
+#
+#   Match heuristic (applied uniformly across both layouts):
+#     - The legacy path's INNERMOST directory segment (the "<repo>"
+#       or "<name>" part — i.e. `basename(dirname(candidate))`) must
+#       equal `basename(repo_root)`.
 #     - On ambiguity (multiple matches), prefer the one whose
-#       grandparent segment (the "<host>" part) matches the
-#       owner slug parsed from `git -C <repo_root> remote get-url
-#       origin` (when the remote is reachable and parseable).
-#     - Fallback: basename-only match.
+#       owner-position segment matches the owner slug parsed from
+#       `git -C <repo_root> remote get-url origin` (when the remote
+#       is reachable and parseable). The owner-position segment is:
+#         * 2-level: the GRANDPARENT (= `<host>` in that layout's
+#           naming, but functionally an owner-style identifier);
+#         * 3-level: the PARENT-OF-INNERMOST (= `<owner>`).
+#     - Fallback: basename-only match (first one wins).
 #
 #   On match: mkdir -p the new directory and `mv` the legacy file
 #   to the new path. Subsequent calls see the new path exists and
@@ -351,24 +362,64 @@ bsp_audit_local_write() {
                 fi
             fi
 
-            # Scan legacy paths. Skip the new "repos/" subtree.
+            # Scan legacy paths. Two layouts are checked (per issue #27):
+            #   2-level: <legacy_root>/<host>/<repo>/audit-local.jsonl
+            #   3-level: <legacy_root>/<host>/<owner>/<name>/audit-local.jsonl
+            # Bash globs return the literal pattern when no matches exist,
+            # so each candidate is guarded by `[ -f "${candidate}" ]`.
+            # The new layout root (~/.board-superpowers/repos/...) is
+            # excluded by checking for a leading "repos/" in the relative
+            # path under legacy_root.
             local candidate
-            for candidate in "${legacy_root}"/*/*/audit-local.jsonl; do
+            for candidate in \
+                "${legacy_root}"/*/*/audit-local.jsonl \
+                "${legacy_root}"/*/*/*/audit-local.jsonl
+            do
                 [ -f "${candidate}" ] || continue
-                # Path layout: <legacy_root>/<host>/<repo>/audit-local.jsonl
-                local cand_dir host_seg repo_seg
-                cand_dir="$(dirname "${candidate}")"
-                repo_seg="$(basename "${cand_dir}")"
-                host_seg="$(basename "$(dirname "${cand_dir}")")"
+
+                # Relative directory under legacy_root (drop the prefix +
+                # the trailing /audit-local.jsonl). This is the
+                # depth-aware key used to classify the layout.
+                local rel_dir="${candidate#"${legacy_root}/"}"
+                rel_dir="${rel_dir%/audit-local.jsonl}"
+
                 # Skip the new layout root.
-                [ "${host_seg}" = "repos" ] && continue
+                case "${rel_dir}" in
+                    repos|repos/*) continue ;;
+                esac
+
+                local repo_seg owner_pos_seg
+                case "${rel_dir}" in
+                    */*/*)
+                        # 3-level: host/owner/name. The owner-position
+                        # segment is the directory immediately above
+                        # the innermost (`name`).
+                        repo_seg="${rel_dir##*/}"
+                        local _without_name="${rel_dir%/*}"
+                        owner_pos_seg="${_without_name##*/}"
+                        ;;
+                    */*)
+                        # 2-level: host/repo. The owner-position segment
+                        # is the grandparent (`host` in the legacy naming
+                        # but treated as owner-style for matching).
+                        repo_seg="${rel_dir##*/}"
+                        owner_pos_seg="${rel_dir%/*}"
+                        ;;
+                    *)
+                        # Anything shallower can't host a legacy file.
+                        continue
+                        ;;
+                esac
+
                 # Basename match required.
                 [ "${repo_seg}" = "${repo_basename}" ] || continue
-                # Strong match: host_seg equals owner_slug.
-                if [ -n "${owner_slug}" ] && [ "${host_seg}" = "${owner_slug}" ]; then
+
+                # Strong match: owner-position segment equals owner_slug.
+                if [ -n "${owner_slug}" ] && [ "${owner_pos_seg}" = "${owner_slug}" ]; then
                     legacy_match="${candidate}"
                     break
                 fi
+
                 # Otherwise remember the first basename match as fallback.
                 if [ -z "${legacy_match}" ]; then
                     legacy_match="${candidate}"

--- a/tests/audit-local-migration.sh
+++ b/tests/audit-local-migration.sh
@@ -496,6 +496,63 @@ check '2-level regression: legacy entry preserved' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
+# Scenario 7: idempotent — second invocation does NOT re-emit migration log line
+# ---------------------------------------------------------------------------
+# Per PR #30 Human Verification TODO: confirm `bsp_log` migration line
+# lands in stderr exactly ONCE. The first invocation discovers + moves
+# the legacy file; the second invocation sees the new path exists and
+# never enters the migration block, so no migration log line is emitted.
+printf 'Scenario 7: migration log line emits exactly once (idempotent stderr)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/board-superpowers/audit-local.jsonl"
+printf '{"ts":"legacy"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+# First invocation — captures stderr, expects "migrated legacy file" line.
+ERR1="$(bash -c "
+    set -euo pipefail
+    export HOME='${HOME_DIR}'
+    source '${COMMON_SH}'
+    bsp_audit_local_write '${REPO_ROOT}' '300' 'R' 'managing-board' 'first-emits-migration'
+" 2>&1 1>/dev/null)"
+
+check 'idempotent log: first invocation emits migration line' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'migrated legacy file'" -- "${ERR1}"
+check 'idempotent log: legacy file moved after first invocation' \
+    test ! -f "${LEGACY_FILE}"
+check 'idempotent log: new file exists after first invocation' \
+    test -f "${NEW_FILE}"
+
+# Second invocation — no legacy left to migrate; stderr must NOT
+# contain the migration log line.
+ERR2="$(bash -c "
+    set -euo pipefail
+    export HOME='${HOME_DIR}'
+    source '${COMMON_SH}'
+    bsp_audit_local_write '${REPO_ROOT}' '301' 'R' 'managing-board' 'second-no-migration'
+" 2>&1 1>/dev/null)"
+
+check_not 'idempotent log: second invocation does NOT emit migration line' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'migrated legacy file'" -- "${ERR2}"
+check_not 'idempotent log: second invocation does NOT emit "completed by another process" line' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'completed by another process'" -- "${ERR2}"
+check_not 'idempotent log: second invocation does NOT emit "migration mv failed" warn' \
+    bash -c "printf '%s' \"\$1\" | grep -Fq 'migration mv failed'" -- "${ERR2}"
+
+# Also verify the new file grew by one line (the second append landed).
+check 'idempotent log: new file has 3 lines (legacy + first + second)' \
+    count_eq "${NEW_FILE}" 3
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/tests/audit-local-migration.sh
+++ b/tests/audit-local-migration.sh
@@ -380,6 +380,122 @@ check 'mode field preserved' \
 rm -rf "${TMP}"
 
 # ---------------------------------------------------------------------------
+# Scenario 6: 3-level legacy path — owner/name split from old caller signature
+# ---------------------------------------------------------------------------
+# Per issue #27: v0.1.0-minimum's `bsp_audit_local_write <host> <repo>`
+# signature accepted a `<repo>` arg containing a slash. Callers that
+# passed `<repo>=<owner>/<name>` (e.g. `PanQiWei/board-superpowers`)
+# ended up with a THREE-level legacy path:
+#
+#   ~/.board-superpowers/<host>/<owner>/<name>/audit-local.jsonl
+#
+# The migration scan glob was previously two-levels-only
+# (`/*/*/audit-local.jsonl`) and silently missed these paths. Seeded
+# legacy persisted; new path started fresh; legacy entries were lost
+# from the canonical timeline until manually merged.
+#
+# Migration MUST detect 3-level legacy paths whose innermost segment
+# (the "<name>" part) matches basename(repo_root). The intermediate
+# "<owner>" segment is the org slug; preferred match still uses
+# `git remote get-url origin` org parsing (now compared against
+# the parent of the innermost dir, not its grandparent).
+printf 'Scenario 6: 3-level legacy path (host/owner/name) — migration triggers\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+# Seed a 3-level legacy path mimicking v0.1.0-minimum caller that
+# passed <repo>="PanQiWei/board-superpowers".
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/PanQiWei/board-superpowers"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/PanQiWei/board-superpowers/audit-local.jsonl"
+printf '{"ts":"3-level-legacy","action_id":"100"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '101' 'R' 'managing-board' 'first-write-after-3-level'
+
+check_not '3-level legacy file moved (no longer at old path)' test -f "${LEGACY_FILE}"
+check '3-level new file exists at canonical path' test -f "${NEW_FILE}"
+check '3-level new file has both legacy + new entries (2 lines)' \
+    count_eq "${NEW_FILE}" 2
+check '3-level legacy entry preserved in migrated file' \
+    grep -q '"ts":"3-level-legacy"' "${NEW_FILE}"
+check '3-level new entry appended after migration' \
+    grep -q '"action_id": "101"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6b: 3-level legacy AND owner-aware match preference
+# ---------------------------------------------------------------------------
+# When git remote points at github.com:<owner>/<repo>, and TWO 3-level
+# candidates have matching innermost basenames but only one matches the
+# org slug, prefer the org-matching one.
+printf 'Scenario 6b: 3-level legacy with owner-slug preference\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+# Make repo a real git repo with a github remote so owner_slug parses.
+git -C "${REPO_ROOT}" init --quiet
+git -C "${REPO_ROOT}" remote add origin "git@github.com:PanQiWei/board-superpowers.git"
+
+# Two 3-level legacy candidates: only one is under PanQiWei.
+mkdir -p "${HOME_DIR}/.board-superpowers/host1/SomeoneElse/board-superpowers"
+mkdir -p "${HOME_DIR}/.board-superpowers/host2/PanQiWei/board-superpowers"
+WRONG_LEGACY="${HOME_DIR}/.board-superpowers/host1/SomeoneElse/board-superpowers/audit-local.jsonl"
+RIGHT_LEGACY="${HOME_DIR}/.board-superpowers/host2/PanQiWei/board-superpowers/audit-local.jsonl"
+printf '{"ts":"wrong-owner"}\n' > "${WRONG_LEGACY}"
+printf '{"ts":"correct-owner"}\n' > "${RIGHT_LEGACY}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '102' 'R' 'managing-board' 'owner-aware'
+
+check_not 'owner-aware: PanQiWei legacy moved' \
+    test -f "${RIGHT_LEGACY}"
+check 'owner-aware: SomeoneElse legacy NOT moved' \
+    test -f "${WRONG_LEGACY}"
+check 'owner-aware: new file has the correct legacy entry' \
+    grep -q '"ts":"correct-owner"' "${NEW_FILE}"
+check_not 'owner-aware: new file does NOT contain wrong-owner entry' \
+    grep -q '"ts":"wrong-owner"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# Scenario 6c: 2-level legacy STILL works (no regression on existing path layout)
+# ---------------------------------------------------------------------------
+# This is a regression guard for Scenario 1: the glob extension MUST
+# keep matching 2-level legacy paths. Re-runs Scenario 1's exact shape
+# to make the regression coverage explicit.
+printf 'Scenario 6c: 2-level legacy STILL migrates (regression guard)\n'
+
+TMP="$(mktemp -d)"
+HOME_DIR="${TMP}/home"
+REPO_ROOT="${TMP}/checkout/board-superpowers"
+mkdir -p "${HOME_DIR}/.board-superpowers/somehost/board-superpowers"
+mkdir -p "${REPO_ROOT}"
+LEGACY_FILE="${HOME_DIR}/.board-superpowers/somehost/board-superpowers/audit-local.jsonl"
+printf '{"ts":"2-level-still-works"}\n' > "${LEGACY_FILE}"
+
+NORMALIZED="$(normalize_path "${REPO_ROOT}")"
+NEW_FILE="${HOME_DIR}/.board-superpowers/repos/${NORMALIZED}/audit-local.jsonl"
+
+run_audit_write "${HOME_DIR}" "${REPO_ROOT}" '103' 'R' 'managing-board' '2-level-regress-guard'
+
+check_not '2-level regression: legacy file moved' test -f "${LEGACY_FILE}"
+check '2-level regression: new file exists' test -f "${NEW_FILE}"
+check '2-level regression: legacy entry preserved' \
+    grep -q '"ts":"2-level-still-works"' "${NEW_FILE}"
+
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"


### PR DESCRIPTION
Fixes #27.

## Summary

The migration scan glob in `bsp_audit_local_write` was
`${legacy_root}/*/*/audit-local.jsonl` (two levels under
`~/.board-superpowers/`). v0.1.0-minimum's `bsp_audit_local_write
<host> <repo> ...` signature accepted a `<repo>` arg containing
a slash, so any caller that passed `<repo>=<owner>/<name>` (e.g.
`PanQiWei/board-superpowers`) ended up with a THREE-level legacy
path `~/.board-superpowers/<host>/<owner>/<name>/audit-local.jsonl`
that the migration glob never matched. After Card 1 landed v0.1.1's
migration helper, the first call on a migrated codebase wrote to
the new path BUT silently skipped relocating the legacy 3-level
history. This dogfood Manager session was the canonical reproducer.

This PR extends the glob to walk both 2-level and 3-level layouts
and replaces the basename/dirname-based segment derivation with a
depth-aware classifier so owner-slug preference works uniformly
across both layouts.

## Automated Verification

- `bash tests/audit-local-migration.sh` → 41/41 PASS
  (36 pre-existing scenarios + 5 new assertions across 3 new
   scenarios: 6 = 3-level migration triggers, 6b = owner-slug
   preference among 3-level candidates, 6c = 2-level regression
   guard)
- `bash tests/*.sh` → 14/14 test files PASS, zero regression
- `shellcheck -x scripts/lib/common.sh tests/audit-local-migration.sh`
  → 0 warnings

## Human Verification TODO

- [ ] On a host that actually carries a 3-level legacy file from a
      v0.1.0-minimum dogfood (manually reconstruct one if none
      exist), run any v1-minimum mutating skill and verify the
      legacy entries appear in the merged
      `~/.board-superpowers/repos/<normalized>/audit-local.jsonl`.
- [ ] Confirm `bsp_log` migration line lands in stderr exactly
      once (idempotency — second invocation is a no-op).

## Retro Notes

The bug was discovered by the v0.2.0 dogfood Manager session
itself: when the v0.1.1 migration ran on this very repo's audit
trail, it left 6 lines of legacy `<host>/<owner>/<name>` history
behind. Manual `cat <legacy> <new> > <new>.merged && mv ... && rm
<legacy>` recovery worked but masks the design failure.

**Lesson**: when a wire-format / signature change introduces a
stricter constraint (here: `<repo>` no longer contains a slash),
the migration code that bridges the change should treat the
*pre-change* shape as authoritative — i.e. assume any historical
caller could have done anything the old signature permitted, not
just the canonical case. Issue #27's reproducer existed because
this repo's own v0.1.0-minimum traffic had used the slash-form
`<repo>=PanQiWei/board-superpowers`, which the migration's
glob structurally couldn't see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)