### PR TITLE
fix(config): split RepoConfig — team-shared config.yml + per-user config.local.yml

### DIFF
--- a/.board-superpowers/config.yml
+++ b/.board-superpowers/config.yml
@@ -1,15 +1,15 @@
 # board-superpowers per-repo config — committed to git, shared by team.
 # Edited by hand (no auto-bootstrap skill in this version).
-# Schema: skills/using-board-superpowers/references/first-time-user-guide.md.
+# Schema: docs/architecture/0005-contracts/03-config-schemas.md.
+#
+# Per-user fields (wip_limit, autonomy_overrides) live in
+# config.local.yml, which is gitignored via the *.local.*
+# pattern in .gitignore. See 03-config-schemas.md § "config.local.yml".
 
 # Project coordinates. Format: <owner>/<number>. The agent splits on '/'
 # when calling scripts/{read-board,claim-card,submit-pr}.sh.
 project: PanQiWei/4
 
-# Per-Consumer WIP cap (hard rejection from claim-card.sh when exceeded).
-wip_cap_per_consumer: 1
-
-# Future fields (not yet consumed by any v1-minimum script):
+# Future team-shared fields (not yet consumed by any v1-minimum script):
 #   base_branch: main
 #   default_execution_skill: superpowers:subagent-driven-development
-#   autonomy_overrides: {}   # mutating-action override map

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,14 @@ venv/
 .claude/logs/
 .claude/tmp/
 
-# board-superpowers local state
-.board-superpowers/
+# Per-user local override files — convention: <name>.local.<ext>
+# Any file matching this pattern is gitignored. Use for per-user
+# config / state that shadows team-shared tracked files (e.g.,
+# config.local.yml shadows config.yml's per-user fields).
+*.local.*
+
+# board-superpowers local state (claim markers are per-session)
+.board-superpowers/claims/
 
 # board-superpowers Consumer session plan briefs — scratch input that
 # the Consumer hands to subagent-driven-development. Not a durable

--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ For each repo where you want board-superpowers active. Currently manual — an a
 3. **Create `.board-superpowers/config.yml`** in the repo root and commit it:
    ```yaml
    project: <owner>/<number>      # e.g., PanQiWei/4
-   wip_cap_per_consumer: 1
+   ```
+   Then create `.board-superpowers/config.local.yml` (gitignored, per-user):
+   ```yaml
+   wip_limit: 5                   # personal capacity; soft cap, default 5
    ```
 4. **Verify** by running:
    ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,7 +155,10 @@ bash ~/.claude/plugins/board-superpowers/scripts/register-codex-hooks.sh --insta
 3. **在 repo 根目录创建 `.board-superpowers/config.yml` 并提交**：
    ```yaml
    project: <owner>/<number>      # 例如 PanQiWei/4
-   wip_cap_per_consumer: 1
+   ```
+   再创建 `.board-superpowers/config.local.yml`（不提交，per-user）：
+   ```yaml
+   wip_limit: 5                   # 个人并行 capacity；soft cap，默认 5
    ```
 4. **验证**：
    ```bash

--- a/docs/architecture/0005-contracts/03-config-schemas.md
+++ b/docs/architecture/0005-contracts/03-config-schemas.md
@@ -173,10 +173,14 @@ form (one blank line above and below the block within the markers).
 
 ---
 
-## `<repo>/.board-superpowers/config.yml` — RepoConfig
+## `<repo>/.board-superpowers/config.yml` — RepoConfig (team-shared)
 
 User-editable; per-repo. Owned by the **RepoConfig aggregate**
-(0003 § 3.3.7).
+(0003 § 3.3.7). Holds only the **team-shared** subset of project
+config — fields whose value should be identical for every
+collaborator on this repo. Per-user fields (`wip_limit`,
+`autonomy_overrides`) live in the sibling `config.local.yml`
+(see next section).
 
 ### Tracked in git? — **Yes** (per I-13). Team-shared.
 
@@ -185,18 +189,15 @@ User-editable; per-repo. Owned by the **RepoConfig aggregate**
 ```yaml
 # board-superpowers project config.
 # Managed by using-board-superpowers. Safe to edit by hand.
+#
+# Per-user fields (wip_limit, autonomy_overrides) live in
+# config.local.yml — gitignored via the *.local.* pattern.
 
 project: "OWNER/NUMBER"
-wip_limit: 5
 
-# Future fields (not yet consumed):
+# Future team-shared fields (not yet consumed):
 #   base_branch: main
 #   default_execution_skill: superpowers:subagent-driven-development
-#   autonomy_overrides:                # see 03-config-schemas.md
-#     - action_id: 5
-#       class: A
-#       since: "2026-05-15T09:00:00Z"
-#       evolved_by: "github_username"
 ```
 
 ### Field types and defaults
@@ -204,10 +205,8 @@ wip_limit: 5
 | Field | Type | Required? | Default | Notes |
 |-------|------|-----------|---------|-------|
 | `project` | string in `OWNER/NUMBER` form (YAML quoting is stylistic; the value is the bare string) | yes | — | Round-trip stable per ADR-0005 (BoardAdapter `parse / serialize`). The example `project: "OWNER/NUMBER"` is YAML-quoted only to avoid the `/` parser quirk; `project: OWNER/NUMBER` is also valid. |
-| `wip_limit` | positive integer | no | `5` | Soft limit; counted as `In Progress + In Review`; `Blocked` does NOT count (I-6) |
 | `base_branch` | string (branch name) | no (commented placeholder) | `main` (auto-detected from `origin/HEAD`) | Future; not yet read by `claim-card.sh` |
 | `default_execution_skill` | string | no (commented placeholder) | `superpowers:subagent-driven-development` | Future |
-| `autonomy_overrides` | list of objects | no (commented placeholder at v1) | `[]` | See "Autonomy overrides schema" below |
 
 ### No `schema_version` field
 
@@ -221,10 +220,79 @@ beyond the initial `bootstrap-project.sh` write.
 ### Rationale link
 
 - §1.5.2 F-B2 — initial write by `bootstrap-project.sh`.
-- I-6 (WIP limit), I-11, I-13.
+- I-11, I-13.
 - ADR-0005 (BoardAdapter — `project:` round-trip stability).
-- ADR-0006 §4 (autonomy overrides — finalized below).
 - 0003 § 3.3.7 RepoConfig aggregate — entity home.
+
+---
+
+## `<repo>/.board-superpowers/config.local.yml` — LocalRepoConfig (per-user)
+
+User-editable; per-repo, per-architect. Owned by the **RepoConfig
+aggregate** at the per-user layer (0003 § 3.3.7). Holds the
+fields that should NOT be team-coordinated:
+
+- `wip_limit` — personal capacity / parallelism choice.
+  Alice running 5 parallel Consumer agents and Bob running 1
+  is not a team-coordination decision; it is each architect's
+  local capacity preference.
+- `autonomy_overrides` (per-project layer) — personal
+  risk-tolerance choice. Per ADR-0006 §4, each architect may
+  promote different R-class actions to A-class without
+  imposing that promotion on collaborators.
+
+### Tracked in git? — **No**. Gitignored via the project-wide `*.local.*` pattern.
+
+The `*.local.*` pattern is a project-wide convention: any file
+whose name matches `<basename>.local.<ext>` is gitignored
+regardless of directory. This generalizes the per-user override
+file convention beyond board-superpowers — any future per-user
+file in any directory follows the same rule.
+
+### v1 schema
+
+```yaml
+# board-superpowers per-user override config.
+# This file is GITIGNORED via the *.local.* pattern in .gitignore.
+# Each architect on this repo may have different values here.
+
+wip_limit: 5
+
+# Per-project autonomy overrides (per ADR-0006 §4).
+# Merged with ~/.board-superpowers/overrides.yml; this file's
+# entries take precedence on conflict.
+# autonomy_overrides:
+#   - action_id: 5
+#     class: A
+#     since: "2026-05-15T09:00:00Z"
+#     evolved_by: "github_username"
+```
+
+### Field types and defaults
+
+| Field | Type | Required? | Default | Notes |
+|-------|------|-----------|---------|-------|
+| `wip_limit` | positive integer | no | `5` | Soft limit; counted as `In Progress + In Review`; `Blocked` does NOT count (I-6). Each architect sets their own value to reflect personal-machine parallelism capacity. |
+| `autonomy_overrides` | list of objects | no | `[]` | Per-project layer of the autonomy-override schema. Merge precedence: `config.local.yml` entries beat `~/.board-superpowers/overrides.yml` entries on conflict (project-specific beats user-global). Per ADR-0006 §4. |
+
+### No `schema_version` field
+
+Same convention as `config.yml`: not schema-versioned;
+hand-editable; future fields appear as commented placeholders.
+
+### Bootstrap behavior
+
+`bootstrap-project.sh` step 2c writes both `config.yml` (the
+team-shared subset) AND `config.local.yml` (the per-user subset
+with sensible defaults). `config.local.yml` is gitignored before
+the first commit, so subsequent collaborators running F-B2 will
+each generate their own.
+
+### Rationale link
+
+- I-6 (WIP limit), I-11, I-13 (per-user state not in git).
+- ADR-0006 §4 (autonomy overrides — project / user layers).
+- 0003 § 3.3.7 RepoConfig aggregate — per-user layer.
 
 ---
 

--- a/docs/architecture/0005-contracts/07-path-conventions.md
+++ b/docs/architecture/0005-contracts/07-path-conventions.md
@@ -238,10 +238,13 @@ Owned by the **RepoConfig aggregate** (0003 § 3.3.7) plus the
 **ConsumerLogical aggregate** at the claim-marker layer (0003
 § 3.3.3). Lives inside the repo; mode inherits the repo's umask.
 The split between tracked and untracked is load-bearing:
-`config.yml` is tracked (team-shared intent), and the per-session
-`claims/` subdirectory is gitignored locally — but individual claim
-markers are force-added onto their own claim branch (per ADR-0002
-+ I-13).
+`config.yml` holds the **team-shared** subset of project config
+and is tracked; `config.local.yml` holds the **per-user**
+subset (host-/architect-specific overrides like `wip_limit`)
+and is gitignored via the project-wide `*.local.*` pattern; the
+per-session `claims/` subdirectory is gitignored locally — but
+individual claim markers are force-added onto their own claim
+branch (per ADR-0002 + I-13).
 
 Note: per-repo plugin state (`state.yml`) does **not** live here.
 It lives at `~/.board-superpowers/repos/<normalized-repo-path>/state.yml`
@@ -252,7 +255,8 @@ state.
 | Path | Tracked in git? | Owner | Purpose |
 |------|-----------------|-------|---------|
 | `<repo>/.board-superpowers/` | yes (directory) | RepoConfig | Per-repo plugin config root |
-| `<repo>/.board-superpowers/config.yml` | **yes** | RepoConfig | User-editable project config (per [`03-config-schemas.md`](./03-config-schemas.md)) |
+| `<repo>/.board-superpowers/config.yml` | **yes** | RepoConfig | User-editable team-shared project config (per [`03-config-schemas.md`](./03-config-schemas.md) § "config.yml") |
+| `<repo>/.board-superpowers/config.local.yml` | **no** (gitignored via `*.local.*` pattern) | RepoConfig (per-user layer) | Per-user override of team-shared config — `wip_limit`, `autonomy_overrides`, etc. (per [`03-config-schemas.md`](./03-config-schemas.md) § "config.local.yml") |
 | `<repo>/.board-superpowers/claims/` | **no** (gitignored locally) | ConsumerLogical | Per-session claim markers; force-committed to claim branch only |
 | `<repo>/.board-superpowers/claims/<N>.claim` | gitignored locally; **force-added on the claim branch** | ConsumerLogical | One marker per claimed card; YAML payload per [`05-github-artifact-schemas.md`](./05-github-artifact-schemas.md) |
 
@@ -277,7 +281,22 @@ Manager during triage). Per
 
 `config.yml` is tracked because a collaborator joining the repo
 MUST see it in their clone — without `config.yml` the routing
-block has no project to point at. Per I-13 + 0003 § 3.3.7.
+block has no project to point at. It carries only the
+**team-shared** subset of project config (today: `project`;
+future: `base_branch`, `default_execution_skill`). Per I-13 +
+0003 § 3.3.7.
+
+`config.local.yml` is **not** tracked because it carries the
+**per-user** subset (today: `wip_limit`; future:
+`autonomy_overrides`). These fields are personal-capacity or
+personal-risk-tolerance choices, not team-coordination decisions
+— Alice's parallel-session capacity has no contractual claim on
+Bob's. Tracking `wip_limit` would silently force one architect's
+preference onto every collaborator's clone. The `*.local.*`
+gitignore pattern is project-wide, generalizing the convention
+beyond just `config.local.yml`: any future per-user file in any
+directory that follows `<name>.local.<ext>` naming is automatically
+gitignored. Per I-13 + 0003 § 3.3.7 (per-user layer).
 
 `state.yml` is **not** here at all — it lives at
 `~/.board-superpowers/repos/<normalized>/state.yml`, host-local.
@@ -419,23 +438,42 @@ reads them. Format breaks land in `MULTI_AGENT_DEVELOPMENT.md`'s
 during F-B2 setup. The exact form, verbatim from the script:
 
 ```gitignore
+# Per-user local override files — convention: <name>.local.<ext>
+# Any file matching this pattern is gitignored. Use for per-user
+# config / state that shadows team-shared tracked files (e.g.,
+# config.local.yml shadows config.yml's per-user fields).
+*.local.*
+
 # board-superpowers local state (claim markers are per-session)
 .board-superpowers/claims/
 ```
+
+Two distinct entries land:
+
+1. The project-wide `*.local.*` pattern — any file whose name
+   matches `<name>.local.<ext>` is gitignored regardless of
+   directory. This is the canonical per-user override
+   convention (see § "Per-repo layout" Tracked-vs-untracked
+   rationale).
+2. The board-superpowers-specific `.board-superpowers/claims/`
+   rule — claim markers are per-session and must never appear
+   on `main`.
 
 ### Write semantics
 
 | Scenario | Behavior |
 |----------|----------|
-| `.gitignore` does not exist | Created with the block above as its only content |
-| `.gitignore` exists, `entry already present` (exact match `.board-superpowers/claims/`) | Idempotent no-op; logs `✓ already present` |
-| `.gitignore` exists, entry missing | Ensures trailing newline on the existing file, prepends one blank line for visual separation, then appends the comment header + entry |
+| `.gitignore` does not exist | Created with both entries above as its initial content |
+| `.gitignore` exists, both entries already present (exact line match for each) | Idempotent no-op; logs `✓ already present` |
+| `.gitignore` exists, one or both entries missing | Ensures trailing newline on the existing file, prepends one blank line for visual separation, then appends only the missing entries with their respective comment headers |
 
 The "exact match" check uses `grep -Fxq` — a fixed-string,
-whole-line, quiet match. Trailing-slash differences (`.board-superpowers/claims`
-without trailing `/`) are NOT considered duplicates and would result
-in a second appended block. Per the inline implementation in
-`bootstrap-project.sh` lines 211–237.
+whole-line, quiet match. Trailing-slash differences
+(`.board-superpowers/claims` without trailing `/`) are NOT
+considered duplicates and would result in a second appended
+entry. Same logic for `*.local.*` — any whitespace or trailing
+characters break the dedup. Per the inline implementation in
+`bootstrap-project.sh`.
 
 ### Future-extension placeholder
 

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -268,27 +268,50 @@ case "${VALIDATION_RESULT}" in
         ;;
 esac
 
-# --- Step 2c — write <repo>/.board-superpowers/config.yml ----------------
+# --- Step 2c — write <repo>/.board-superpowers/config.yml + config.local.yml ----
 
 CONFIG_DIR="${REPO_ROOT}/.board-superpowers"
 CONFIG_FILE="${CONFIG_DIR}/config.yml"
+LOCAL_CONFIG_FILE="${CONFIG_DIR}/config.local.yml"
 
 mkdir -p "${CONFIG_DIR}" || bsp_die "step 2c: cannot create ${CONFIG_DIR}"
 
 write_config_yml() {
     cat > "${CONFIG_FILE}" <<EOF
-# board-superpowers per-repo configuration (committed to git).
+# board-superpowers per-repo configuration (committed to git, team-shared).
 # Managed by using-board-superpowers. Safe to edit by hand.
 # See docs/architecture/0005-contracts/03-config-schemas.md for the
 # full schema.
+#
+# Per-user fields (wip_limit, autonomy_overrides) live in
+# config.local.yml — gitignored via the *.local.* pattern.
 
 project: "${OWNER}/${PROJECT_NUM}"
+
+# Future team-shared fields (uncomment when needed):
+# audit_db_url: "postgresql://user:pwd@host:5432/db"
+# base_branch: main
+# default_execution_skill: superpowers:subagent-driven-development
+EOF
+}
+
+write_local_config_yml() {
+    cat > "${LOCAL_CONFIG_FILE}" <<'EOF'
+# board-superpowers per-user override config (gitignored).
+# Each architect on this repo may have different values here.
+# See docs/architecture/0005-contracts/03-config-schemas.md
+# § "config.local.yml — LocalRepoConfig" for the full schema.
+
+# Personal capacity / parallelism choice (Soft cap; default 5).
+# Counted as: In Progress + In Review; Blocked excluded.
 wip_limit: 5
 
-# Future fields (uncomment when needed):
-# audit_db_url: "postgresql://user:pwd@host:5432/db"
-# claim_branch_prefix: "claim/"
-# worktree_dir: "/custom/worktrees"
+# Per-project autonomy overrides (per ADR-0006 §4).
+# autonomy_overrides:
+#   - action_id: 5
+#     class: A
+#     since: "YYYY-MM-DDTHH:MM:SSZ"
+#     evolved_by: "github_username"
 EOF
 }
 
@@ -303,40 +326,73 @@ else
     write_config_yml
 fi
 
+if [ -f "${LOCAL_CONFIG_FILE}" ] && [ "${FORCE}" -eq 0 ]; then
+    bsp_log "step 2c: ${LOCAL_CONFIG_FILE} already exists — leaving alone (use --force to overwrite)"
+else
+    if [ -f "${LOCAL_CONFIG_FILE}" ]; then
+        bsp_log "step 2c: --force overwriting ${LOCAL_CONFIG_FILE}"
+    else
+        bsp_log "step 2c: writing ${LOCAL_CONFIG_FILE} (gitignored, per-user)"
+    fi
+    write_local_config_yml
+fi
+
 # --- Step 2d — append to <repo>/.gitignore (idempotent) ------------------
+#
+# Two distinct entries land independently:
+#   1. Project-wide *.local.* per-user override pattern.
+#   2. board-superpowers-specific .board-superpowers/claims/ rule.
+# Each is checked + appended on its own so partial state (one
+# entry already present, the other missing) is handled correctly.
 
 GITIGNORE_FILE="${REPO_ROOT}/.gitignore"
-GITIGNORE_HEADER="# board-superpowers local state (claim markers are per-session)"
-GITIGNORE_ENTRY=".board-superpowers/claims/"
+LOCAL_PATTERN_HEADER="# Per-user local override files — convention: <name>.local.<ext>"
+LOCAL_PATTERN_ENTRY="*.local.*"
+CLAIMS_HEADER="# board-superpowers local state (claim markers are per-session)"
+CLAIMS_ENTRY=".board-superpowers/claims/"
 
-write_gitignore_block() {
-    # Append a leading blank line for visual separation only when the
-    # file already has content. New files start with the block.
-    local prepend_blank="$1"
+ensure_trailing_newline() {
+    if [ -s "${GITIGNORE_FILE}" ]; then
+        tail -c1 "${GITIGNORE_FILE}" | od -An -c | tr -d ' ' | grep -q '\\n' \
+            || printf '\n' >> "${GITIGNORE_FILE}"
+    fi
+}
+
+append_block() {
+    # $1 = header line; $2 = entry line; $3 = "1" to prepend blank line.
+    local header="$1"
+    local entry="$2"
+    local prepend_blank="$3"
     {
         if [ "${prepend_blank}" = "1" ]; then
             printf '\n'
         fi
-        printf '%s\n%s\n' "${GITIGNORE_HEADER}" "${GITIGNORE_ENTRY}"
+        printf '%s\n%s\n' "${header}" "${entry}"
     } >> "${GITIGNORE_FILE}"
 }
 
-if [ -f "${GITIGNORE_FILE}" ]; then
-    if grep -Fxq "${GITIGNORE_ENTRY}" "${GITIGNORE_FILE}"; then
-        bsp_log "step 2d: .gitignore already contains '${GITIGNORE_ENTRY}' — no change"
-    else
-        # Defensive: ensure trailing newline before append so we don't
-        # glue our block onto the last line of an unterminated file.
-        if [ -s "${GITIGNORE_FILE}" ]; then
-            tail -c1 "${GITIGNORE_FILE}" | od -An -c | tr -d ' ' | grep -q '\\n' \
-                || printf '\n' >> "${GITIGNORE_FILE}"
-        fi
-        bsp_log "step 2d: appending board-superpowers block to ${GITIGNORE_FILE}"
-        write_gitignore_block 1
-    fi
+# Bootstrap: create file with both blocks if absent.
+if [ ! -f "${GITIGNORE_FILE}" ]; then
+    bsp_log "step 2d: creating ${GITIGNORE_FILE} with board-superpowers blocks"
+    append_block "${LOCAL_PATTERN_HEADER}" "${LOCAL_PATTERN_ENTRY}" 0
+    append_block "${CLAIMS_HEADER}" "${CLAIMS_ENTRY}" 1
 else
-    bsp_log "step 2d: creating ${GITIGNORE_FILE} with board-superpowers block"
-    write_gitignore_block 0
+    # Append-on-missing for each entry independently.
+    if grep -Fxq "${LOCAL_PATTERN_ENTRY}" "${GITIGNORE_FILE}"; then
+        bsp_log "step 2d: .gitignore already contains '${LOCAL_PATTERN_ENTRY}' — no change"
+    else
+        ensure_trailing_newline
+        bsp_log "step 2d: appending '${LOCAL_PATTERN_ENTRY}' block to ${GITIGNORE_FILE}"
+        append_block "${LOCAL_PATTERN_HEADER}" "${LOCAL_PATTERN_ENTRY}" 1
+    fi
+
+    if grep -Fxq "${CLAIMS_ENTRY}" "${GITIGNORE_FILE}"; then
+        bsp_log "step 2d: .gitignore already contains '${CLAIMS_ENTRY}' — no change"
+    else
+        ensure_trailing_newline
+        bsp_log "step 2d: appending '${CLAIMS_ENTRY}' block to ${GITIGNORE_FILE}"
+        append_block "${CLAIMS_HEADER}" "${CLAIMS_ENTRY}" 1
+    fi
 fi
 
 # --- Step 2e — BYO-RDBMS audit-log credential UX -------------------------

--- a/scripts/bootstrap-rollback.sh
+++ b/scripts/bootstrap-rollback.sh
@@ -131,18 +131,28 @@ fi
 
 bsp_log "rollback starting for ${REPO_ROOT}"
 
-# --- Step 1 (reverse): rm <repo>/.board-superpowers/config.yml ----------
+# --- Step 1 (reverse): rm <repo>/.board-superpowers/{config,config.local}.yml ----
 
 CONFIG_FILE="${REPO_ROOT}/.board-superpowers/config.yml"
+LOCAL_CONFIG_FILE="${REPO_ROOT}/.board-superpowers/config.local.yml"
+
 if [ -f "${CONFIG_FILE}" ]; then
     rm -f "${CONFIG_FILE}"
     bsp_log "removed ${CONFIG_FILE}"
-    # Best-effort: if .board-superpowers/ is now empty (no claims/, no
-    # other files), remove it. rmdir fails silently when non-empty.
-    rmdir "${REPO_ROOT}/.board-superpowers" 2>/dev/null || true
 else
     bsp_log "config.yml absent — skip"
 fi
+
+if [ -f "${LOCAL_CONFIG_FILE}" ]; then
+    rm -f "${LOCAL_CONFIG_FILE}"
+    bsp_log "removed ${LOCAL_CONFIG_FILE}"
+else
+    bsp_log "config.local.yml absent — skip"
+fi
+
+# Best-effort: if .board-superpowers/ is now empty (no claims/, no
+# other files), remove it. rmdir fails silently when non-empty.
+rmdir "${REPO_ROOT}/.board-superpowers" 2>/dev/null || true
 
 # --- Step 2 (reverse): remove bootstrap entry from <repo>/.gitignore ----
 

--- a/skills/board-canon/SKILL.md
+++ b/skills/board-canon/SKILL.md
@@ -125,7 +125,7 @@ WIP_count(consumer) =
 
 Cards in `Blocked` are **excluded** from the count — being blocked is not active work; the Consumer should be picking up something else while waiting.
 
-The default cap is 1 per Consumer. Override per-repo by writing `wip_cap_per_consumer: <N>` in `.board-superpowers/config.yml`. A Consumer attempting to claim a second card while at the cap gets a hard rejection from `claim-card.sh`.
+The default cap is 5 per Consumer (per spec). Each architect overrides per-repo by writing `wip_limit: <N>` in `.board-superpowers/config.local.yml` — this file is **per-user** (gitignored via the project-wide `*.local.*` pattern), so Alice running 5 parallel sessions and Bob running 1 do not impose their preferences on each other. A Consumer attempting to claim a card past their `wip_limit` gets a hard rejection at the agent layer (this skill enforces it before invoking `claim-card.sh`).
 
 `references/wip-counting.md` documents corner cases (suspended cards, abandoned worktrees, post-merge accounting lag, override mechanism).
 

--- a/skills/board-canon/references/state-machine.md
+++ b/skills/board-canon/references/state-machine.md
@@ -13,7 +13,7 @@ Every transition writes one entry to the audit log at `~/.board-superpowers/repo
 
 ## Ready → In Progress
 
-- [ ] Consumer's current WIP_count + 1 ≤ wip_cap_per_consumer
+- [ ] Consumer's current WIP_count + 1 ≤ `wip_limit` (read from `.board-superpowers/config.local.yml`)
 - [ ] No other Consumer has an open `claim/N-...` branch for this card
 - [ ] All hard `depends-on` cards are in Done
 

--- a/skills/board-canon/references/wip-counting.md
+++ b/skills/board-canon/references/wip-counting.md
@@ -33,7 +33,7 @@ A Consumer working on multiple repos has independent WIP counts per repo. The ca
 
 ### WIP cap = 0
 
-Setting `wip_cap_per_consumer: 0` in `.board-superpowers/config.yml` means "no claims allowed without explicit architect override". Useful for read-only Producer sessions or audit-only modes.
+Setting `wip_limit: 0` in `.board-superpowers/config.local.yml` means "no claims allowed without explicit architect override". Useful for read-only Producer sessions or audit-only modes.
 
 ## Why Blocked is excluded
 

--- a/skills/using-board-superpowers/references/first-time-user-guide.md
+++ b/skills/using-board-superpowers/references/first-time-user-guide.md
@@ -37,17 +37,24 @@ gh label create "pr-contract-override"  --description "Bypass PR three-section v
 ### 4. Create `.board-superpowers/config.yml` in the repo
 
 ```yaml
-# .board-superpowers/config.yml — committed to git, shared by team.
+# .board-superpowers/config.yml — committed to git, team-shared.
+# Per-user fields (wip_limit, autonomy_overrides) live in
+# .board-superpowers/config.local.yml — gitignored via *.local.* pattern.
 
 # Project coordinates. Format: <owner>/<number>. The agent splits
 # on '/' when calling the plugin's scripts.
 project: <owner>/<number>
+```
 
-# Per-Consumer WIP cap (hard rejection from claim-card.sh when exceeded).
-wip_cap_per_consumer: 1
+```yaml
+# .board-superpowers/config.local.yml — per-user, NOT committed.
+# Each architect on this repo may set different values here.
 
-# Future fields (not yet consumed):
-#   autonomy_overrides: {}  # mutating-action override map (empty = ask-architect on every mutation)
+# Personal capacity / parallelism choice (Soft cap; default 5).
+wip_limit: 5
+
+# Future fields:
+#   autonomy_overrides: []  # per-project autonomy overrides (per ADR-0006 §4)
 ```
 
 When the agent calls `bash scripts/read-board.sh --owner <X> --project <N>`,

--- a/tests/test-bootstrap-end-to-end.sh
+++ b/tests/test-bootstrap-end-to-end.sh
@@ -298,13 +298,23 @@ CRED_FILE="${HOME_DIR}/.board-superpowers/credentials.yml"
 STATE_DIR="$(normalized_state_dir "${HOME_DIR}" "${REPO_ROOT}")"
 STATE_FILE="${STATE_DIR}/state.yml"
 
+LOCAL_CONFIG_FILE="$(dirname "${CONFIG_FILE}")/config.local.yml"
+
 check 'F-B2: config.yml present' test -f "${CONFIG_FILE}"
 check 'F-B2: config.yml has project: "foo/1"' \
     grep -Fq 'project: "foo/1"' "${CONFIG_FILE}"
-check 'F-B2: config.yml has wip_limit: 5' \
-    grep -Eq '^wip_limit:[[:space:]]*5$' "${CONFIG_FILE}"
+# shellcheck disable=SC2016  # $1 is intentional bash -c positional, not parent expansion
+check 'F-B2: config.yml does NOT carry per-user wip_limit' \
+    bash -c '! grep -Eq "^wip_limit:" "$1"' _ "${CONFIG_FILE}"
 
-check 'F-B2: .gitignore present with bootstrap entry' \
+check 'F-B2: config.local.yml present (per-user, gitignored)' \
+    test -f "${LOCAL_CONFIG_FILE}"
+check 'F-B2: config.local.yml has wip_limit: 5' \
+    grep -Eq '^wip_limit:[[:space:]]*5$' "${LOCAL_CONFIG_FILE}"
+
+check 'F-B2: .gitignore has *.local.* per-user pattern' \
+    grep -Fxq '*.local.*' "${GITIGNORE}"
+check 'F-B2: .gitignore has claims/ bootstrap entry' \
     grep -Fxq '.board-superpowers/claims/' "${GITIGNORE}"
 
 check 'F-B2: AGENTS.md present with both markers' \

--- a/tests/test-bootstrap-rollback.sh
+++ b/tests/test-bootstrap-rollback.sh
@@ -526,6 +526,8 @@ stub_gh "${STUBS_DIR}"
 mkdir -p "${REPO_ROOT}/.board-superpowers"
 cat > "${REPO_ROOT}/.board-superpowers/config.yml" <<EOF
 project: "foo/1"
+EOF
+cat > "${REPO_ROOT}/.board-superpowers/config.local.yml" <<EOF
 wip_limit: 5
 EOF
 cat > "${REPO_ROOT}/.gitignore" <<EOF

--- a/tests/test-fb2-per-repo.sh
+++ b/tests/test-fb2-per-repo.sh
@@ -337,18 +337,30 @@ with open(sys.argv[1]) as f:
 " "${STUBS_DIR}/labels.json")"
 assert_eq 'cold start: 13 labels created' '13' "${LABEL_COUNT}"
 
-# config.yml: written with project: "foo/1" + wip_limit: 5
+# config.yml: written with project: "foo/1" (team-shared only)
 CONFIG="${REPO_ROOT}/.board-superpowers/config.yml"
 check 'config.yml exists' test -f "${CONFIG}"
 check 'config.yml has project: "foo/1"' \
     grep -Fxq 'project: "foo/1"' "${CONFIG}"
-check 'config.yml has wip_limit: 5' \
-    grep -Fxq 'wip_limit: 5' "${CONFIG}"
+# shellcheck disable=SC2016  # $1 is intentional bash -c positional, not parent expansion
+check 'config.yml does NOT carry per-user wip_limit' \
+    bash -c '! grep -Eq "^wip_limit:" "$1"' _ "${CONFIG}"
 
-# .gitignore: created with the canonical entries
+# config.local.yml: written with wip_limit: 5 (per-user, gitignored)
+LOCAL_CONFIG="${REPO_ROOT}/.board-superpowers/config.local.yml"
+check 'config.local.yml exists' test -f "${LOCAL_CONFIG}"
+check 'config.local.yml has wip_limit: 5' \
+    grep -Fxq 'wip_limit: 5' "${LOCAL_CONFIG}"
+
+# .gitignore: created with the canonical entries (both blocks)
 GITIGNORE="${REPO_ROOT}/.gitignore"
 check '.gitignore exists' test -f "${GITIGNORE}"
-check '.gitignore has comment header' \
+check '.gitignore has *.local.* pattern header' \
+    grep -Fxq '# Per-user local override files — convention: <name>.local.<ext>' \
+        "${GITIGNORE}"
+check '.gitignore has *.local.* entry' \
+    grep -Fxq '*.local.*' "${GITIGNORE}"
+check '.gitignore has claims/ comment header' \
     grep -Fxq '# board-superpowers local state (claim markers are per-session)' \
         "${GITIGNORE}"
 check '.gitignore has claims/ entry' \
@@ -492,11 +504,14 @@ stub_gh "${STUBS_DIR}"
 printf '%s\n' "${CANONICAL_STATUS}" > "${STUBS_DIR}/status_opts"
 printf '[]\n' > "${STUBS_DIR}/labels.json"
 
-# Pre-existing config.yml with hand-edited wip_limit: 7
+# Pre-existing config.yml + config.local.yml with hand-edited wip_limit: 7
 mkdir -p "${REPO_ROOT}/.board-superpowers"
 cat > "${REPO_ROOT}/.board-superpowers/config.yml" <<'EOF'
 # hand-edited
 project: "foo/1"
+EOF
+cat > "${REPO_ROOT}/.board-superpowers/config.local.yml" <<'EOF'
+# hand-edited (per-user)
 wip_limit: 7
 EOF
 
@@ -507,11 +522,11 @@ RC=$?
 set -e
 
 assert_eq '--force exit 0' '0' "${RC}"
-CONFIG="${REPO_ROOT}/.board-superpowers/config.yml"
-check '--force regenerated config.yml: wip_limit: 5' \
-    grep -Fxq 'wip_limit: 5' "${CONFIG}"
+LOCAL_CONFIG="${REPO_ROOT}/.board-superpowers/config.local.yml"
+check '--force regenerated config.local.yml: wip_limit: 5' \
+    grep -Fxq 'wip_limit: 5' "${LOCAL_CONFIG}"
 check_not '--force erased hand-edited wip_limit: 7' \
-    grep -Fxq 'wip_limit: 7' "${CONFIG}"
+    grep -Fxq 'wip_limit: 7' "${LOCAL_CONFIG}"
 
 rm -rf "${TMP}"
 
@@ -537,6 +552,9 @@ printf '[]\n' > "${STUBS_DIR}/labels.json"
 cat > "${REPO_ROOT}/.gitignore" <<'EOF'
 # user existing rule
 node_modules/
+
+# Per-user local override files — convention: <name>.local.<ext>
+*.local.*
 
 # board-superpowers local state (claim markers are per-session)
 .board-superpowers/claims/


### PR DESCRIPTION
## Summary

- Split `<repo>/.board-superpowers/config.yml` into team-shared (`config.yml`, tracked) and per-user (`config.local.yml`, gitignored). `wip_limit` and future `autonomy_overrides` move to the per-user file.
- Establish project-wide `*.local.*` gitignore convention — any file matching `<basename>.local.<ext>` is gitignored regardless of directory.
- Rationale: per-user fields like `wip_limit` are personal-capacity choices (parallelism preference per architect's machine) and should not be team-coordinated. The earlier blanket `.board-superpowers/` gitignore line was an *accidentally-correct* workaround for this; the proper fix is the split.

This was discovered during v1-complete intake when the user asked why `.board-superpowers/` was broadly ignored even though `config.yml` is supposed to be tracked per spec — surfacing a spec-vs-implementation drift that didn't fit the human-team-coordination assumption underlying the original schema.

## Changes

- New: `<repo>/.board-superpowers/config.local.yml` (per-user, gitignored)
- Bootstrap: `bootstrap-project.sh` writes both files; appends both gitignore entries (`*.local.*` + `.board-superpowers/claims/`) with independent dedup
- Rollback: `bootstrap-rollback.sh` removes both files
- Spec: `07-path-conventions.md` + `03-config-schemas.md` updated to reflect the split + the `*.local.*` convention
- Skills: `board-canon` SKILL + references point at `config.local.yml` and use spec-correct field name `wip_limit`
- Docs: READMEs (en + zh-CN), `first-time-user-guide.md` updated
- Tests: 3 test files updated; 127/127 pass

## Automated Verification

- [x] shellcheck `-x` clean on all touched scripts and test files
- [x] `verify-skill-frontmatter.sh` OK
- [x] `verify-skill-metadata.sh` OK (6 skills checked)
- [x] `tests/test-fb2-per-repo.sh` — 51/51 pass (including new checks: config.yml lacks wip_limit, config.local.yml has wip_limit: 5, both gitignore entries present, hand-edit preservation in config.local.yml under --force)
- [x] `tests/test-bootstrap-end-to-end.sh` — 42/42 pass
- [x] `tests/test-bootstrap-rollback.sh` — 34/34 pass

## Human Verification TODO

After merging:

- [ ] In your dogfood checkout, discard the unstaged \`wip_cap_per_consumer: 5\` change at the repo-root config.yml (\`git checkout -- .board-superpowers/config.yml\`) since the field no longer lives there.
- [ ] Manually create \`.board-superpowers/config.local.yml\` on your dogfood machine with your preferred \`wip_limit\` (5 by default). The file is gitignored so it stays personal.
- [ ] Verify \`gh project item-list\` parallel claim attempts respect your local \`wip_limit\` (the agent layer reads the new file path).

## Retro Notes

This PR collapses what could have been multiple small cards (gitignore fix, spec amendment, bootstrap update, tests) into one coherent change per the project's AI-cadence-100x scope rule. Discovery → spec amendment → implementation → tests in one session.

Three drifts remain, deliberately scoped *out* and tracked for card #38 (v1 release gate):

1. `wip_cap_per_consumer` (impl name) vs `wip_limit` (spec name) — board-canon SKILL still uses the impl name in some prose; ADR-0006 / spec uses `wip_limit`.
2. Soft-vs-hard semantics for WIP cap — spec says soft, board-canon SKILL says hard, claim-card.sh comment says hard but body doesn't enforce.
3. Layer-A vs Layer-B WIP enforcement — agent enforces procedurally, script-layer enforcement is vapor.

These three are the same shape of problem (impl-vs-spec drift) and belong in the systematic v1 release-gate audit, not piecemeal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)