### PR TITLE
docs(adr): land ADR-0010 (v1 GA-relative anchors + 100x cadence)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -433,7 +433,7 @@ preparation:
 | If you change… | You must also update… |
 |----------------|----------------------|
 | `0001-positioning.md` premise (P1..P8) or non-goal | Every spec doc that cites the changed premise (grep `docs/architecture/` for `P<N>`). Promote to a new ADR if the premise materially shifts. |
-| ADR-0005 BoardAdapter contract surface | `0003-domain-model/03-aggregates-and-entities.md` § 3.6.3 (Anti-Corruption Layer); spec for any v1 script that calls the adapter (`board-canon` skill, future scripts). Per ADR-0005 Consequences, the GitHubProjectAdapter wrapper port has a 60-day landing deadline. |
+| ADR-0005 BoardAdapter contract surface | `0003-domain-model/03-aggregates-and-entities.md` § 3.6.3 (Anti-Corruption Layer); spec for any v1 script that calls the adapter (`board-canon` skill, future scripts). Per ADR-0005 Consequences (as amended by ADR-0010), the GitHubProjectAdapter wrapper port lands before v1 GA. |
 | ADR-0006 D-AUTONOMY-1 matrix (rows or A/R/N classification) | `0002-product-features-and-flows/03-producer-surface.md` + `04-consumer-surface.md` (every feature row that cites the matrix); `classifying-actions` skill spec; `auditing-actions` skill spec (`action_id` catalog); `0005-contracts/06-audit-log-schema.md`. |
 | ADR-0007 plugin-runtime constraint set (C-PLUGIN-1/-2/-3) | Every Producer / Consumer feature with verbs like *monitor*, *detect*, *trigger automatically*. The preflight-piggyback idiom citation. |
 | ADR-0008 plugin-to-plugin SKILL invocation | `0005-contracts/04-skill-contracts.md` (sibling-skill classification table); `consuming-card` skill spec (F-C4 fallback rule). |

--- a/docs/architecture/0001-positioning.md
+++ b/docs/architecture/0001-positioning.md
@@ -76,13 +76,14 @@ second-adapter-implementable detail. The reference implementation
 is currently spread across the existing `gh`-bound scripts
 (`claim-card.sh`, `create-card.sh`, `transition-card.sh`); the
 GitHubProjectAdapter wrapper port that consolidates them behind
-the contract is a follow-up PR with a 60-day deadline (see
-ADR-0005 Consequences). So P2a is **"contract committed,
-implementation port queued."**
+the contract is a follow-up PR scheduled to land before v1 GA
+(see ADR-0005 Consequences as amended by ADR-0010). So P2a is
+**"contract committed, implementation port queued."**
 
-*Falsification:* if 6 months pass (by 2026-10-25) and no second
-adapter has been seriously attempted (by us or a contributor),
-P2a was aspiration dressed as commitment.
+*Falsification:* if v1 GA + 1 week (AI cadence) passes and no
+second adapter has been seriously attempted (by us or a
+contributor), P2a was aspiration dressed as commitment. (Anchor
+re-shaped from a 6-month calendar offset by ADR-0010.)
 
 ### P2b — Methodology embedded as code
 

--- a/docs/architecture/adr/0001-pluggable-board-backend-with-github-project-v1.md
+++ b/docs/architecture/adr/0001-pluggable-board-backend-with-github-project-v1.md
@@ -66,9 +66,9 @@ The board layer is **pluggable behind a stable contract**.
 - Teams already on Linear or Jira can adopt board-superpowers
   without migrating boards — once the second adapter ships.
 - The plugin's positioning (P2a) gets a falsifiable architectural
-  anchor: if no second adapter is attempted within 6 months
-  (deadline 2026-10-25, see ADR-0005 Consequences), P2a's "present
-  commitment" framing is downgraded.
+  anchor: if no second adapter is attempted by v1 GA + 1 week (AI
+  cadence; see ADR-0005 Consequences as amended by ADR-0010),
+  P2a's "present commitment" framing is downgraded.
 - ADR-0002 (claim primitive) decouples cleanly from the board: git
   pushes are atomic on any git host; the board adapter only
   observes the resulting status transition.
@@ -82,10 +82,10 @@ The board layer is **pluggable behind a stable contract**.
 - Every new feature that touches board state must route through the
   BoardAdapter contract — not through `gh` directly. The existing
   scripts pre-date this commitment and will be ported behind the
-  contract via the **GitHubProjectAdapter wrapper port** (60-day
-  deadline; see ADR-0005 Consequences). Until then, the contract
-  ships as design intent and the implementation gap is documented
-  honestly.
+  contract via the **GitHubProjectAdapter wrapper port** (lands
+  before v1 GA; see ADR-0005 Consequences as amended by ADR-0010).
+  Until then, the contract ships as design intent and the
+  implementation gap is documented honestly.
 - The contract surface itself (ADR-0005) is now immutable-modulo-
   superseding-ADR. Any change to method signatures, type
   definitions, or error semantics requires a new ADR.

--- a/docs/architecture/adr/0005-board-adapter-contract.md
+++ b/docs/architecture/adr/0005-board-adapter-contract.md
@@ -1,6 +1,6 @@
 # ADR 0005: v1 BoardAdapter contract surface
 
-**Status:** accepted
+**Status:** accepted; § Consequences amended by ADR-0010
 **Date:** 2026-04-25
 **Deciders:** PanQiWei (maintainer)
 
@@ -318,21 +318,26 @@ supersession, not a silent contract amendment.
   not in shape. Refactoring to a single
   `lib/adapters/github.sh` (or equivalent) implementing this
   contract is a separate PR. Sized M-L.
-  - **Hard deadline:** wrapper port lands within 60 days of this
-    ADR's acceptance (i.e., by **2026-06-24**), or P2a is
-    downgraded from "present commitment" to "aspirational" via a
-    0001-positioning.md amendment.
+  - **Hard deadline:** wrapper port lands **before v1 GA**, or
+    P2a is downgraded from "present commitment" to
+    "aspirational" via a 0001-positioning.md amendment.
+    *Anchor re-shaped from a 60-day calendar offset to a
+    v1-GA-relative event by ADR-0010.*
   - Bootstrap-CLI side note: when the wrapper port lands, also
     resolve whether `bootstrap-project.sh`'s `OWNER/NUMBER` arg
     becomes `--adapter github --project-ref OWNER/NUMBER`
     (generic) or stays adapter-specific (each adapter ships its
     own bootstrap script).
-- **6-month falsification check.** If no second adapter has been
-  seriously attempted by **2026-10-25**, file a retro card
-  reconsidering whether P2a + P4a are honest commitments or
-  aspiration. Mechanism: a `chore` Backlog card titled `P2a/P4a
-  falsification check (2026-10-25)` is filed in the same Backlog
-  the day this ADR's PR merges.
+- **Falsification check (v1 GA + 1 week, AI cadence).** If no
+  second adapter has been seriously attempted by **v1 GA +
+  1 week**, file a retro card reconsidering whether P2a + P4a
+  are honest commitments or aspiration. Mechanism: a `chore`
+  Backlog card titled `P2a/P4a falsification check (v1 GA +
+  1w)` is filed in the same Backlog the day this ADR's PR
+  merges; the title is **edited to** `P2a/P4a falsification
+  check (YYYY-MM-DD)` once v1 GA is declared and the absolute
+  date becomes computable. *Anchor re-shaped from a 6-month
+  calendar offset to a v1-GA-relative event by ADR-0010.*
 
 **What this rules out:**
 
@@ -381,10 +386,12 @@ implementation. Closing it now is the whole point of this ADR.
   call sites use it yet" is the price of doing this in the
   right order: spec → port → second-adapter, instead of
   spec-and-port-and-second-adapter-all-at-once.
-- The 60-day wrapper-port deadline and the 6-month
-  P2a/P4a-falsification check are both real commitments. If they
-  slip, 0001-positioning.md P2a should be amended honestly rather
-  than quietly carried.
+- The wrapper-port deadline ("before v1 GA") and the
+  P2a/P4a-falsification check ("v1 GA + 1 week (AI cadence)")
+  are both real commitments. If they slip,
+  0001-positioning.md P2a should be amended honestly rather
+  than quietly carried. *Original anchor sizes (60-day /
+  6-month calendar offsets) re-shaped by ADR-0010.*
 - Future ADR supersessions of this contract should record the
   `before` and `after` contract surface so decision history
   stays traceable.

--- a/docs/architecture/adr/0010-re-anchor-deadlines-ai-cadence.md
+++ b/docs/architecture/adr/0010-re-anchor-deadlines-ai-cadence.md
@@ -1,0 +1,313 @@
+# ADR 0010: Re-anchor ADR-0005 Consequences deadlines to v1 GA + project-wide AI cadence 100x convention (supersedes ADR-0005 § Consequences partial)
+
+**Status:** accepted
+**Date:** 2026-04-27
+**Deciders:** PanQiWei (maintainer)
+
+## Context
+
+ADR-0005 § Consequences pinned two human-cadence anchors when
+the contract surface was first accepted on 2026-04-25:
+
+- **GitHubProjectAdapter wrapper port** — "Hard deadline:
+  wrapper port lands within 60 days of this ADR's acceptance
+  (i.e., by **2026-06-24**), or P2a is downgraded from
+  'present commitment' to 'aspirational'."
+- **6-month falsification check** — "If no second adapter has
+  been seriously attempted by **2026-10-25**, file a retro
+  card reconsidering whether P2a + P4a are honest commitments
+  or aspiration. Mechanism: a `chore` Backlog card titled
+  `P2a/P4a falsification check (2026-10-25)`…"
+
+Two days of dogfood reality on this very repo — plus the
+project's now-explicit cadence expectations — surface a
+mismatch the original anchors did not anticipate:
+
+- **Deadlines were sized in human-team cadence.** A 60-day
+  hard deadline approximates one sprint-length; a 6-month
+  falsification check approximates a quarterly retrospective.
+  Both shapes presuppose throughput that an AI-orchestrated
+  solo project does not have — neither the bottleneck nor the
+  release rhythm matches the assumption baked into those
+  numbers.
+- **Observed cadence on this repo is ~100x compressed.**
+  Between v0.1.0-minimum (2026-04-24) and v0.2.0 (2026-04-26),
+  the project shipped roughly a sprint's worth of
+  spec + implementation in two days. ADR-0009 itself landed
+  two days after ADR-0006. At that cadence, "60 days" and "6
+  months" no longer behave as deadlines — they behave as
+  forgotten footnotes.
+- **The architect's natural-language intervals already
+  presume AI cadence.** Phrases like "in two weeks" or "by
+  next quarter" stated in conversation reflect AI-cadence
+  intentions, not the human-team intervals the same words
+  imply when read literally. Without a project-level
+  convention, future spec authors silently re-import
+  human-cadence semantics into new ADRs and re-introduce the
+  same anchor mismatch.
+- **Anchor types matter as much as anchor sizes.** The
+  wrapper port's deadline is *internal* (it gates a P2a
+  downgrade); the falsification check's anchor is *external*
+  (it asks "did anyone outside try"). The right anchors are
+  not just "smaller numbers" — they are anchors whose
+  triggering events are observable and *meaningful* under the
+  observed cadence: "before v1 GA" for an internal gate;
+  "v1 GA + 1 week" for a market-facing observation window.
+
+These forces require re-anchoring without re-litigating the
+rest of ADR-0005. The contract surface (type definitions,
+method signatures, error semantics, status mapping policy)
+remains immutable per ADR-0005's own immutability gate. Only
+the two deadline anchors in § Consequences move, and a
+project-wide cadence convention is added so future ADRs
+inherit the new semantics by default.
+
+## Decision
+
+Three things land in this ADR. Each is stated as a positive
+present-tense claim.
+
+### 1. Re-anchor the wrapper-port deadline
+
+ADR-0005 § Consequences "GitHubProjectAdapter wrapper port"
+item's `Hard deadline` sub-bullet is replaced with:
+
+> **Hard deadline:** wrapper port lands **before v1 GA**, or
+> P2a is downgraded from "present commitment" to
+> "aspirational" via a 0001-positioning.md amendment.
+
+No fixed calendar date. The anchor is the v1 GA milestone
+itself; the wrapper port is internal architecture and gates
+the P2a commitment, so the natural anchor is the moment
+P2a's "present commitment" first faces external readers (the
+GA announcement), not an arbitrary calendar offset from the
+ADR's acceptance date.
+
+### 2. Re-anchor the falsification check
+
+ADR-0005 § Consequences "6-month falsification check" item is
+replaced with:
+
+> **Falsification check (v1 GA + 1 week, AI cadence).** If no
+> second adapter has been seriously attempted by **v1 GA +
+> 1 week**, file a retro card reconsidering whether P2a + P4a
+> are honest commitments or aspiration. Mechanism: a `chore`
+> Backlog card titled `P2a/P4a falsification check (v1 GA +
+> 1w)` is filed in the same Backlog the day this ADR's PR
+> merges; the title is **edited to** `P2a/P4a falsification
+> check (YYYY-MM-DD)` once v1 GA is declared and the absolute
+> date becomes computable.
+
+The two-stage title (placeholder before GA → absolute date
+after GA) is a deliberate choice: while v1 GA is unscheduled
+the title carries a stable symbolic anchor visible in any
+Backlog scan; once v1 GA lands the title self-updates to a
+concrete date that grep tools and humans can act on.
+
+### 3. Project-wide AI cadence 100x convention
+
+The following is hereby a project-level convention,
+spec-level binding on all docs under `docs/architecture/`
+and `docs/board-superpowers/`:
+
+> All time estimates, deadlines, and intervals in this
+> project's specs assume AI orchestration acceleration of
+> ~100x vs human-team baselines unless explicitly noted
+> otherwise. User-stated natural-language intervals are
+> AI-cadence native and not further compressed.
+
+Scope coverage extends beyond time. The same 100x
+compression applies to **scope-shaped quantities** that are
+sized by analogy with human-team estimation conventions:
+
+- **Card count per batch.** Human-team backlog grooming sizes
+  a sprint at 8–15 cards; AI-cadence batches are sized 1/100
+  of that envelope and re-decomposed each session, not
+  pre-loaded for two-week windows.
+- **Decomposition density.** Human-team story splitting aims
+  for ~1-week stories; AI-cadence cards target the equivalent
+  of "complete in one consumed card" (S-size cards mapping to
+  hours of architect interaction, not weeks of solo work).
+- **Batch granularity.** "Sprint-shaped" plan grouping
+  (multiple weekly sub-deliveries) collapses to a single
+  ad-hoc batch when the AI-orchestration throughput makes
+  the multi-week shape vestigial.
+
+User-stated quantities of any of the above (time, card count,
+batch size) are AI-cadence native — when the architect says
+"two weeks" or "five cards" or "this batch", those
+expressions reference the post-100x reality already and are
+**not** to be re-divided by a future spec author.
+
+The convention's intent: prevent future spec authors from
+reaching for human-team rules of thumb and silently
+re-importing the wrong cadence assumptions. When in doubt,
+spec authors cite this ADR as the canonical source of the
+convention.
+
+### What this ADR does not change
+
+- **ADR-0005 contract surface** — type definitions, method
+  signatures, error semantics, status-mapping policy. All
+  immutable per ADR-0005's own immutability gate. This ADR
+  touches only the two § Consequences deadline anchors.
+- **No other ADR's contract surface.** ADR-0001 P2a / P4a
+  framing stays as-is; the falsification mechanism stays;
+  only the trigger date shape changes.
+- **No chore card is filed by this ADR.** Filing the chore
+  card titled `P2a/P4a falsification check (v1 GA + 1w)` is
+  the responsibility of card #32, which is queued and waits
+  for this ADR to land so the title is contract-compliant.
+- **No 0001-positioning.md amendment.** The 100x convention
+  is a cadence convention, not a P-level commitment; it goes
+  into spec's ADR layer because that is where conventions
+  binding on future spec authors live.
+
+## Consequences
+
+**Same-PR companion edits required:**
+
+- `docs/architecture/adr/0005-board-adapter-contract.md`:
+  - Header `Status:` field amended to
+    `accepted; § Consequences amended by ADR-0010`.
+  - § Consequences "GitHubProjectAdapter wrapper port" item:
+    `Hard deadline` sub-bullet's anchor replaced per
+    Decision §1 above. The 60-day calendar date
+    (`2026-06-24`) is removed.
+  - § Consequences "6-month falsification check" item:
+    anchor + chore card title replaced per Decision §2 above.
+    The 6-month calendar date (`2026-10-25`) is removed.
+- `docs/architecture/adr/README.md`:
+  - Index table appended with row for ADR-0010.
+
+**What this enables:**
+
+- Future spec authors cite this ADR as the canonical source
+  of the AI-cadence convention; "by next quarter" and "in
+  two weeks" stop carrying ambiguous semantics across
+  authors.
+- Wrapper-port and falsification-check anchors become
+  observable under the project's actual release shape rather
+  than aging into forgotten calendar dates.
+- Card #32 unblocks: it can be filed with a contract-
+  compliant title once this ADR lands.
+
+**What this constrains:**
+
+- When v1 GA is declared, the chore card titled `P2a/P4a
+  falsification check (v1 GA + 1w)` MUST be edited to
+  `P2a/P4a falsification check (YYYY-MM-DD)` with the
+  absolute date computed as GA + 7 days. This is a one-shot
+  edit, not a recurring obligation; tracking lives on the
+  chore card itself, not in this ADR.
+- Spec authors quoting human-team timing references in new
+  docs MUST either translate to AI cadence or annotate the
+  reference with `(human-team baseline; AI cadence applies
+  per ADR-0010)` so the divergence is visible at read time.
+
+**What this rules out:**
+
+- Silent re-introduction of human-cadence numbers in new
+  ADRs. Calendar-shaped deadlines that presume human-team
+  throughput are rejected at PR review unless the deadline's
+  context (e.g., a vendor's external SLA) is genuinely human-
+  cadence-bound and explicitly so noted.
+- Treating the 100x convention as a fudge factor. The
+  convention is not an excuse to under-spec; it is a unit
+  conversion. Decomposition rigor (INVEST, vertical slicing)
+  and verification rigor (verification chain in
+  `consuming-card`) are unaffected.
+
+## Alternatives considered
+
+**Leave ADR-0005 § Consequences anchors unchanged; rely on
+the architect to remember the dates.** Rejected: at observed
+cadence both anchors age out of relevance within days of the
+ADR landing. A deadline that the architect "remembers to
+ignore" defeats the purpose of recording the deadline at
+spec level.
+
+**Update only the dates (e.g., "30 days" → "3 days") and
+keep calendar anchors.** Rejected: smaller numbers do not
+fix the *kind* of anchor mismatch. The wrapper port's
+correct anchor is "before v1 GA" (it gates a public
+commitment); the falsification check's correct anchor is
+"v1 GA + 1 week" (it observes a market-facing window). Both
+are event-relative, not calendar-relative; mechanically
+shrinking the calendar offset misses that.
+
+**Bulk-revise every human-cadence anchor across all 9
+existing ADRs in this PR.** Rejected on scope grounds: the
+"one ADR per architectural decision" rule (ADR-0001 § Notes,
+ADR-README.md) means each anchor revision should be its own
+ADR with its own context. Card #31 is scoped to ADR-0005's
+two anchors; other ADRs that need similar re-anchoring get
+their own cards.
+
+**Codify the 100x convention only in `AGENTS.md` /
+`CLAUDE.md` instead of an ADR.** Rejected: those files are
+developer-onboarding guides, not spec-level decisions.
+Conventions binding on future spec authors live in ADRs so
+they survive guide rewrites and so their rationale is
+preserved alongside other architectural decisions. AGENTS.md
+may cross-reference this ADR; the canonical source stays
+here.
+
+**Restrict the convention to time only; leave scope-shaped
+quantities (card count, batch granularity) for a later
+ADR.** Rejected after architect feedback during the
+pre-claim brainstorm for this card: time and scope share
+the same human-team-baseline source, and splitting them into
+two ADRs would replay the same context twice. Coverage of
+both at first drafting is cheaper and clearer; if either
+dimension produces emergent friction later, a follow-up ADR
+narrows or extends as evidence accumulates.
+
+## Notes
+
+- The driver for this ADR is recurring architect feedback
+  during the v1-complete intake batch — captured both in
+  the user's `feedback_ai_cadence_100x.md` auto-memory entry
+  for cross-session continuity and in spec form here. The
+  auto-memory entry is an agent-side convenience; this ADR
+  is the project-level binding source.
+- Scope coverage of the 100x convention (Decision §3
+  "scope-shaped quantities" sub-list) reflects the
+  architect's amended intent — `feedback_ai_cadence_100x.md`
+  was updated mid-claim from "time only" to "time AND
+  scope," and this ADR follows the amended intent rather
+  than the card's original AC text. This is a permitted
+  one-step expansion (still within the ADR-0010 charter of
+  "establish project-wide AI cadence convention") and is
+  surfaced in the PR's Retro Notes for review-time
+  visibility.
+- This ADR ships before v1 GA is declared. The GA-relative
+  anchors are deliberate forward references; they activate
+  semantically the moment v1 GA is announced. Until then
+  the chore card filed by #32 carries the placeholder title
+  per Decision §2.
+- Future ADRs that need to re-introduce human-cadence
+  numbers (e.g., a vendor SLA, an external regulatory
+  deadline) MUST annotate them per the convention's
+  divergence rule above; otherwise PR review treats the
+  number as suspect.
+
+## Related
+
+- ADR-0001 — Pluggable board backend (P2a / P4a are the
+  premises whose falsifiability this ADR protects).
+- ADR-0005 — v1 BoardAdapter contract surface
+  (§ Consequences partially superseded by this ADR;
+  contract surface unchanged).
+- ADR-0006 — Producer autonomy boundary (the ADR that
+  defines AI-orchestration's mutation semantics; this ADR
+  formalizes the cadence side of the same orchestration).
+- ADR-0009 — Allow SQLite as a BYO audit DB scheme
+  (precedent template for "partial supersession of an
+  earlier ADR's specific section").
+- `0001-positioning.md` P2a, P4a, P3 — substrate-commitment
+  and solo / small-team scale framing whose cadence is now
+  explicitly AI-baseline.
+- `feedback_ai_cadence_100x.md` (auto-memory) — agent-side
+  cross-session record of the convention; spec-level binding
+  source is this ADR.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -71,8 +71,9 @@ Omit if no such notes apply.
 | [0002](./0002-claim-via-branch-push.md) | Atomic claim via remote branch push | accepted |
 | [0003](./0003-worktree-per-consumer.md) | One worktree per Consumer session | accepted |
 | [0004](./0004-composition-over-reimplementation.md) | Composition over reimplementation of TDD/QA | accepted |
-| [0005](./0005-board-adapter-contract.md) | v1 BoardAdapter contract surface | accepted |
+| [0005](./0005-board-adapter-contract.md) | v1 BoardAdapter contract surface | accepted; § Consequences amended by ADR-0010 |
 | [0006](./0006-producer-autonomy-boundary.md) | Producer autonomy boundary — autonomous-with-transparency, with explicit permission matrix | accepted |
 | [0007](./0007-plugin-runtime-derived-constraints.md) | Plugin-runtime-derived constraints — three constraints arising from CC / Codex plugin physics | proposed |
 | [0008](./0008-plugin-to-plugin-skill-invocation.md) | Plugin-to-plugin composition via SKILL invocation (vs subagent spawn / MCP / direct import) | accepted |
 | [0009](./0009-allow-sqlite-as-byo-audit-db.md) | Allow SQLite as a BYO audit DB scheme (supersedes ADR-0006 §5 partial) | accepted |
+| [0010](./0010-re-anchor-deadlines-ai-cadence.md) | Re-anchor ADR-0005 Consequences deadlines to v1 GA + project-wide AI cadence 100x convention (supersedes ADR-0005 § Consequences partial) | accepted |

--- a/scripts/submit-pr.sh
+++ b/scripts/submit-pr.sh
@@ -57,7 +57,13 @@ bsp_require_cmd python3
 # validation-rules.md. This script enforces a subset; the full filler
 # detection is delegated to the SKILL body.
 
-VALIDATION_OUTPUT="$(python3 - <<'PY'
+# Pass BODY_FILE as the positional arg to `python3 -`. The arg MUST sit
+# between `python3 -` and the here-doc opener: bash treats tokens after
+# the closing here-doc delimiter as the *next* command, not as args to
+# the here-doc-receiving command. The previous "PY\n${BODY_FILE})" form
+# silently dropped the arg, producing IndexError on sys.argv[1] and a
+# spurious "Permission denied" as bash tried to execute the body file.
+VALIDATION_OUTPUT="$(python3 - "${BODY_FILE}" <<'PY'
 import re, sys
 body = open(sys.argv[1]).read()
 
@@ -96,7 +102,7 @@ if errors:
     sys.exit(1)
 print("PR body validation passed")
 PY
-"${BODY_FILE}")" || bsp_die "PR body validation failed — fix before retry"
+)" || bsp_die "PR body validation failed — fix before retry"
 
 bsp_log "${VALIDATION_OUTPUT}"
 


### PR DESCRIPTION
Lands ADR-0010, which supersedes ADR-0005 § Consequences (partial)
on its two human-cadence deadline anchors and codifies a project-
wide AI cadence 100x convention as spec-level contract.

> **Scope expansion (architect ack 2026-04-27).** While drafting
> this PR, `scripts/submit-pr.sh` exhibited a here-doc-arg bug
> that blocked validation (`sys.argv[1]` IndexError + bash
> "Permission denied" trying to execute the body file). Per
> architect instruction the fix is bundled into this same PR
> rather than filed as a separate followup, since the script's
> brokenness directly affected the very card it was meant to
> close. The fix is a 2-line move (positional arg from after the
> here-doc terminator into the `python3 -` command line). See the
> second commit on this branch (`fix(scripts): submit-pr.sh
> heredoc arg ordering …`) for the details, and the Retro Notes
> for the lesson about here-doc parsing semantics.

## What changed

**ADR-0010 (new):**

- Wrapper-port deadline: `60-day calendar offset` → `before v1 GA`.
- Falsification check: `6-month calendar offset (2026-10-25)` →
  `v1 GA + 1 week (AI cadence)`. Chore-card title pinned as
  `P2a/P4a falsification check (v1 GA + 1w)` until v1 GA is
  declared, then edited to `(YYYY-MM-DD)` once the absolute date
  is computable.
- Project-wide convention (Decision §3): time estimates,
  deadlines, intervals, AND scope-shaped quantities (card count
  per batch, decomposition density, batch granularity) in this
  project's specs assume AI orchestration acceleration of ~100x
  vs human-team baselines. User-stated natural-language intervals
  are AI-cadence native and not further compressed.

**Same-PR companion edits (per AGENTS.md "Same-PR contract update"):**

- `adr/0005-board-adapter-contract.md`: Status field amended to
  `accepted; § Consequences amended by ADR-0010`; the two
  anchor sub-bullets in § Consequences replaced; § Notes
  synchronized.
- `adr/README.md`: index extended (ADR-0010 row + ADR-0005
  status reflected).
- `AGENTS.md`: change-impact matrix row for ADR-0005 updated to
  reference the new "before v1 GA" anchor.
- `0001-positioning.md` P2a paragraph + `adr/0001-...md`
  § Consequences (line 70 falsification anchor + line 85
  wrapper-port anchor) re-anchored to v1-GA-relative for spec-
  graph self-consistency.

## What this PR explicitly does NOT change

- ADR-0005 contract surface (type definitions, method signatures,
  error semantics, status-mapping policy) — immutable per
  ADR-0005's own immutability gate. Verified by post-edit grep
  (no `+`/`-` lines under those headings in the diff).
- Other ADRs' Decision sections.
- `0001-positioning.md` P2a/P4a framing — only the anchor
  expression inside P2a's Falsification paragraph changes.

## Followups deliberately left for separate PRs

- `docs/architecture/0003-domain-model/06-context-map.md:126`
  edge-case mention of "60-day deadline".
- `docs/architecture/adr/0006-producer-autonomy-boundary.md:287`
  "6-month mark" — separate semantics (N=0 sample re-examination,
  not the ADR-0005 anchor).

## Automated Verification

- [x] AC1: ADR file exists at `docs/architecture/adr/0010-re-anchor-deadlines-ai-cadence.md` with `Status: accepted` and `Date: 2026-04-27` — verified via `head -5` + `grep`.
- [x] AC2: Decision section explicitly supersedes ADR-0005 § Consequences "GitHubProjectAdapter wrapper port" + "6-month falsification check" items — verified via `grep -E "GitHubProjectAdapter wrapper port|6-month falsification check"`.
- [x] AC3: New falsification anchor `v1 GA + 1 week` + chore-card title regime (`(v1 GA + 1w)` placeholder → `(YYYY-MM-DD)` post-GA) present — verified via `grep`.
- [x] AC4: New wrapper-port anchor = `before v1 GA`, no fixed calendar date — Decision §1 carries the explicit clarifying paragraph "No fixed calendar date." `2026-06-24` only appears in Context (historical reference) and Consequences (explicit "removed" bookkeeping); not in the new anchor expression.
- [x] AC5: Project-wide AI cadence 100x convention paragraph present verbatim (lines 113-117 of ADR-0010) — verified via `grep -F`.
- [x] AC6: ADR-0005 Status field amended to `accepted; § Consequences amended by ADR-0010` — verified via `head -5 adr/0005-...md`.
- [x] AC7 (negative): No other ADR's contract surface touched — verified via `git diff main... -- docs/architecture/adr/0005-board-adapter-contract.md` filtered for type / signature / error / status-mapping headings; no matches.
- [x] All 5 spec-graph cross-references to the obsoleted anchors (within scope of C′) updated — verified via `grep -nE "60-day|60 days|6-month|2026-06-24|2026-10-25"` sweep (only Context/Consequences historical references and the explicit "Original anchor sizes... re-shaped" annotations remain).
- [x] No emoji introduced into any spec body (project convention; this PR is doc-only on the spec side).
- [x] **submit-pr.sh fix verified** — real run reaches `[bsp] PR body validation passed` before duplicate-PR rejection (proving here-doc args now reach `python3`); negative test rejects filler "n/a" body; `shellcheck -x scripts/submit-pr.sh` clean. See commit `a9b37fa`.

## Human Verification TODO

- [ ] Skim `adr/0010-re-anchor-deadlines-ai-cadence.md` rendered as Markdown in GitHub's UI — confirm the blockquote-styled "Hard deadline" + "Falsification check" replacement bullets read cleanly and don't look amputated.
- [ ] Read Decision §3's "Scope coverage extends beyond time" paragraph + the three sub-bullets — confirm the time→scope expansion (driven by amended architect feedback during this claim, not by the original AC text) reads as a deliberate deepening rather than scope creep. See ADR-0010 Notes §2 for the explicit acknowledgement.
- [ ] Sanity-check that the chore-card title regime is unambiguous — `P2a/P4a falsification check (v1 GA + 1w)` while pending, edited to `P2a/P4a falsification check (YYYY-MM-DD)` once v1 GA is declared. The two-stage title is stored in ADR-0010 Decision §2; #32 will use the placeholder form when filed.

## Retro Notes

- **AC 字面 vs spec-graph 一致性的张力是真问题。** Card AC 第 6 条说 "No other ADR's contract surface is touched" 字面意思容易被读成 "其他 ADR 文件一个字节都不能改"。但 ADR-0005 anchor 一动，引用它的 5 处地方就 stale，AGENTS.md "Same-PR contract update" 又要求同 PR 修。两条规则的真正分界 = "contract surface" 而非"文件字节"——ADR-0005 自己定义的 "contract surface" 是 type/signature/error semantics/status mapping，不包含 § Consequences 的可变锚点。下次再遇到 AC 第 6 条这种"不动其他 ADR"措辞时，先确认 spec-graph 里有几处是引用被修订对象的，把它们一并纳入 PR scope。
- **按文件分组 vs 按"被引用对象"分组，扫 stale 引用要用后者。** 第一次扫描后我把 7 处 stale 引用按"行号差不多"分了组，结果把同一份 ADR-0001 里两处引用同一个 ADR-0005 anchor 的位置分到了 "改" / "不改" 两边。架构师指出后才发现：正确的分组维度是"引用了哪个被修订对象"，无论这些引用在哪个文件第几行。
- **ADR 修订时给被替换的旧 anchor 加 italic 注脚** ("*Anchor re-shaped from … by ADR-0010.*") 是一个轻量但高价值的做法 — 让未来读 ADR-0005 单独阅读的人立刻知道有 amendment，不必跨文件追踪。这个做法可以作为 ADR 修订的 default convention 沉淀。
- **`bash -c` + HEREDOC + 嵌套引号转义不可靠，commit message 走临时文件 + `git commit -F`。** 这次 commit 第一次因转义炸了。Subagent / 自动化场景下应当默认走 `-F`。
- **sandbox shell 是 zsh 不是 bash**。`set -u` + `command -v` 在 zsh 下行为差异让 `bsp_audit_local_write` 第一次报 "dirname not found"。所有调用 `scripts/lib/common.sh` 的脚本都应当用 `bash -c` 显式包一层；可以考虑把这条加到 `common.sh` 顶部的注释里作为调用规约。
- **`submit-pr.sh` 的 here-doc 参数传递 bug（已在本 PR 第二个 commit 修复）。** 原写法 `python3 - <<'PY' ... PY "${BODY_FILE}"` 把位置参数放在 here-doc **之后**——bash 不会把它作为 `python3 -` 的 argv，反而把它当作下一条命令的开头。Python 侧 `sys.argv[1]` 不存在 IndexError；shell 侧 body 文件路径不可执行报 "Permission denied"。修复 = 2 行移动（参数挪到 `python3 -` 之后、here-doc opener 之前）。lesson 沉淀：**任何要给 `python3 -` / `cat -` / 类似"`-` 表示从 stdin 读"的命令传位置参数时，必须放在 `-` 之后、here-doc 之前**——这是 bash 解析 here-doc 时 token 归属的硬规则；放错位置不会报错（语法合法），只会让参数静默丢失，调试时容易误判为 python 代码逻辑问题。
- **PR scope 扩展的判定标准。** 本 PR 原本应只覆盖 ADR-0010，但 `submit-pr.sh` 的 bug 直接阻塞了"close #31"这一动作本身。当 v1-minimum 自身的工具链阻塞了它要交付的卡时，**就地修复 + bundle 到同 PR** 比"file followup card 让 PR 卡住"更符合 100x AI cadence 的精神（也避免后续每张 Consumer 卡都重复撞这个坑）。判定规则可表述为："如果 v1-minimum 内部脚本的 bug 直接阻塞了当前卡的 close 动作，可以 in-PR 修；如果只是 bug 让 close 路径绕了一下但不阻塞，就 file followup。" 这条规矩值得在 `consuming-card` SKILL 里以 anti-pattern / scope-expansion 节的形式沉淀。

---

Closes #31 — board-superpowers v0.2.0 claim trailer.

