### PR TITLE
refactor(agents): shard root AGENTS.md into per-directory contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,53 +46,73 @@ index lists everything else in canonical order. v1-minimum
 implementation is the **current state**, not the **target
 state** — v1-complete is the target.
 
-## Required reading
+## Subdirectory contracts
 
-The three documents below are large
-(`PLUGIN_DEVELOPMENT.md` ~440 lines,
-`MULTI_AGENT_DEVELOPMENT.md` ~700 lines,
-`SKILL_DEVELOPMENT.md` ~1290 lines). They are intentionally
-**referenced by name, not loaded with `@`-prefix**, so they do
-not ride into every session's context. Open them on demand
-using `Read` (or its platform equivalent) when the work matches
-their scope. **Do not "fix" these references back to
-`@`-prefix** — that change would force-load all three docs into
-every session and is exactly the anti-pattern they themselves
-warn against.
+This project's per-directory rules are sharded into nested
+`AGENTS.md` files. **Read the relevant contract before any
+work that touches the listed directory** — including planning
+/ design / discussion phases, not just file edits.
 
-### Quick reference: when to read what
+CC auto-loads the nested `CLAUDE.md` shim lazily when you Read
+or Edit a file under that path; Codex CLI does **not** —
+Codex sessions must Read the contract file explicitly before
+editing that subtree.
 
-Use this table to decide before any code or spec change. If
-multiple rows match, read all matched docs.
+When you need to consult a contract during planning, design,
+or cross-directory discussion (i.e., before any file is
+touched), Read the listed file directly — don't rely on lazy
+loading.
 
-| Trigger (what you're about to touch / design) | Read first | Why it's load-bearing |
-|-----------------------------------------------|-----------|----------------------|
-| Anything under `hooks/`, `scripts/`, `.claude-plugin/`, `.codex-plugin/`, or any `marketplace.json`; editing the plugin manifest, adding / changing a hook event, modifying a script's exit-code / stdout contract | `PLUGIN_DEVELOPMENT.md` | Defines the dual-platform (Claude Code + Codex CLI) contracts every script / hook / manifest in this repo conforms to. Wrong contract change = silently broken downstream installs. |
-| Designing or modifying any orchestration where one agent spawns another (Producer → Consumer subagent, agent-teams, `SendMessage`, fan-out / fan-in pipelines, session-id reachback) | `MULTI_AGENT_DEVELOPMENT.md` | Documents the experimental surfaces and the hard rules (e.g., "subagents cannot spawn subagents"). Get this wrong and Mode-2 designs assume capabilities that do not exist. |
-| Writing a new `skills/<name>/SKILL.md` or revising any existing one (incl. its `references/`, `scripts/`, `agents/`, `assets/`, `evals/` siblings); adding a new skill type; renaming a skill; touching frontmatter `description`, `argument-hint`, `arguments`, `when_to_use`, or any other Tier 2 field | `SKILL_DEVELOPMENT.md` | Canonical guide for skill design / creation / maintenance — covers the skill-graph framing (entry / molecular / atomic), three-tier frontmatter discipline, body skeletons, anti-patterns, testing regimes. Skills are this repo's product surface; sloppy authoring fails downstream invisibly. |
-| Creating or modifying a `<skill-dir>/.skill-meta.yaml` (the version + 4-dim metadata file) | `SKILL_DEVELOPMENT.md` § "board-superpowers metadata convention" | Defines the schema: `version` (semver) + `layer` (entry/molecular/atomic) + `type` (technique/pattern/reference/discipline) + `mode` (claude-code-only/codex-only/both) + `bounded-context` (board/session/bootstrap/audit/spec). CI gate `scripts/verify-skill-metadata.sh` enforces consistency between yaml and `SKILLS.md` catalog. Drift here causes silent topology rot. |
-| **Adding, removing, renaming, or re-layering any skill** (anything that changes the topology of `skills/` or the cross-plugin edges board-superpowers depends on) | `SKILLS.md` (already always-loaded) — **edit it BEFORE editing `skills/`**, then both halves land in the same PR. Per `SKILLS.md` "Source-of-truth contract", a `skills/` change without a `SKILLS.md` change is incomplete and unmergeable. | `SKILLS.md` is the source of truth for the skills system topology. Bypassing it lets the catalog drift silently; SPOT (single-point-of-truth) consolidations decay; cross-plugin Mode-2 compatibility loses its checklist. |
-| Editing any file under `docs/architecture/` | All three docs that match the affected surface | The spec leads the implementation. A spec change that violates a platform / multi-agent / skill contract is worse than a code change that does, because every future implementer trusts the spec. |
-| Anything that **clearly** falls in two or three categories above | All matched docs | These docs are designed to compose. Their cross-references assume each is read when its scope is touched. |
+| Working in / about | Contract file | CC auto-load? | Codex auto-load? |
+|--------------------|---------------|---------------|------------------|
+| `skills/**` (writing / editing / discussing skills) | [`skills/AGENTS.md`](./skills/AGENTS.md) | yes (lazy on Read/Edit) | no — Read explicitly |
+| `hooks/**` (hook scripts, `hooks.json`) | [`hooks/AGENTS.md`](./hooks/AGENTS.md) | yes (lazy) | no — Read explicitly |
+| `scripts/**` (bash tooling, `common.sh`) | [`scripts/AGENTS.md`](./scripts/AGENTS.md) | yes (lazy) | no — Read explicitly |
+| `docs/architecture/**` (spec, ADRs, change-impact matrix) | [`docs/architecture/AGENTS.md`](./docs/architecture/AGENTS.md) | yes (lazy) | no — Read explicitly |
+
+The nested `CLAUDE.md` files in each of those directories are
+one-line shims that `@`-include the sibling `AGENTS.md`. Make
+all edits in the `AGENTS.md`, not in the `CLAUDE.md` shim.
+
+### Cross-cutting reference docs
+
+The three large companion docs below are referenced by name —
+**not loaded with `@`-prefix** — so they don't ride into every
+session's context. Open them on demand using `Read` (or its
+platform equivalent) when the work matches their scope. Each
+nested `AGENTS.md` above sends you to the relevant companion
+doc when its scope is touched.
+
+| Doc | When it applies |
+|-----|-----------------|
+| [`PLUGIN_DEVELOPMENT.md`](./PLUGIN_DEVELOPMENT.md) (~440 lines) | hook scripts, bash tooling, plugin manifest, dual-platform (CC + Codex CLI) contracts. |
+| [`MULTI_AGENT_DEVELOPMENT.md`](./MULTI_AGENT_DEVELOPMENT.md) (~700 lines) | subagent / agent-team / orchestration design, `Agent` tool / `SendMessage` / fan-out-fan-in. |
+| [`SKILL_DEVELOPMENT.md`](./SKILL_DEVELOPMENT.md) (~1290 lines) | skill authoring — frontmatter, body skeletons, anti-patterns, testing, `.skill-meta.yaml` schema. |
+
+**Do not "fix" these references back to `@`-prefix** — that
+change would force-load all three docs into every session and
+is exactly the anti-pattern they themselves warn against.
 
 ### Doctrine
 
-These three rules close the rationalization loopholes that make
-"required reading" merely advisory:
+These three rules close the rationalization loopholes that
+make per-directory contracts merely advisory:
 
-1. **No "I already know."** If the trigger row matches, the doc
-   gets read in this session. "I read it last week" is not a
-   substitute — the doc may have changed, and your context
-   window has long since dropped the relevant passages.
+1. **No "I already know."** If a Subdirectory contract row
+   matches your work, the contract file gets read in this
+   session. "I read it last week" is not a substitute — the
+   doc may have changed, and your context window has long
+   since dropped the relevant passages.
 2. **No "this change is too small."** A one-line edit to a
    spec table, a single new field in a SKILL frontmatter, a
    one-character rename of a hook marker — each can violate a
-   contract documented in one of these three docs. Smallness of
+   contract documented in one of these files. Smallness of
    diff is not smallness of blast radius.
-3. **Same-PR contract update.** If your change makes a contract
-   in one of these docs (or in `docs/architecture/`) stale, fix
-   the doc in the **same PR** — not a follow-up. Doc lag is the
-   primary failure mode that makes this pattern decay over time.
+3. **Same-PR contract update.** If your change makes a
+   contract in a nested `AGENTS.md` or a cross-cutting
+   companion doc stale, fix the doc in the **same PR** — not a
+   follow-up. Doc lag is the primary failure mode that makes
+   this pattern decay over time.
 
 ## Architecture at a glance (v1 design)
 
@@ -424,100 +444,19 @@ consumer to read past the other's noise.
   contract — promote it. `docs/plans/` is human-readable
   scaffolding only.
 
-## Spec change-impact matrix
-
-The v1 spec is a graph of cross-references. Touching one node
-often forces companion edits. Use this matrix during PR
-preparation:
-
-| If you change… | You must also update… |
-|----------------|----------------------|
-| `0001-positioning.md` premise (P1..P8) or non-goal | Every spec doc that cites the changed premise (grep `docs/architecture/` for `P<N>`). Promote to a new ADR if the premise materially shifts. |
-| ADR-0005 BoardAdapter contract surface | `0003-domain-model/03-aggregates-and-entities.md` § 3.6.3 (Anti-Corruption Layer); spec for any v1 script that calls the adapter (`board-canon` skill, future scripts). Per ADR-0005 Consequences (as amended by ADR-0010), the GitHubProjectAdapter wrapper port lands before v1 GA. |
-| ADR-0006 D-AUTONOMY-1 matrix (rows or A/R/N classification) | `0002-product-features-and-flows/03-producer-surface.md` + `04-consumer-surface.md` (every feature row that cites the matrix); `classifying-actions` skill spec; `auditing-actions` skill spec (`action_id` catalog); `0005-contracts/06-audit-log-schema.md`. |
-| ADR-0007 plugin-runtime constraint set (C-PLUGIN-1/-2/-3) | Every Producer / Consumer feature with verbs like *monitor*, *detect*, *trigger automatically*. The preflight-piggyback idiom citation. |
-| ADR-0008 plugin-to-plugin SKILL invocation | `0005-contracts/04-skill-contracts.md` (sibling-skill classification table); `consuming-card` skill spec (F-C4 fallback rule). |
-| `0002-product-features-and-flows/05-bootstrap-surface.md` (state file path / schema) | `0003-domain-model/02-bounded-contexts.md` § 3.2.3; `0003-domain-model/03-aggregates-and-entities.md` § RepoBootstrap / HostBootstrap; `0005-contracts/03-config-schemas.md` + `07-path-conventions.md`; `bootstrapping-repo` + `migrating-repo-version` skill specs. |
-| `0002-product-features-and-flows/08-pr-contract.md` (three-section shape) | `consuming-card` skill spec (F-C12); `enforcing-pr-contract` skill spec; `managing-board` Review Queue routine spec (F-02 violation flagging). |
-| Skill catalog (add / rename / split / merge any of the 10 v1 skills) | **`SKILLS.md` FIRST** (per its Source-of-truth contract — do not touch `skills/` until SKILLS.md is updated); then `0004-component-architecture.md` Decision 2 (capability → slot table); `0005-contracts/04-skill-contracts.md` (sibling-skill classification; v1 catalog table); the trigger row above; `README.md` and `README.zh-CN.md` if user-facing trigger phrases change. |
-| Hook intent-injection marker grammar (`INVOKE:` / `REASON:`) | `0004-component-architecture.md` § "Hook intent injection pattern"; `0005-contracts/02-hook-contracts.md` § "Intent-injection markers"; `using-board-superpowers` entry-skill spec. |
-| `~/.board-superpowers/` path layout (host-local state) | `0002-product-features-and-flows/05-bootstrap-surface.md`; `0003-domain-model/02-bounded-contexts.md` § 3.2.3; `0005-contracts/03-config-schemas.md` + `07-path-conventions.md`; `0002-product-features-and-flows/07-cross-cutting-invariants.md` I-13. |
-
-When v1 implementation lands, this matrix grows additional rows
-mapping spec → code (e.g., "if `0005-contracts/04-skill-contracts.md`
-description discipline changes → re-read every `skills/*/SKILL.md`
-frontmatter").
-
-## Maintaining the spec
-
-1. **Read the relevant Required-reading docs first.** The
-   trigger table above tells you which.
-2. **One ADR per architectural decision.** ADRs are immutable
-   once accepted. Superseding an ADR creates a new one; the old
-   one's status field gets `superseded by ADR-N`.
-3. **Cite sources.** When a spec page makes a claim about the
-   platform, link the canonical doc URL (CC docs, Codex docs,
-   agentskills.io). When it makes a claim about academic
-   methodology, link the primary source. The Required-reading
-   docs maintain a "URL freshness" check — adopt the same
-   discipline for new pages.
-4. **Same-PR contract update.** If a spec change makes a
-   companion doc stale, fix the companion in the same PR.
-5. **Spec body stays in English** for shareability across
-   collaborators and locales (per
-   [`SKILL_DEVELOPMENT.md`](./SKILL_DEVELOPMENT.md) Anti-pattern
-   A5). Chinese discussion belongs in commit messages, PR
-   bodies, or `notes-zh.md` files outside the spec tree.
-
 ## Maintaining v1 implementation
 
-The v1-minimum plugin is loadable. The operational checklist:
+Per-directory operational checklists live in nested `AGENTS.md`
+files — see "Subdirectory contracts" above. The
+[`docs/architecture/AGENTS.md`](./docs/architecture/AGENTS.md)
+file owns spec governance (ADR discipline, citation rules,
+Spec change-impact matrix). This section captures only the
+cross-cutting checks that span multiple subdirectories.
 
-### Skills (`skills/<name>/`)
+### Tests / smoke checks (cross-cutting)
 
-- Frontmatter: Tier 1 portable subset (`name` + `description`)
-  is mandatory; Tier 2 fields per the recommendation table in
-  [`SKILLS.md`](./SKILLS.md) catalog. Tier 3 (custom non-spec
-  fields like `version: ...`) is forbidden — those go in
-  `.skill-meta.yaml`.
-- Every skill directory must contain `SKILL.md` AND
-  `.skill-meta.yaml`. CI gate `scripts/verify-skill-metadata.sh`
-  enforces.
-- New skills: edit `SKILLS.md` catalog FIRST (per its
-  Source-of-truth contract), then create the directory.
-- Body length: ≤200 lines for entry, 250-450 for molecular,
-  200-300 for atomic. References move to `references/<topic>.md`
-  past 100 lines.
-
-### Scripts (`scripts/`)
-
-- Strict-mode bash: callers `set -euo pipefail` before sourcing
-  `scripts/lib/common.sh`.
-- Header comment + shellcheck `-x` clean (CI gate).
-- AI-callable tools live under `scripts/`; user-facing CLIs do
-  NOT exist in this plugin (the plugin is consumed via skills /
-  slash commands, not a dedicated CLI).
-
-### Hooks (`hooks/`)
-
-- v1-minimum wires only `SessionStart`. Future hook events use
-  the same `INVOKE: <skill> / REASON: <line>` payload pattern
-  per [`docs/architecture/0005-contracts/02-hook-contracts.md`](./docs/architecture/0005-contracts/02-hook-contracts.md).
-- Every hook script must declare a 10s timeout in `hooks.json`.
-- **Dual-platform registration**: CC auto-discovers
-  `hooks/hooks.json` at plugin load. Codex CLI does NOT — users
-  run `scripts/register-codex-hooks.sh --install-user` (or
-  `--install-repo`) once per Codex install to wire the same
-  `SessionStart` script into `~/.codex/hooks.json` (or
-  `<repo>/.codex/hooks.json`). The script is idempotent and
-  backs up the target file before merging. When adding a new
-  hook event, update BOTH `hooks/hooks.json` AND the snippet
-  generator inside `register-codex-hooks.sh`.
-
-### Tests / smoke checks
-
-- `scripts/verify-skill-metadata.sh` — yaml ↔ SKILLS.md catalog
-  consistency.
+- `scripts/verify-skill-metadata.sh` — yaml ↔ `SKILLS.md`
+  catalog consistency.
 - `scripts/verify-skill-frontmatter.sh` — Tier 1 + Tier 2 +
   no-Tier-3 compliance per SKILL.md.
 - `shellcheck -x scripts/**/*.sh hooks/*.sh` — full pass.
@@ -527,25 +466,12 @@ The v1-minimum plugin is loadable. The operational checklist:
 ### Release flow
 
 - Bump `.claude-plugin/plugin.json` + `.codex-plugin/plugin.json`
-  `version` field per semver (e.g., `v0.1.0-minimum` → `v0.1.1`
-  is a patch; `v0.1.x` → `v0.2.0` is a minor).
+  `version` field per semver (e.g., `v0.1.0-minimum` →
+  `v0.1.1` is a patch; `v0.1.x` → `v0.2.0` is a minor).
 - For deferred-atomic landings, also bump per-skill
   `.skill-meta.yaml` `version` (per
-  [`SKILL_DEVELOPMENT.md`](./SKILL_DEVELOPMENT.md) § "
-  board-superpowers metadata convention").
-
-## Commands (v1 target)
-
-```bash
-# Spec review
-ls docs/architecture/                          # what's specced
-ls docs/architecture/adr/                      # what's decided
-
-# v1 implementation (when it begins)
-# bash scripts/check-deps.sh                   (not yet implemented)
-# for t in tests/*.sh; do bash "$t" || exit 1; done
-# (cd scripts && shellcheck -x ./*.sh)
-```
+  [`SKILL_DEVELOPMENT.md`](./SKILL_DEVELOPMENT.md) §
+  "board-superpowers metadata convention").
 
 <!-- board-superpowers:routing -->
 ## board-superpowers session routing
@@ -644,3 +570,37 @@ a release process.
   skill's "start coding" suggestion does not excuse skipping
   Red → Green → Refactor.
 <!-- /board-superpowers:routing -->
+
+## Do Not
+
+High-frequency footguns. Items here are documented in detail
+elsewhere; this list is a quick scan before submitting a PR.
+
+- **Do not edit at the repo root on a feature branch.** Repo
+  root stays on `main`; all feature work happens in a
+  `git worktree`. See "Working tree discipline" above.
+- **Do not put worktrees inside the repo tree** (e.g.,
+  `<repo>/.worktrees/<branch>`). IDEs and file watchers scan
+  them and the visual confusion is real.
+- **Do not edit `skills/` before `SKILLS.md`.** Per its
+  Source-of-truth contract, a `skills/` change without a
+  paired `SKILLS.md` change is unmergeable.
+- **Do not "fix" `PLUGIN_DEVELOPMENT.md` /
+  `MULTI_AGENT_DEVELOPMENT.md` / `SKILL_DEVELOPMENT.md`
+  references back to `@`-prefix.** That force-loads all three
+  into every session and is the exact anti-pattern they warn
+  against.
+- **Do not skip pre-commit hooks** (`--no-verify`,
+  `--no-gpg-sign`) unless explicitly authorized. Investigate
+  and fix the underlying issue.
+- **Do not amend a commit when a hook failed** — the commit
+  did not happen. Fix the issue, re-stage, and create a NEW
+  commit.
+- **Do not commit changes to `~/.board-superpowers/`** — that
+  directory is host-local state, not project state, and is
+  outside the repo tree.
+- **Do not auto-reach for `gstack:/ship` / `/canary` /
+  `/land-and-deploy`** — board-superpowers does not prescribe
+  a release process. Enable these skills only if they match
+  this repo's deployment shape; otherwise use whatever release
+  flow the consuming repo already has.

--- a/MULTI_AGENT_DEVELOPMENT.md
+++ b/MULTI_AGENT_DEVELOPMENT.md
@@ -683,9 +683,13 @@ periodically.
   to the relevant platform section with a note: "Empirically
   verified <date>; not in primary docs." Link to the test or
   reproducer.
-- This doc is referenced from `AGENTS.md`'s "Required reading"
-  section (after the parent edit accompanying this commit) and is
-  loaded into every Mode-2-design session.
+- This doc is referenced **by name** from `AGENTS.md`'s
+  "Cross-cutting reference docs" table — not loaded with
+  `@`-prefix — so it does not ride into every session's
+  context. The `skills/AGENTS.md` per-directory contract
+  sends agents here when designing orchestration where one
+  agent spawns another (Producer → Consumer subagent,
+  agent-teams, fan-out / fan-in pipelines).
 
 ---
 

--- a/PLUGIN_DEVELOPMENT.md
+++ b/PLUGIN_DEVELOPMENT.md
@@ -479,18 +479,25 @@ accordingly when designing plugin code:
 - When a contract from this doc changes (new hook event, frontmatter
   field renamed, schema breaking change), update both the section
   here AND the dependent code in board-superpowers in the same PR.
-- This doc is referenced from `CLAUDE.md`'s "Required reading"
-  section and is therefore implicitly loaded into every
-  plugin-maintainer session via the `@PLUGIN_DEVELOPMENT.md`
-  syntax. Keep it digestible — agents read it cold.
+- This doc is referenced **by name** from `AGENTS.md`'s
+  "Cross-cutting reference docs" table — not loaded with
+  `@`-prefix — so it does not ride into every session's
+  context. The `hooks/AGENTS.md` and `scripts/AGENTS.md`
+  per-directory contracts send agents here on demand when
+  those subdirectories are touched. Keep it digestible —
+  agents read it cold.
 
 ---
 
 ## See also
 
-- `CLAUDE.md` — board-superpowers developer guide (architecture,
-  change-impact matrix, scripts/skills/hooks-specific maintenance
-  rules)
+- `AGENTS.md` (root) — board-superpowers developer guide
+  (architecture, subdirectory-contract router, working-tree
+  discipline, role routing).
+- `docs/architecture/AGENTS.md` — spec governance + the Spec
+  change-impact matrix that this doc is cross-referenced from.
+- `hooks/AGENTS.md` and `scripts/AGENTS.md` — per-directory
+  operational checklists that send agents to this doc.
 - `README.md` — end-user overview
 - `docs/architecture/0001-positioning.md` — project positioning, premises,
   non-goals

--- a/SKILL_DEVELOPMENT.md
+++ b/SKILL_DEVELOPMENT.md
@@ -1031,7 +1031,7 @@ content, where does each piece live?"
 
 This keeps the body scannable while concentrating maintenance in
 files that can be tested and shellchecked independently. See the
-project-wide rule in `AGENTS.md` § Maintaining scripts: every
+project-wide rule in `scripts/AGENTS.md`: every
 script gets a header comment, strict mode, and `shellcheck -x`.
 
 ### `scripts/` is for AI-callable tools, not user CLIs
@@ -1497,7 +1497,7 @@ each is a known unknown to re-check periodically.
   renamed, a directory convention shifted, the spec at
   agentskills.io updated), update both the section here AND any
   dependent skills in board-superpowers in the same PR.
-- This doc is referenced from `AGENTS.md`'s "Maintaining skills"
+- This doc is referenced from `skills/AGENTS.md`
   section. Keep it digestible — agents read it cold.
 - When promoting an "Honest gap" to a documented contract (e.g.,
   a body-length cap finally documented upstream), move the entry
@@ -1515,9 +1515,10 @@ each is a known unknown to re-check periodically.
 - `MULTI_AGENT_DEVELOPMENT.md` — multi-agent / subagent /
   orchestration contracts. Required reading before designing a
   skill that spawns subagents (Skeleton C / pipeline skills).
-- `AGENTS.md` — board-superpowers developer guide.
-  "Maintaining skills" section is the operational checklist that
-  complements this doc.
+- `AGENTS.md` — board-superpowers developer guide. The root
+  `AGENTS.md` "Cross-cutting reference docs" table sends agents
+  here on demand. The `skills/AGENTS.md` per-directory contract
+  is the operational checklist that complements this doc.
 - `README.md` — end-user overview.
 - Reference implementations read in full while drafting:
   - `anthropics/skills` (`skill-creator`, `docx`, `claude-api`)

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface.md
@@ -33,10 +33,11 @@ The four user scenarios this matrix covers (see §2.1 / §2.2 /
 **Cross-cutting principles applied throughout this section**
 (every subsection MUST honor):
 
-- **Self-contained scripts at the dep-check layer.** Per `CLAUDE.md`
-  ("Two files are deliberately self-contained"),
-  `scripts/check-deps.sh` and `hooks/session-start.sh` MUST NOT
-  source `scripts/lib/common.sh`. A broken lib must never break
+- **Self-contained scripts at the dep-check layer.** Per
+  `scripts/AGENTS.md` § "Self-contained scripts" and
+  `hooks/AGENTS.md` Invariant 1, `scripts/check-deps.sh` and
+  `hooks/session-start.sh` MUST NOT source
+  `scripts/lib/common.sh`. A broken lib must never break
   dependency detection or session startup.
 - **Three-layer alert + intent-injection strategy.** Layer 1
   (SessionStart hook) does **two** things: (a) the dep alert
@@ -185,7 +186,7 @@ needs its config.
   PROJECT=<absolute path>
   ```
   Renaming any of these three keys breaks the SessionStart hook
-  parser (`hooks/session-start.sh`); see `CLAUDE.md` change-impact
+  parser (`hooks/session-start.sh`); see `docs/architecture/AGENTS.md` change-impact
   matrix.
 - **Three-layer delivery** (in increasing reliability):
   - **Layer 1 — SessionStart hook**: `hooks/session-start.sh`

--- a/docs/architecture/0002-product-features-and-flows/07-cross-cutting-invariants.md
+++ b/docs/architecture/0002-product-features-and-flows/07-cross-cutting-invariants.md
@@ -165,9 +165,10 @@ injected into downstream `CLAUDE.md` and `AGENTS.md` is
 byte-identical to the fenced block in
 `skills/using-board-superpowers/references/agentsmd-routing.md`
 between the marker pair. Edits to one MUST land in the other
-in the same commit. Cited by: F-B2, F-B4, `CLAUDE.md`
-change-impact matrix, the `<!-- board-superpowers:routing -->`
-marker pair detected by `check-deps.sh`.
+in the same commit. Cited by: F-B2, F-B4,
+`docs/architecture/AGENTS.md` change-impact matrix, the
+`<!-- board-superpowers:routing -->` marker pair detected by
+`check-deps.sh`.
 **Aggregate:** RepoBootstrap (RoutingBlockTracker member
 entity carries the BlockHash that enforces the mirror).
 What breaks: routing

--- a/docs/architecture/0002-product-features-and-flows/30-cross-references.md
+++ b/docs/architecture/0002-product-features-and-flows/30-cross-references.md
@@ -61,7 +61,7 @@ feature, all are listed.
 | 1.6.2 Vertical slicing rule | `skills/decomposing-into-milestones/SKILL.md` ("Vertical slicing") + `references/decomposition-patterns.md` |
 | 1.6.3 Card body schema | `skills/decomposing-into-milestones/references/card-schema.md`; `skills/board-protocol/SKILL.md` |
 | 1.6.4 Size labels | `skills/decomposing-into-milestones/SKILL.md` ("Size calibration"); `scripts/bootstrap-project.sh` (creates `size:*` labels) |
-| 1.7 Cross-cutting invariants I-1..I-13 | Distributed across skills + scripts; `CLAUDE.md` change-impact matrix; `docs/architecture/adr/*.md`; for I-11..I-13 also `${CLAUDE_PLUGIN_ROOT}/scripts/migrations/` (planned) |
+| 1.7 Cross-cutting invariants I-1..I-13 | Distributed across skills + scripts; `docs/architecture/AGENTS.md` change-impact matrix; `docs/architecture/adr/*.md`; for I-11..I-13 also `${CLAUDE_PLUGIN_ROOT}/scripts/migrations/` (planned) |
 | 1.8.1 `## Automated Verification` | `skills/consuming-card/references/pr-template.md` |
 | 1.8.2 `## Human Verification TODO` | `skills/consuming-card/references/pr-template.md` |
 | 1.8.3 `## Retro Notes` | `skills/consuming-card/references/pr-template.md`; aggregated by F-12 |

--- a/docs/architecture/0003-domain-model/06-context-map.md
+++ b/docs/architecture/0003-domain-model/06-context-map.md
@@ -246,7 +246,7 @@ current map's logic.
   (`scripts/*.sh` exit codes, `check-deps.sh --machine` keys,
   routing-block marker strings, `${CLAUDE_PLUGIN_ROOT}` env
   var, etc.) live in `0005-contracts.md` (when filled) and
-  the `CLAUDE.md` change-impact matrix.
+  the `docs/architecture/AGENTS.md` change-impact matrix.
 
 The map's job is to make context boundaries argumentatively
 visible — to give a future maintainer a one-page check on

--- a/docs/architecture/0004-component-architecture.md
+++ b/docs/architecture/0004-component-architecture.md
@@ -126,7 +126,7 @@ in `using-board-superpowers/SKILL.md` body:
 
 CC's `SessionStart` delivery is documented as unreliable
 (`PLUGIN_DEVELOPMENT.md` "Hooks (`hooks/hooks.json`)" calls out
-the buggy delivery; `AGENTS.md` "Maintaining hooks" mandates
+the buggy delivery; `hooks/AGENTS.md` mandates
 silent-no-op-on-error). So:
 
 - `using-board-superpowers/SKILL.md` Step 1 always re-runs

--- a/docs/architecture/0005-contracts/01-script-contracts.md
+++ b/docs/architecture/0005-contracts/01-script-contracts.md
@@ -17,7 +17,7 @@ These rules apply to every script under `scripts/`:
   sources `scripts/lib/common.sh` immediately after — except
   `check-deps.sh`, which is **deliberately self-contained** (no
   source) so a broken lib cannot derail dep detection. Per
-  `AGENTS.md` "Two files are deliberately self-contained."
+  `scripts/AGENTS.md` "Self-contained scripts".
 - **Header comment is the help text.** `bsp_show_help` (from
   `lib/common.sh`) prints the leading `# ...` block as `--help`
   output. Every script supports `-h` / `--help`.
@@ -45,7 +45,7 @@ These rules apply to every script under `scripts/`:
     not consolidate without an ADR-0002 supersession.
 
   New exit codes require updating every caller plus every branching
-  skill. See `AGENTS.md` change-impact matrix.
+  skill. See `docs/architecture/AGENTS.md` change-impact matrix.
 
 - **Strict input parsing.** Owner / number / repo arguments go
   through `bsp_parse_owner_number` or `bsp_parse_owner_repo` in
@@ -94,7 +94,7 @@ No flag arg vector beyond optional `--machine` mode toggle.
 
 **`--machine` keys are protocol** — `MISSING`, `ROUTING_INJECTED`,
 `PROJECT`. Renaming any of them breaks `hooks/session-start.sh`'s
-parser (per `AGENTS.md` change-impact matrix).
+parser (per `docs/architecture/AGENTS.md` change-impact matrix).
 
 ### Exit codes
 
@@ -115,8 +115,9 @@ root's `CLAUDE.md` (if present).
 
 - `0002-product-features-and-flows/05-bootstrap-surface.md` §1.5.0
   (the dep-check shared primitive).
-- `AGENTS.md` "Two files are deliberately self-contained" + change-
-  impact matrix entry for the `--machine` keys.
+- `scripts/AGENTS.md` "Self-contained scripts" +
+  `docs/architecture/AGENTS.md` change-impact matrix entry for
+  the `--machine` keys.
 - ADR-0007 C-PLUGIN-2 (no daemon — preflight check is the
   no-daemon-friendly readiness probe).
 
@@ -438,7 +439,7 @@ injection vector (H1/L3) is closed.
 ## `scripts/lib/common.sh`
 
 Shared library; not directly executable. Caller MUST `set -euo
-pipefail` before sourcing. Per `AGENTS.md` "Maintaining scripts."
+pipefail` before sourcing. Per `scripts/AGENTS.md`.
 
 ### Exported functions
 
@@ -472,13 +473,13 @@ pipefail` before sourcing. Per `AGENTS.md` "Maintaining scripts."
 Function signatures are part of the public contract for any script
 under `scripts/` that sources `common.sh`. Renaming a function or
 changing its arg order requires updating every caller in the same
-PR (per `AGENTS.md` change-impact matrix row 3).
+PR (per `docs/architecture/AGENTS.md` change-impact matrix row 3).
 
 ---
 
 ## Shell-style discipline
 
-Per `AGENTS.md` "Maintaining scripts":
+Per `scripts/AGENTS.md`:
 
 - `shellcheck -x ./*.sh` from the `scripts/` directory before
   committing. SC1091 typically means wrong cwd, not a real bug.

--- a/docs/architecture/0005-contracts/02-hook-contracts.md
+++ b/docs/architecture/0005-contracts/02-hook-contracts.md
@@ -281,22 +281,24 @@ pure-bash RFC 8259 §7 string escaper:
 | Any other non-zero | Non-blocking error | Hook output ignored; session continues |
 
 **board-superpowers' invariant: hook failures MUST NEVER block
-session start.** Per `AGENTS.md` "Maintaining hooks": silent no-op
-on error is the correct failure mode at this layer; the SKILL
-preflight (Layer 2) is the real safety net.
+session start.** Per `hooks/AGENTS.md` Invariant 3 ("Never
+block"): silent no-op on error is the correct failure mode at
+this layer; the SKILL preflight (Layer 2) is the real safety
+net.
 
 ### Timeout
 
-Declared `10` seconds in `hooks.json`. Per `AGENTS.md`: "Keep new
-work well under it." If `check-deps.sh --machine` ever exceeds 10s
-in practice, the dep-detection algorithm (not the timeout) is the
-thing to fix.
+Declared `10` seconds in `hooks.json`. Per `hooks/AGENTS.md`
+Invariant 4 ("10-second budget"): "Keep new work well under
+it." If `check-deps.sh --machine` ever exceeds 10s in practice,
+the dep-detection algorithm (not the timeout) is the thing to
+fix.
 
 ### Self-containment
 
 `hooks/session-start.sh` MUST NOT source `scripts/lib/common.sh`.
 A broken or missing lib must never prevent Claude Code startup.
-Per `AGENTS.md` "Two files are deliberately self-contained."
+Per `hooks/AGENTS.md` Invariant 1 ("Self-contained").
 
 The script's only dependency-resolution step at v1 is locating
 `${CLAUDE_PLUGIN_ROOT}/scripts/check-deps.sh` and exec-ing it via
@@ -304,7 +306,7 @@ The script's only dependency-resolution step at v1 is locating
 
 ### Cited rationale
 
-- `AGENTS.md` "Maintaining hooks" — invariants 1–4 (self-contained,
+- `hooks/AGENTS.md` — invariants 1–4 (self-contained,
   sanitize, never block, 10s budget).
 - `0002-product-features-and-flows/05-bootstrap-surface.md` §1.5
   three-layer alert strategy — Layer 1 is this hook.
@@ -373,5 +375,5 @@ recommended convention; see [`08-environment-variables.md`](./08-environment-var
   `CLAUDE_PLUGIN_ROOT`, `CLAUDE_PROJECT_DIR`, `BOARD_SP_DEBUG`.
 - ADR-0007 — derivation of why hooks must be best-effort.
 - `PLUGIN_DEVELOPMENT.md` — upstream hook contracts (CC + Codex).
-- `AGENTS.md` "Maintaining hooks" — operational checklist for
+- `hooks/AGENTS.md` — operational checklist for
   changes to this surface.

--- a/docs/architecture/0005-contracts/08-environment-variables.md
+++ b/docs/architecture/0005-contracts/08-environment-variables.md
@@ -32,8 +32,9 @@ These rules apply to every env var in this section:
   table. Silent fallback to the default on bad input is forbidden.
 - **Reserved namespace: `BOARD_SP_*`.** All plugin-specific env
   vars live in this namespace. Adding a new one requires updating
-  this file and any caller in the same PR (per `AGENTS.md`
-  change-impact matrix; new env vars are a contract surface).
+  this file and any caller in the same PR (per
+  `docs/architecture/AGENTS.md` change-impact matrix; new env
+  vars are a contract surface).
 
 ### `--machine` keys are NOT env vars
 
@@ -198,7 +199,7 @@ event), not board-superpowers-driven.
 The **only** reliable way to reference plugin-internal files
 (scripts, references, agent definitions) from a hook or skill.
 Hard-coding `~/.claude/plugins/board-superpowers/...` is forbidden
-per `AGENTS.md` "Maintaining scripts" + `PLUGIN_DEVELOPMENT.md`
+per `scripts/AGENTS.md` + `PLUGIN_DEVELOPMENT.md`
 "Claude Code → `${CLAUDE_PLUGIN_ROOT}`".
 
 **Codex CLI equivalent: none.** Codex scripts must derive their own
@@ -214,9 +215,9 @@ surface mapping → Plugin install env var".
   — canonical home for the upstream contract.
 - `hooks/session-start.sh` line 21 + `hooks/hooks.json` line 8 —
   v1 consumers.
-- `AGENTS.md` "Maintaining scripts → `${CLAUDE_PLUGIN_ROOT}` is the
-  only reliable way for scripts to reference the plugin's own files."
-  — protocol invariant.
+- `scripts/AGENTS.md` — `${CLAUDE_PLUGIN_ROOT}` is the only
+  reliable way for scripts to reference the plugin's own files,
+  surfaced as a protocol invariant.
 
 ---
 
@@ -303,5 +304,6 @@ change-impact matrix.
 - `MULTI_AGENT_DEVELOPMENT.md` "What this means for
   board-superpowers" — context for the experimental-flag entries
   in the "does NOT read" table.
-- `AGENTS.md` "Worktree default path", "Maintaining scripts" —
-  protocol invariants surfaced here.
+- `AGENTS.md` § "Working tree discipline" → "Default worktree
+  path" + `scripts/AGENTS.md` — protocol invariants surfaced
+  here.

--- a/docs/architecture/0005-contracts/README.md
+++ b/docs/architecture/0005-contracts/README.md
@@ -19,7 +19,7 @@
 0005 supersedes the "Protocol invariants" section that previously
 lived in `CLAUDE.md`; that section now points here.
 
-When `CLAUDE.md`'s change-impact matrix names a coupling, the schema
+When `docs/architecture/AGENTS.md`'s change-impact matrix names a coupling, the schema
 on each side of the coupling is pinned in 0005. When 0002 / 0003 / an
 ADR explains *why* a contract exists, 0005 just says *what its exact
 shape is* and links back. **0005 pins shape; rationale lives in the
@@ -133,8 +133,8 @@ Three rules apply across every contract pinned here:
   but not duplicated), ADR-0006 (audit-log + autonomy_overrides),
   ADR-0007 (preflight piggyback constraints), ADR-0008 (SKILL
   invocation as the cross-plugin contract).
-- `CLAUDE.md` (root) — change-impact matrix; absorbed into 0005's
-  per-section entries.
+- `docs/architecture/AGENTS.md` — change-impact matrix; absorbed
+  into 0005's per-section entries.
 - `PLUGIN_DEVELOPMENT.md` — CC + Codex plugin contract surfaces;
   04-skill-contracts cites this for portable-frontmatter rules.
 - `MULTI_AGENT_DEVELOPMENT.md` — Mode-1 vs Mode-2 contracts;

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -1,0 +1,84 @@
+# docs/architecture/ — spec governance contract
+
+> **Before any edit under `docs/architecture/`** (writing /
+> revising any spec doc, ADR, or contract — not just running
+> an editor):
+>
+> 1. Identify which spec section your change touches and which
+>    other docs cite it. The Spec change-impact matrix below
+>    is the canonical cross-reference.
+> 2. If your change makes a contract in any of
+>    [`../../PLUGIN_DEVELOPMENT.md`](../../PLUGIN_DEVELOPMENT.md),
+>    [`../../MULTI_AGENT_DEVELOPMENT.md`](../../MULTI_AGENT_DEVELOPMENT.md),
+>    or
+>    [`../../SKILL_DEVELOPMENT.md`](../../SKILL_DEVELOPMENT.md)
+>    stale, fix the companion in the **same PR** — not a
+>    follow-up. Doc lag is the primary failure mode that makes
+>    this pattern decay over time.
+> 3. Spec body stays in **English** (per
+>    `SKILL_DEVELOPMENT.md` Anti-pattern A5). Chinese
+>    discussion belongs in commit messages, PR bodies, or
+>    `notes-zh.md` files outside the spec tree.
+
+This contract is the per-directory operational checklist for
+spec authoring. The full discipline is shaped by the docs
+themselves; this file is the thin "what every spec PR must
+satisfy" view.
+
+## ADR discipline
+
+- **One ADR per architectural decision.** ADRs are immutable
+  once accepted. Superseding an ADR creates a new one; the old
+  one's status field gets `superseded by ADR-N`. Never edit a
+  retired ADR's body in-place.
+- **Cite sources.** When a spec page makes a claim about the
+  platform, link the canonical doc URL (CC docs, Codex docs,
+  agentskills.io). When it makes a claim about academic
+  methodology, link the primary source.
+- **URL freshness.** Each spec page that cites external URLs
+  carries a "URL freshness" check date. Re-verify when
+  modifying related code; a broken or moved canonical URL is a
+  load-bearing fact and must be patched in the PR that catches
+  it.
+
+## Same-PR contract update
+
+If a spec change makes a companion doc stale (one of the three
+required-reading docs above, or another spec page), fix the
+companion in the **same PR**. PRs that update one side of a
+contract without the matched side are incomplete.
+
+## Spec change-impact matrix
+
+The v1 spec is a graph of cross-references. Touching one node
+often forces companion edits. Use this matrix during PR
+preparation:
+
+| If you change… | You must also update… |
+|----------------|----------------------|
+| `0001-positioning.md` premise (P1..P8) or non-goal | Every spec doc that cites the changed premise (grep `docs/architecture/` for `P<N>`). Promote to a new ADR if the premise materially shifts. |
+| ADR-0005 BoardAdapter contract surface | `0003-domain-model/03-aggregates-and-entities.md` § 3.6.3 (Anti-Corruption Layer); spec for any v1 script that calls the adapter (`board-canon` skill, future scripts). Per ADR-0005 Consequences (as amended by ADR-0010), the GitHubProjectAdapter wrapper port lands before v1 GA. |
+| ADR-0006 D-AUTONOMY-1 matrix (rows or A/R/N classification) | `0002-product-features-and-flows/03-producer-surface.md` + `04-consumer-surface.md` (every feature row that cites the matrix); `classifying-actions` skill spec; `auditing-actions` skill spec (`action_id` catalog); `0005-contracts/06-audit-log-schema.md`. |
+| ADR-0007 plugin-runtime constraint set (C-PLUGIN-1/-2/-3) | Every Producer / Consumer feature with verbs like *monitor*, *detect*, *trigger automatically*. The preflight-piggyback idiom citation. |
+| ADR-0008 plugin-to-plugin SKILL invocation | `0005-contracts/04-skill-contracts.md` (sibling-skill classification table); `consuming-card` skill spec (F-C4 fallback rule). |
+| `0002-product-features-and-flows/05-bootstrap-surface.md` (state file path / schema) | `0003-domain-model/02-bounded-contexts.md` § 3.2.3; `0003-domain-model/03-aggregates-and-entities.md` § RepoBootstrap / HostBootstrap; `0005-contracts/03-config-schemas.md` + `07-path-conventions.md`; `bootstrapping-repo` + `migrating-repo-version` skill specs. |
+| `0002-product-features-and-flows/08-pr-contract.md` (three-section shape) | `consuming-card` skill spec (F-C12); `enforcing-pr-contract` skill spec; `managing-board` Review Queue routine spec (F-02 violation flagging). |
+| Skill catalog (add / rename / split / merge any of the 10 v1 skills) | **`../../SKILLS.md` FIRST** (per its Source-of-truth contract — do not touch `../../skills/` until SKILLS.md is updated); then `0004-component-architecture.md` Decision 2 (capability → slot table); `0005-contracts/04-skill-contracts.md` (sibling-skill classification; v1 catalog table); the trigger row above; `../../README.md` and `../../README.zh-CN.md` if user-facing trigger phrases change. |
+| Hook intent-injection marker grammar (`INVOKE:` / `REASON:`) | `0004-component-architecture.md` § "Hook intent injection pattern"; `0005-contracts/02-hook-contracts.md` § "Intent-injection markers"; `using-board-superpowers` entry-skill spec. |
+| `~/.board-superpowers/` path layout (host-local state) | `0002-product-features-and-flows/05-bootstrap-surface.md`; `0003-domain-model/02-bounded-contexts.md` § 3.2.3; `0005-contracts/03-config-schemas.md` + `07-path-conventions.md`; `0002-product-features-and-flows/07-cross-cutting-invariants.md` I-13. |
+
+When v1 implementation grows, this matrix grows additional
+rows mapping spec → code (e.g., "if
+`0005-contracts/04-skill-contracts.md` description discipline
+changes → re-read every `skills/*/SKILL.md` frontmatter").
+
+## Where the long-form companion docs live
+
+- Plugin / hook / script platform contracts (CC + Codex) →
+  [`../../PLUGIN_DEVELOPMENT.md`](../../PLUGIN_DEVELOPMENT.md).
+- Subagent / agent-team / orchestration contracts →
+  [`../../MULTI_AGENT_DEVELOPMENT.md`](../../MULTI_AGENT_DEVELOPMENT.md).
+- Skill-authoring discipline →
+  [`../../SKILL_DEVELOPMENT.md`](../../SKILL_DEVELOPMENT.md).
+- Skill catalog / call graph / topology →
+  [`../../SKILLS.md`](../../SKILLS.md).

--- a/docs/architecture/CLAUDE.md
+++ b/docs/architecture/CLAUDE.md
@@ -1,0 +1,8 @@
+# docs/architecture/CLAUDE.md (redirect to docs/architecture/AGENTS.md)
+
+Bridge file: Claude Code auto-loads `CLAUDE.md` (not `AGENTS.md`)
+when reading or editing files in this directory. The substantive
+per-directory contract lives in [`AGENTS.md`](./AGENTS.md). Make
+all edits there, not here.
+
+@AGENTS.md

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -1,0 +1,127 @@
+# hooks/ — hook script contract
+
+> **Before any work in this directory** (writing, editing,
+> adding a hook event, modifying timeout / payload — not just
+> running an editor):
+>
+> 1. Read [`../PLUGIN_DEVELOPMENT.md`](../PLUGIN_DEVELOPMENT.md)
+>    § "Hooks (`hooks/hooks.json`)" — the dual-platform (CC +
+>    Codex CLI) contract every hook script in this repo
+>    conforms to.
+> 2. If adding a new hook event, also read
+>    [`../docs/architecture/0005-contracts/02-hook-contracts.md`](../docs/architecture/0005-contracts/02-hook-contracts.md)
+>    § "Intent-injection markers".
+> 3. **Update BOTH `hooks.json` AND
+>    [`../scripts/register-codex-hooks.sh`](../scripts/register-codex-hooks.sh)**
+>    snippet generator — Codex CLI does not auto-discover
+>    `hooks/hooks.json`, so a new event without an updated
+>    register script silently breaks Codex installs.
+
+This contract is the per-directory operational checklist for
+hook authoring. The full platform contract lives in
+`PLUGIN_DEVELOPMENT.md`; this file is the thin "what every PR
+under `hooks/` must satisfy" view.
+
+## v1 events wired
+
+v1-minimum wires only `SessionStart`. Other events
+(`PreToolUse`, `PostToolUse`, `Stop`) are not yet active but
+must use the same payload pattern when added later.
+
+## INVOKE / REASON marker grammar
+
+Hook scripts emit intent-injection markers via
+`hookSpecificOutput.additionalContext` (CC) /
+`hookSpecificOutput` (Codex). The grammar is:
+
+```
+INVOKE: <skill>
+REASON: <one-line rationale>
+```
+
+Multi-line `REASON:` continues with leading whitespace. The
+entry skill `using-board-superpowers` consumes the marker as a
+fast-path routing optimization — but the entry skill ALSO does
+the same state probe itself, because CC `SessionStart` delivery
+is unreliable. **The marker is an optimization, not a
+correctness requirement.**
+
+Full grammar contract:
+[`../docs/architecture/0005-contracts/02-hook-contracts.md`](../docs/architecture/0005-contracts/02-hook-contracts.md)
+§ "Intent-injection markers".
+
+## 10-second timeout (mandatory)
+
+Every hook script must declare `timeout: 10` in
+`hooks.json`. Hook execution beyond 10 seconds blocks session
+start / tool dispatch and degrades user experience. If a hook
+needs slow work, fork-and-exit the slow part to a background
+process and return the marker fast.
+
+## Dual-platform registration
+
+| Platform | Discovery |
+|----------|-----------|
+| Claude Code | Auto-discovers `hooks/hooks.json` at plugin load. No user action required. |
+| Codex CLI | **Does NOT auto-discover.** Users run `scripts/register-codex-hooks.sh --install-user` (or `--install-repo`) once per Codex install to wire the same `SessionStart` script into `~/.codex/hooks.json` (or `<repo>/.codex/hooks.json`). |
+
+The register script is idempotent and backs up the target file
+before merging. When adding a new hook event:
+
+1. Update `hooks.json` (CC side).
+2. Update the snippet generator inside
+   `scripts/register-codex-hooks.sh` (Codex side).
+3. Both changes ship in the same PR.
+
+## Hook invariants
+
+Hook scripts under this directory have stricter rules than
+`../scripts/` because they run in a context (CC / Codex
+`SessionStart`) where any error must NOT block session
+startup. Spec docs cite these by number — **keep the numbering
+stable**; multiple references in
+[`../docs/architecture/0005-contracts/02-hook-contracts.md`](../docs/architecture/0005-contracts/02-hook-contracts.md)
+and
+[`../docs/architecture/0004-component-architecture.md`](../docs/architecture/0004-component-architecture.md)
+cite "invariants 1–4" as a fixed enumeration.
+
+1. **Self-contained.** Hook scripts MUST NOT source
+   `../scripts/lib/common.sh`. A broken or missing lib must
+   never prevent CC / Codex startup. If you need helpers from
+   `common.sh`, duplicate them INLINE and keep the two
+   implementations in lockstep (existing precedent:
+   `bsp_sanitize_reason_line` in `session-start.sh`). This
+   forces shebang `#!/usr/bin/env bash` + `set -euo pipefail`
+   inline at the top of every hook script — you cannot lean on
+   `common.sh`'s strict-mode helpers.
+2. **Sanitize.** All text the hook injects into the session
+   context (REASON lines, `additionalContext` payload, any
+   marker body) MUST be sanitized — control chars stripped,
+   newlines normalized, JSON-breaking sequences escaped — via
+   `bsp_sanitize_reason_line` or its inline equivalent. An
+   unsanitized REASON breaks the JSON envelope at best and
+   leaks unintended content into the model's context at
+   worst.
+3. **Never block.** Hooks MUST exit `0` even when internal
+   checks fail — non-zero exit codes block session start,
+   which is a strictly worse failure than the plugin running
+   unconfigured. Per
+   [`../docs/architecture/0005-contracts/02-hook-contracts.md`](../docs/architecture/0005-contracts/02-hook-contracts.md)
+   § "Exit codes": *"board-superpowers' invariant: hook
+   failures MUST NEVER block session start."*
+4. **10-second budget.** Declared in `hooks.json` (see
+   "10-second timeout" section below). Keep new work well
+   under it; long-running work should fork-and-exit a
+   background process and return the marker fast.
+
+## Where the long-form rules live
+
+- CC `${CLAUDE_PLUGIN_ROOT}` env, `hooks.json` schema,
+  `hookSpecificOutput.additionalContext` payload shape, Codex
+  CLI `~/.codex/hooks.json` format →
+  [`../PLUGIN_DEVELOPMENT.md`](../PLUGIN_DEVELOPMENT.md).
+- Marker grammar contract, payload examples →
+  [`../docs/architecture/0005-contracts/02-hook-contracts.md`](../docs/architecture/0005-contracts/02-hook-contracts.md).
+- Hook intent injection pattern rationale →
+  [`../docs/architecture/0004-component-architecture.md`](../docs/architecture/0004-component-architecture.md)
+  § "Hook intent injection pattern".

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,0 +1,8 @@
+# hooks/CLAUDE.md (redirect to hooks/AGENTS.md)
+
+Bridge file: Claude Code auto-loads `CLAUDE.md` (not `AGENTS.md`)
+when reading or editing files in this directory. The substantive
+per-directory contract lives in [`AGENTS.md`](./AGENTS.md). Make
+all edits there, not here.
+
+@AGENTS.md

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,92 @@
+# scripts/ — bash tooling contract
+
+> **Before any work in this directory** (writing, editing,
+> renaming a script — not just running an editor):
+>
+> 1. Read [`../PLUGIN_DEVELOPMENT.md`](../PLUGIN_DEVELOPMENT.md)
+>    — especially § "What this means for board-superpowers"
+>    items 3 (Hooks ↔ scripts split) and the broader CC vs
+>    Codex env-var differences. There is no standalone
+>    "Scripts" section; conventions are woven through.
+> 2. Note: this directory is for **AI-callable tools**, not
+>    user-facing CLIs. The plugin is consumed via skills /
+>    slash commands, not a dedicated CLI binary.
+
+This contract is the per-directory operational checklist for
+bash tooling. The full platform contract lives in
+`PLUGIN_DEVELOPMENT.md`; this file is the thin "what every PR
+under `scripts/` must satisfy" view.
+
+## Self-contained scripts
+
+Two scripts in this directory are **deliberately self-contained**
+— they do NOT source `scripts/lib/common.sh`:
+
+- `scripts/check-deps.sh` — must run before `common.sh` is
+  available (it is the dep-check shared primitive). A broken
+  or missing lib cannot derail dep detection.
+- (Hook scripts under `../hooks/` follow the same rule per
+  [`../hooks/AGENTS.md`](../hooks/AGENTS.md) Invariant 1, but
+  they live in a different directory.)
+
+Helpers needed by these self-contained scripts are duplicated
+INLINE; keep the two implementations in lockstep (existing
+precedent: `bsp_sanitize_reason_line` is mirrored between
+`session-start.sh` and `common.sh`).
+
+## Strict-mode bash
+
+Every script:
+
+- Begins with `#!/usr/bin/env bash` (not `#!/bin/bash` —
+  macOS ships bash 3.2 at `/bin/bash`; we target bash 3.2+
+  via `env`).
+- Sets `set -euo pipefail` before sourcing
+  `scripts/lib/common.sh`.
+- Sources `common.sh` for shared helpers (path resolution via
+  `bsp_plugin_root()`, audit-log writers via
+  `bsp_audit_local_write()`, etc.). Never hardcode
+  `${CLAUDE_PLUGIN_ROOT}` (CC-only) or `${CODEX_PLUGIN_ROOT}`
+  (Codex-only) — `bsp_plugin_root()` resolves correctly under
+  both.
+
+## shellcheck `-x` clean (CI gate)
+
+Every script and its sourced helpers must pass
+`shellcheck -x scripts/**/*.sh hooks/*.sh` cleanly. The `-x`
+flag follows `source` directives so violations in `common.sh`
+are caught at every caller. CI fails on warnings.
+
+## Header comment
+
+Every script's first non-shebang block is a one-paragraph
+header comment explaining what the script does, what its
+inputs are (env vars, args, stdin), and what it writes
+(stdout, files, exit codes). This header is read both by
+humans and by AI agents that source-walk the directory.
+
+## Exit-code / stdout contracts
+
+Scripts have well-defined contracts:
+
+- **Exit code 0** = success. Non-zero exit codes are
+  documented in the header comment (e.g., `1` = generic
+  failure, `2` = preflight check failed, `3` = user
+  cancellation).
+- **stdout** = structured output for the caller (often JSON
+  or one-record-per-line). Don't mix logging and structured
+  output on the same stream.
+- **stderr** = human-readable progress / warnings / errors.
+
+Hooks (under `../hooks/`) follow the same conventions plus the
+hook-specific `hookSpecificOutput.additionalContext` payload
+shape for intent-injection markers (see
+[`../hooks/AGENTS.md`](../hooks/AGENTS.md)).
+
+## Where the long-form rules live
+
+- Full bash conventions, `common.sh` API surface, Codex CLI vs
+  CC env-var differences, plugin manifest schema →
+  [`../PLUGIN_DEVELOPMENT.md`](../PLUGIN_DEVELOPMENT.md).
+- Hook-specific contracts (timeout, marker grammar) →
+  [`../hooks/AGENTS.md`](../hooks/AGENTS.md).

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,8 @@
+# scripts/CLAUDE.md (redirect to scripts/AGENTS.md)
+
+Bridge file: Claude Code auto-loads `CLAUDE.md` (not `AGENTS.md`)
+when reading or editing files in this directory. The substantive
+per-directory contract lives in [`AGENTS.md`](./AGENTS.md). Make
+all edits there, not here.
+
+@AGENTS.md

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,133 @@
+# skills/ — skill-authoring contract
+
+> **Before any work in this directory** (writing, editing,
+> renaming, re-layering, or even *designing / discussing /
+> reviewing* a skill — not just running an editor):
+>
+> 1. Invoke `example-skills:skill-creator` — the canonical entry
+>    skill for create / modify / improve skill work. It carries
+>    the cross-platform skill-authoring discipline.
+> 2. Read [`../SKILL_DEVELOPMENT.md`](../SKILL_DEVELOPMENT.md) if
+>    its content is not already in context. ~1290 lines, but
+>    you only need the section your work touches (skill graph
+>    framing, three-tier frontmatter, body skeletons,
+>    anti-patterns, testing regimes).
+> 3. **If your change adds / removes / renames / re-layers a
+>    skill, edit [`../SKILLS.md`](../SKILLS.md) FIRST** —
+>    per its Source-of-truth contract a `skills/` change without
+>    a paired `SKILLS.md` change is unmergeable.
+
+This contract is the per-directory operational checklist for
+the skill-authoring discipline. The full guide lives in
+`SKILL_DEVELOPMENT.md`; this file is the thin "what every PR
+under `skills/` must satisfy" view.
+
+## Frontmatter discipline (Tier 1 / 2 / 3)
+
+- **Tier 1 (mandatory)**: `name` + `description`. The
+  `description` field is **WHEN, not WHAT** — triggering
+  conditions in third person, prefer "Use when …". Never
+  summarize the procedure here.
+- **Tier 2 (CC-spec optional fields, additive UX only)**:
+  `when_to_use`, `argument-hint`, `arguments`, `user-invocable`
+  — among others. The full 11-field CC-spec list (also
+  including `disable-model-invocation`, `allowed-tools`,
+  `model`, `effort`, `context: fork`, `agent`, `hooks`,
+  `paths`, `shell`) lives in
+  [`../PLUGIN_DEVELOPMENT.md`](../PLUGIN_DEVELOPMENT.md)
+  § "Skills (`SKILL.md`)" and § "Skill frontmatter / metadata"
+  (Codex parser silently ignores them; behavior must not depend
+  on Tier 2 fields). Per-skill recommendations on which Tier 2
+  fields to set live in [`../SKILLS.md`](../SKILLS.md)
+  catalog.
+- **Tier 3 (forbidden)**: custom non-spec fields like
+  `version: …`. Those go in `.skill-meta.yaml` (see below).
+  CI gate `scripts/verify-skill-frontmatter.sh` enforces.
+
+## Required dual-file: `SKILL.md` + `.skill-meta.yaml`
+
+Every skill directory must contain BOTH files. The yaml schema
+is documented in `SKILL_DEVELOPMENT.md` § "board-superpowers
+metadata convention" and consists of:
+
+- `version` (semver, per-skill independent of plugin version)
+- `layer` — entry / molecular / atomic
+- `type` — technique / pattern / reference / discipline
+- `mode` — claude-code-only / codex-only / both
+- `bounded-context` — board / session / bootstrap / audit / spec
+
+CI gate `scripts/verify-skill-metadata.sh` enforces consistency
+between the yaml and the [`../SKILLS.md`](../SKILLS.md) catalog.
+Drift here causes silent topology rot.
+
+## Body length budgets
+
+Per layer, hard ceilings:
+
+- **Entry** ≤ 200 lines (loaded every session — every line
+  counts against shared context budget).
+- **Molecular** 250–450 lines (loaded when triggered by
+  workflow scenarios).
+- **Atomic** 200–300 lines (loaded on demand from molecular
+  bodies).
+
+Past 100 lines for a single topic, move it to
+`references/<topic>.md` and link from the body explicitly.
+Never use `@`-auto-load for references; never chain references
+more than one level deep.
+
+## Cross-skill references
+
+Always carry the `<plugin>:<skill>` namespace prefix. Examples:
+
+- `superpowers:test-driven-development` ✓
+- `gstack:/qa` ✓
+- `test-driven-development` ✗ (bare reference — fails to
+  resolve unambiguously across plugins)
+
+Internal same-plugin references inside this repo also use the
+prefix `board-superpowers:<skill>` for consistency.
+
+## Atomic-layer reflexive constraint
+
+Atomic skills MUST NOT call same-plugin skills. They are
+reflexes consumed by molecular skills, not orchestrators. If a
+change appears to require an atomic calling another atomic, the
+design has gone wrong — split / merge the atomics instead of
+introducing the upward call.
+
+## SKILLS.md edit-first contract
+
+When adding / removing / renaming / re-layering any skill:
+
+1. Edit [`../SKILLS.md`](../SKILLS.md) catalog FIRST (catalog
+   row, call graph, bounded-context map, cross-plugin edges as
+   applicable).
+2. THEN create / move / delete the `skills/<name>/` directory.
+3. Both halves land in the same PR. PRs that touch `skills/`
+   without a paired `SKILLS.md` change are incomplete.
+
+## CI gates (must pass before PR lands)
+
+- `scripts/verify-skill-frontmatter.sh` — Tier 1 + Tier 2
+  presence, no Tier 3.
+- `scripts/verify-skill-metadata.sh` — yaml ↔ SKILLS.md
+  catalog consistency.
+- `shellcheck -x` over any new / changed scripts in the skill
+  directory (e.g., skill-bundled scripts under
+  `<skill>/scripts/`).
+
+## Where the long-form rules live
+
+This file is intentionally the per-directory checklist, not
+the manual. For:
+
+- Skill graph framing (entry / molecular / atomic), three-tier
+  frontmatter rationale, body skeletons, anti-patterns, testing
+  regimes → [`../SKILL_DEVELOPMENT.md`](../SKILL_DEVELOPMENT.md).
+- Catalog of the 10 v1 skills + call graph + SPOT derivation +
+  cross-plugin edges + maintenance contract →
+  [`../SKILLS.md`](../SKILLS.md).
+- Subagent / Mode-2 orchestration constraints (`max_depth=1`,
+  procedural fallback patterns, `Agent` tool use) →
+  [`../MULTI_AGENT_DEVELOPMENT.md`](../MULTI_AGENT_DEVELOPMENT.md).

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -1,0 +1,8 @@
+# skills/CLAUDE.md (redirect to skills/AGENTS.md)
+
+Bridge file: Claude Code auto-loads `CLAUDE.md` (not `AGENTS.md`)
+when reading or editing files in this directory. The substantive
+per-directory contract lives in [`AGENTS.md`](./AGENTS.md). Make
+all edits there, not here.
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Shards the 646-line monolithic root `AGENTS.md` into 4 nested per-directory `AGENTS.md` files (`skills/`, `hooks/`, `scripts/`, `docs/architecture/`) with one-line `CLAUDE.md` shims that `@`-include them, replacing the language-level "Required reading" trigger table with mechanism-level lazy loading on Claude Code.
- Same-PR contract update: 11 orphaned cross-spec citations to removed root sections redirected to the matching nested `AGENTS.md`; factual errors in `PLUGIN_DEVELOPMENT.md` / `MULTI_AGENT_DEVELOPMENT.md` fixed (they claimed to be `@`-included into every session, which contradicts the long-standing "by name, not `@`-prefix" anti-bloat rule); `hooks/AGENTS.md` adds 4 numbered Hook invariants that spec docs were already citing as "invariants 1–4" but were never documented.
- Codex CLI's downward-non-loading is documented as a known limitation in the new "Subdirectory contracts" table with explicit `Codex auto-load? no — Read explicitly` column. CC users get mechanism-level enforcement; Codex users get prose-level self-discipline scoped down to one row per subdirectory.

## Automated Verification

- ` scripts/verify-skill-frontmatter.sh` passes — no skill-frontmatter drift.
- `scripts/verify-skill-metadata.sh` passes — 6 skills checked, yaml ↔ `SKILLS.md` catalog consistent.
- **I-10 routing-block invariant** preserved: `<!-- board-superpowers:routing -->` block in root `AGENTS.md` is byte-identical to `origin/main` (verified via awk-extract + `diff`).
- **CC nested-load mechanism**: `claude --print` invocation reading `skills/managing-board/SKILL.md` returned a verbatim quote of the new "Invoke `example-skills:skill-creator`" rule from the new `skills/AGENTS.md`, confirming `skills/CLAUDE.md` → `@AGENTS.md` lazy-load chain works end-to-end. Repeated for `hooks/`: agent quoted "Sanitize" as Hook Invariant 2 verbatim when reading `hooks/session-start.sh`.
- **`@`-include relative-path semantic**: standalone `/tmp` test confirmed `@AGENTS.md` inside a nested `CLAUDE.md` resolves to the SIBLING `AGENTS.md`, not the root one. Both root + nested rules concatenate (not replace).
- **Codex CLI limitation empirically confirmed**: `codex exec` tests with workdir at root vs subdir showed Codex walks upward from workdir to git root and never loads `AGENTS.md` files below workdir, regardless of whether files in the subdir are read. Hence the "Codex auto-load? no" column.

## Human Verification TODO

- [ ] After merge, open a fresh CC session on `main`, claim a skill-implementation card, edit a file under `skills/`, confirm the session transcript shows `skills/CLAUDE.md` loaded and the "Invoke `example-skills:skill-creator`" rule is in effect (the originating problem this PR solves).
- [ ] Spot-check that the Spec change-impact matrix in the new `docs/architecture/AGENTS.md` is content-equivalent to the matrix that previously lived in root `AGENTS.md` — internal relative paths inside cells were updated (e.g., `SKILLS.md` → `../../SKILLS.md`); content rows unchanged.
- [ ] Confirm `bootstrapping-repo` skill's routing-block injection still works on a fresh consuming repo — root `AGENTS.md` / `CLAUDE.md` structure changed around the marker pair but the `<!-- board-superpowers:routing -->` block itself was not modified.
- [ ] Skim `skills/AGENTS.md` "Frontmatter discipline" + Tier 2 list against `PLUGIN_DEVELOPMENT.md` § "Skills (`SKILL.md`)" — Tier 2 list now points at PLUGIN_DEVELOPMENT.md for the full 11-field enumeration; confirm the qualifier reads naturally.

## Retro Notes

- **Pre-existing spec drift was caught only via the reviewer agent.** 11 cross-spec citations to `AGENTS.md` "Maintaining X" sections never matched actual section names in root `AGENTS.md` — likely diverged silently across historical edits. Future structural-rename PRs touching `AGENTS.md` should add a CI grep gate that enforces every `` `AGENTS.md` `` "Section name" citation resolves to an actual section, before the `same-PR contract` rule can decay back to advisory.
- **Two factual errors in long-standing docs survived for years.** Both `PLUGIN_DEVELOPMENT.md` and `MULTI_AGENT_DEVELOPMENT.md` claimed to be `@`-included into every session, when `AGENTS.md` has consistently referenced them by name to avoid context bloat. Caught only because the new "Subdirectory contracts" table forced re-examining original wording. Validates the doc-heavy verification protocol's claim that spec writing accuracy rate is poor.
- **CC vs Codex CLI nested-load asymmetry is a real platform divergence**, not a doc bug. CC has lazy downward loading; Codex has only upward walking from workdir to git root. This forces the hybrid pattern (`CLAUDE.md` shim + `AGENTS.md` substantive sibling). Future hook-level work could narrow the gap on Codex (e.g., a session-start hook detecting workdir and injecting the relevant nested `AGENTS.md` content via the existing `INVOKE` / `REASON` payload pattern), but is out of scope here.
- **`@`-include relative-path semantic is undocumented in CC docs but works as expected.** `@xxx.md` inside a nested `CLAUDE.md` resolves relative to the containing file's directory, not project root. Worth citing in `PLUGIN_DEVELOPMENT.md` § "Honest gaps in official docs" if that section grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)