### PR TITLE
spec: bootstrap surface redesign — design doc + 13 ADRs + setup-stages dev guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,10 @@ doc when its scope is touched.
 | [`PLUGIN_DEVELOPMENT.md`](./PLUGIN_DEVELOPMENT.md) (~440 lines) | hook scripts, bash tooling, plugin manifest, dual-platform (CC + Codex CLI) contracts. |
 | [`MULTI_AGENT_DEVELOPMENT.md`](./MULTI_AGENT_DEVELOPMENT.md) (~700 lines) | subagent / agent-team / orchestration design, `Agent` tool / `SendMessage` / fan-out-fan-in. |
 | [`SKILL_DEVELOPMENT.md`](./SKILL_DEVELOPMENT.md) (~1290 lines) | skill authoring — frontmatter, body skeletons, anti-patterns, testing, `.skill-meta.yaml` schema. |
+| [`SETUP_STAGES_DEVELOPMENT.md`](./SETUP_STAGES_DEVELOPMENT.md) (~700 lines) | setup-stages system — `scripts/stages-registry.yml`, `scripts/stages_lib/`, `scripts/stages-registry.schema.json`, `hooks/session-start.sh` lifecycle diff, `skills/bootstrapping-repo/`, the four partitioned `settings.yml` files. Read before adding/editing/removing a stage, before changing the 5-callable contract, before introducing a new `applicable_when` form, or before any spec change touching § 1.5 (Bootstrap surface redesign). The legacy filename `BOOTSTRAP_STAGES_DEVELOPMENT.md` is a one-line shim that redirects here. |
 
 **Do not "fix" these references back to `@`-prefix** — that
-change would force-load all three docs into every session and
+change would force-load all four docs into every session and
 is exactly the anti-pattern they themselves warn against.
 
 ### Doctrine

--- a/BOOTSTRAP_STAGES_DEVELOPMENT.md
+++ b/BOOTSTRAP_STAGES_DEVELOPMENT.md
@@ -1,0 +1,20 @@
+# BOOTSTRAP_STAGES_DEVELOPMENT.md (redirect to SETUP_STAGES_DEVELOPMENT.md)
+
+This document was renamed. The canonical guide for the
+plugin-wide setup-stages system (registry, lifecycle, the
+5-callable contract, agentic config-item protocol, etc.) lives
+in **[`SETUP_STAGES_DEVELOPMENT.md`](./SETUP_STAGES_DEVELOPMENT.md)**.
+
+> **Why "setup" not "bootstrap"?** The system originally only
+> covered first-time setup (hence "bootstrap"). It now also
+> covers plugin-upgrade reconvergence and the agentic
+> config-item elicitation flow — i.e., the plugin's settings
+> UX. "Setup" is the broader and accurate name; "bootstrap"
+> understates the scope. Rationale and ADR citations live in
+> the canonical guide § 1.
+
+> **Make all edits in `SETUP_STAGES_DEVELOPMENT.md`, not here.**
+> Codex CLI will not auto-load this redirect file; this is a
+> human-readable hint for readers searching for the legacy
+> name. AGENTS.md references throughout the project point at
+> the canonical doc.

--- a/SETUP_STAGES_DEVELOPMENT.md
+++ b/SETUP_STAGES_DEVELOPMENT.md
@@ -1,0 +1,905 @@
+# SETUP_STAGES_DEVELOPMENT.md — plugin-wide development guide for the setup-stages system
+
+> **Audience.** Plugin-maintainer agents (CC + Codex) editing
+> any of: `scripts/stages-registry.yml`, `scripts/stages_lib/`,
+> `scripts/stages-registry.schema.json`, `hooks/session-start.sh`'s
+> lifecycle-diff path, `skills/bootstrapping-repo/`, the four
+> partitioned `settings.yml` files, or any spec passage describing
+> the same system. If your work touches none of those, you do
+> not need to read this guide.
+>
+> **What this guide IS.** A *navigation layer* over the
+> authoritative spec, plus the development-time judgment calls
+> the spec cannot encode (when to add a stage vs. some other
+> mechanism, common misclassifications across the three axes,
+> graceful-degradation philosophy, anti-patterns).
+>
+> **What this guide IS NOT.** A second copy of the spec or the
+> ADRs. Whenever a fact has a canonical home, this guide links
+> there instead of restating it. If you find a contradiction,
+> the canonical home wins; **patch this guide in the same PR**.
+
+## Table of contents
+
+1. [What "setup-stages" means and why the rename](#1-what-setup-stages-means-and-why-the-rename)
+2. [Where the source-of-truth lives](#2-where-the-source-of-truth-lives)
+3. [Mental model in one page](#3-mental-model-in-one-page)
+4. [When to add a stage — and when NOT to](#4-when-to-add-a-stage--and-when-not-to)
+5. [Picking the three axes — common misclassifications](#5-picking-the-three-axes--common-misclassifications)
+6. [The 5-callable contract — judgment & traps](#6-the-5-callable-contract--judgment--traps)
+7. [Agentic stage = config-item elicitation flow](#7-agentic-stage--config-item-elicitation-flow)
+8. [`applicable_when` — when to use vs alternatives](#8-applicable_when--when-to-use-vs-alternatives)
+9. [`platforms` — when something genuinely differs across CC and Codex](#9-platforms--when-something-genuinely-differs-across-cc-and-codex)
+10. [Settings layering — where `target_state` lands](#10-settings-layering--where-target_state-lands)
+11. [BoardAdapter capability dispatch — M3-conditioning](#11-boardadapter-capability-dispatch--m3-conditioning)
+12. [Cross-version evolution — `generation` bumps & `schema_version`](#12-cross-version-evolution--generation-bumps--schema_version)
+13. [The canonicalization invariant — agent footguns](#13-the-canonicalization-invariant--agent-footguns)
+14. [Recipe — adding a new stage end-to-end](#14-recipe--adding-a-new-stage-end-to-end)
+15. [Testing — what CI gates and what you must hand-test](#15-testing--what-ci-gates-and-what-you-must-hand-test)
+16. [Anti-patterns](#16-anti-patterns)
+17. [Failure-mode philosophy — graceful degradation](#17-failure-mode-philosophy--graceful-degradation)
+18. [Cross-cutting reading map](#18-cross-cutting-reading-map)
+
+---
+
+## 1. What "setup-stages" means and why the rename
+
+The system was originally called "bootstrap" because v0.2.0 only
+did first-time setup. Since v0.4.0-redesign it has grown to
+cover three independent runtime concerns:
+
+- **First-time setup** — the original "bootstrap" use case.
+- **Plugin-upgrade reconvergence** — when the registry's
+  `generation` bumps or new stages are added in plugin v(N+1),
+  existing repos see those stages as `never-run` / `stale` and
+  the same machinery brings them current. Replaces the deferred
+  `migrating-repo-version` SKILL ([ADR-0012](./docs/architecture/adr/0012-unified-check-script-trigger-model.md)).
+- **Agentic config-item elicitation (the settings UX)** —
+  `character: agentic` stages *are* the plugin's settings
+  surface. There is no separate "settings" mechanism; the
+  architect's interaction with bootstrap is itself the
+  configuration UI ([ADR-0023](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md)).
+
+"Bootstrap" understates the scope. The canonical name in v1
+documentation is **setup-stages**; the legacy file
+[`BOOTSTRAP_STAGES_DEVELOPMENT.md`](./BOOTSTRAP_STAGES_DEVELOPMENT.md)
+is a one-line shim that redirects here.
+
+> **Implication for SKILL naming.** The skill is still
+> `bootstrapping-repo` because changing the SKILL id is a
+> separate breaking change deferred to a later cleanup. The
+> SKILL's body, however, owns the entire setup-stages flow
+> including version reconvergence and agentic config-item
+> elicitation. Don't be surprised by the name mismatch.
+
+## 2. Where the source-of-truth lives
+
+If a fact has a canonical home, link to it. Do not restate it
+in the SKILL, in code comments, in commit messages, or in this
+guide.
+
+| Fact | Canonical home |
+|------|----------------|
+| Three axes (module / character / locality) — definitions | [`05-bootstrap-surface-redesign.md` § "The three axes"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#the-three-axes) |
+| Stages table (the 22-row registry view) | [§ "Stages"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#stages) |
+| Trigger model — hook flow + SKILL flow + hook–SKILL contract | [§ "Trigger model"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#trigger-model) + [ADR-0012](./docs/architecture/adr/0012-unified-check-script-trigger-model.md) |
+| 5-state lifecycle + three-layer fingerprint | [§ "Stage lifecycle states"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#stage-lifecycle-states) + [ADR-0013](./docs/architecture/adr/0013-declarative-state-schema-and-lifecycle.md) + [ADR-0020](./docs/architecture/adr/0020-stage-applicability-and-not-applicable-state.md) |
+| Stage registry contract (YAML + Python + JSON Schema) | [§ "Stage registry contract"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#stage-registry-contract) + [ADR-0014](./docs/architecture/adr/0014-stage-registry-contract.md) |
+| Per-stage entry shape (what gets persisted) | [§ "Per-stage entry shape"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#per-stage-entry-shape) |
+| Settings modular layering (4 files + `modules.<id>` + per-module `schema_version`) | [§ "Settings modular layering"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#settings-modular-layering-in-file-structure) + [ADR-0021](./docs/architecture/adr/0021-settings-modular-layering.md) |
+| `applicable_when` predicate forms (3 of them) | [ADR-0020](./docs/architecture/adr/0020-stage-applicability-and-not-applicable-state.md) § Decision |
+| `platforms` field semantics | [ADR-0016](./docs/architecture/adr/0016-cross-platform-parity-contract.md) |
+| Architect UX flow + 5-element config item protocol | [§ "Architect UX"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#architect-ux) + [ADR-0023](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md) |
+| Repo identity scheme + I-13 cross-clone state sharing | [§ "Repo identity"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#repo-identity) + [ADR-0017](./docs/architecture/adr/0017-i13-invariant-revision-cross-clone-state-sharing.md) |
+| BoardAdapter capability dispatch (M3) + M10 backend selection | [ADR-0022](./docs/architecture/adr/0022-boardadapter-capability-dispatch.md) |
+| M7 multi-stage AGENTS.md / CLAUDE.md routing-block protocol | [ADR-0018](./docs/architecture/adr/0018-m7-multi-stage-routing-block-protocol.md) |
+| Zero-config SQLite default audit backend | [ADR-0019](./docs/architecture/adr/0019-zero-config-sqlite-default-audit-backend.md) + [ADR-0009](./docs/architecture/adr/0009-allow-sqlite-as-byo-audit-db.md) |
+| M4 audit per-repo locality (replaces host-shared credentials) | [ADR-0015](./docs/architecture/adr/0015-m4-audit-per-repo-locality.md) |
+| settings.yml family rename + new config-item stages | [ADR-0024](./docs/architecture/adr/0024-settings-rename-and-config-item-stages.md) |
+| Producer autonomy boundary (D-AUTONOMY-1 matrix) | [ADR-0006](./docs/architecture/adr/0006-producer-autonomy-boundary.md) |
+
+When in doubt: **read the design doc end-to-end** before
+opening a stage-touching PR. It is ~1700 lines but the table of
+contents is dense — you can skim non-relevant sections in
+seconds.
+
+## 3. Mental model in one page
+
+```
+                               ┌────────────────────────┐
+   SessionStart hook ─────────▶│  hooks/session-start.sh │
+                               └─────────┬───────────────┘
+                                         │ reads partitioned settings,
+                                         │ runs lifecycle diff,
+                                         │ emits INVOKE marker if
+                                         │ any stage is never-run / stale
+                                         ▼
+                               ┌────────────────────────┐
+                               │ bootstrapping-repo SKILL│
+                               └─────────┬───────────────┘
+                                         │ topo-orders pending stages
+                                         │ by depends_on, runs each
+                                         ▼
+              ┌──────────────────────────┴──────────────────────────┐
+              │                                                     │
+   character: automated                              character: agentic
+   (executor runs autonomously)                      (5-element config item
+   ─────────────────────────────                     protocol elicits choice;
+   • Bash / DDL / file write                         result is target_state)
+   • idempotency_check                               • interactive_prompt
+   • compute_target_state                            • target_state_schema
+   • target_state_predicate                          • locality decides
+   • generation int                                    persistence file
+                                                     • re-prompt = lifecycle
+                                                       transition
+              │                                                     │
+              └──────────────────────────┬──────────────────────────┘
+                                         │ writes target_state
+                                         ▼
+              4 partitioned settings.yml files (per locality)
+              + status entries → next hook tick reads them
+```
+
+The **three axes** (module / character / locality) collectively
+identify a stage. Two stages with the same `(module, character,
+locality)` triple may not coexist; that uniqueness is the
+identity invariant the registry's JSON Schema enforces.
+
+The **5-state lifecycle** (`never-run`, `completed`, `stale`,
+`deprecated`, `not-applicable`) is computed by the hook from
+the partitioned settings + the registry; the SKILL never
+guesses, it only consumes the lifecycle output.
+
+If you internalize one diagram, internalize the one above.
+Everything else in this guide elaborates on a piece of it.
+
+## 4. When to add a stage — and when NOT to
+
+The single most common authoring mistake is adding a stage when
+some lighter mechanism would do, or skipping a stage when a
+heavier mechanism is being mis-applied. Run this decision tree
+before opening a registry PR:
+
+```
+Is this configuration / setup work that the plugin needs done
+on first install, on plugin upgrade, OR every time some
+declarative invariant drifts?
+│
+├─ NO → don't add a stage. Use one of:
+│      • A one-shot script callable from the SKILL body
+│      • An idempotent shell helper in scripts/lib/
+│      • A SKILL flow that runs each session (not a stage)
+│
+└─ YES → continue.
+   │
+   Does the work need to happen WITHOUT architect attention?
+   (i.e., the agent can compute target_state from existing
+    state alone, with no architect input)
+   │
+   ├─ NO  → character: agentic. Continue.
+   │
+   └─ YES → character: automated. Continue.
+   │
+   Does the work's "did it land" check require remote IO
+   (GitHub API, RDBMS query) or only local file inspection?
+   │
+   ├─ Remote IO  → locality: external. Add `external_ttl_seconds`.
+   │
+   └─ Local file → locality is host-shared / repo-shared /
+                   repo-clone (the storage axis), pick by
+                   "where the artifact lives".
+   │
+   Does the SAME logical decision affect every clone of this
+   repo on disk, or is it per-clone (e.g., per-architect's
+   personal preference)?
+   │
+   ├─ Per-clone → locality: repo-clone (gitignored)
+   ├─ Per-repo, shared across clones → locality: repo-shared
+   │  (committed in repo)
+   └─ Cross-repo on same host → locality: host-shared
+      (in $HOME, gitignored at host level)
+```
+
+### Things that look like a stage but are NOT one
+
+| Looks like… | Actually use… |
+|-------------|---------------|
+| One-time DB seed for a test fixture | A test setup helper, not a stage. Stages are about plugin operation, not test infrastructure. |
+| Per-architect personal preference (e.g., "always use vim") | Out of scope. The plugin doesn't carry architect-personal config. |
+| Logging verbosity flag | Environment variable. Stages are for declarative invariants, not runtime knobs. |
+| Migration of legacy data on a schema bump | If the schema is owned by a stage, the migration belongs *inside* that stage's `compute_target_state` + `executor` (module-local migration per [ADR-0014](./docs/architecture/adr/0014-stage-registry-contract.md)). If it's truly one-shot data migration (will never re-run), it's a script, not a stage. |
+| New SKILL prompt path that asks the architect a question | If the answer needs persistence + re-prompt on plugin upgrade, that's an agentic stage. If the answer is per-session ephemeral, it's regular SKILL prompting, not a stage. The litmus test: does the answer need to survive across sessions? |
+| `gh` CLI not installed | Dependency check, not a stage. Use `scripts/check-deps.sh`. Stages assume their deps are present. |
+
+If you read the above and your work falls in "actually use…",
+**stop and use the lighter mechanism**. Adding a stage that
+shouldn't be one creates registry noise that every architect
+has to wade through on every plugin upgrade.
+
+## 5. Picking the three axes — common misclassifications
+
+### Module (functional axis)
+
+The 10 modules (M1–M10) are listed in [§ "Axis C — Functional
+module"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#axis-c--functional-module).
+Common misclassifications:
+
+- **"Audit DDL apply" feels like M1 plugin-runtime infra**
+  because it sets up infrastructure. Wrong — it is M4 audit.
+  M1 covers only the plugin's *own* runtime state files
+  (`settings.yml`, `state.yml`, etc.). Anything an architect
+  could opt out of (audit, kanban backend, autonomy presets)
+  is its own module.
+- **"Routing block injection" feels like M5 repo config**
+  because it edits a config-shaped file. Wrong — it is M7
+  agent routing. M5 is about plugin-internal repo config
+  (e.g., WIP limits); M7 is specifically about the
+  AGENTS.md/CLAUDE.md routing instructions agents read on
+  session start.
+- **"Codex hook registration" feels like M1 plugin-runtime
+  infra**. Wrong — it is M9 hook registration. M9 is the
+  parity-gap remediation module; if a separate codepath
+  exists *because* CC and Codex differ, it lives in M9.
+
+When in doubt, ask: "if this module disappeared, what
+architect-facing capability disappears?" The answer names the
+module.
+
+### Character (automated vs agentic)
+
+Mistake: adding `character: automated` because "the agent
+runs it autonomously". `automated` means **no architect input
+is required to compute target_state**. An agentic stage's
+executor is also run by the agent — the difference is whether
+the architect's choice is necessary input.
+
+Examples often confused:
+
+- **Writing a generated file from a template** = automated.
+  Architect made no choice; agent computed everything.
+- **Writing a routing block whose body is fixed** = automated.
+- **Writing a routing block where the architect can opt out
+  of certain block types** = agentic. The choice is
+  architect-input.
+- **Applying audit DDL in SQLite** = automated (the DSN is
+  defaulted, no architect input on a fresh repo per
+  [ADR-0019](./docs/architecture/adr/0019-zero-config-sqlite-default-audit-backend.md)).
+- **Choosing audit backend (sqlite / postgres / mysql)** =
+  agentic, because backend choice IS architect input.
+
+### Locality (storage axis)
+
+Mistake: putting credentials in `repo-shared` because "they
+relate to this repo". Wrong — credentials are
+`repo-clone` (per-clone, gitignored, never committed). The
+locality axis answers **"where does this state live, given
+git semantics?"**, not "what does this state describe?".
+
+Recap of the four:
+
+- `host-shared` — `$HOME/.board-superpowers/settings.yml`,
+  shared across ALL repos on this host
+- `repo-shared` — committed in the repo, identical for every
+  clone of the repo
+- `repo-clone` — gitignored, **per-clone-on-disk**, NEVER
+  committed (revised I-13: same architect with two clones of
+  the same repo gets different files; OK because the clone
+  is the unit of locality, see [ADR-0017](./docs/architecture/adr/0017-i13-invariant-revision-cross-clone-state-sharing.md))
+- `external` — not a settings file at all; lives in GitHub /
+  RDBMS / etc., observed via API
+
+If the artifact contains a secret or a path that is
+host-specific or architect-specific, it is `repo-clone` or
+`host-shared`. Never `repo-shared`.
+
+## 6. The 5-callable contract — judgment & traps
+
+Five required Python callables per stage in
+`scripts/stages_lib/<stage_id>.py`. Signatures and intent:
+[§ "What the lifecycle model asks of each stage"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#what-the-lifecycle-model-asks-of-each-stage).
+
+The contract itself is in the spec; what follows is the
+judgment the spec doesn't encode.
+
+### `executor` — the work itself
+
+Trap: "executor runs side effects, but partial-failure halfway
+through corrupts everything." Mitigation: **always make
+executor idempotent**. If the work is multi-step, sequence the
+steps so a re-run from any intermediate state converges on the
+same outcome. The 5-callable contract doesn't enforce
+idempotency — `idempotency_check` is a *fast-path optimization*,
+not a substitute. If your executor needs `idempotency_check` to
+return False before it can safely run, you've broken the
+invariant.
+
+### `idempotency_check` — fast-path short-circuit
+
+Trap: writing `idempotency_check` such that it returns True
+only when target_state matches *exactly*. Wrong — that
+duplicates `target_state_predicate`. The right shape is:
+"would re-running executor be a no-op?" — usually a cheap
+file-existence + magic-bytes check, NOT a full target_state
+comparison.
+
+If `idempotency_check` is expensive (network call, RDBMS
+query), you've over-scoped it. Move the expense to
+`target_state_predicate`.
+
+### `target_state_predicate` — confirms outcome landed
+
+Trap: implementing `target_state_predicate` with a stale cached
+view of external state. For `external`-locality stages, the
+predicate is the *only* way the lifecycle observes ground
+truth. **Always do the live IO** (subject to `external_ttl_seconds`
+caching at the lifecycle level, not inside the predicate).
+
+### `compute_target_state` — what the registry expects to be true
+
+Trap: making `compute_target_state` non-deterministic (e.g.,
+including `datetime.now()` or random IDs). The output is
+fed to `_canonical.py` for the layer-2 hash; non-determinism
+makes the hash flap and every stage permanently `stale`.
+
+If you genuinely need a per-run-derived value (timestamps,
+correlation IDs), put it in `hash_excluded_fields`
+([§ "Hash-allowlist"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#hash-allowlist-fields-excluded-from-hash)).
+
+### `generation` int — declared in YAML, not Python
+
+Trap: forgetting to bump `generation` after editing
+`compute_target_state` or `target_state_schema`. Without the
+bump, the layer-1 fast-path keeps short-circuiting to
+`completed` even though the expected target shape changed —
+existing repos miss the migration silently.
+
+**Rule**: every PR that edits the per-stage Python module's
+`compute_target_state` or `target_state_schema` MUST bump
+`generation`. CI enforces (paired diff). If you genuinely just
+fixed a typo in a docstring, no bump — but `_canonical.py`
+strips comments, so a docstring change doesn't affect the
+hash anyway.
+
+## 7. Agentic stage = config-item elicitation flow
+
+Agentic stages are the plugin's settings UX. The
+[5-element config item protocol](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md)
+is mandatory for every agentic stage:
+
+1. **Schema declaration** (`target_state_schema`)
+2. **Detection** (lifecycle 5-state — see § 12)
+3. **Interaction** (`interactive_prompt` registry field)
+4. **Persistence** (`locality` chooses the settings file)
+5. **Re-prompt trigger** (lifecycle transition to `stale`)
+
+See [ADR-0023](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md)
+for full details.
+
+### Judgment: when an agentic stage's `interactive_prompt` is wrong
+
+Five `kind` values are supported:
+`single-choice` / `multi-choice` / `free-text` /
+`boolean` / `numeric-range`. If your stage needs:
+
+- **A multi-step wizard** (e.g., "first answer A, then if A
+  was X ask B, otherwise ask C") → split into multiple stages
+  with `depends_on`. Each stage handles one decision; the
+  `applicable_when` predicate handles the conditional branch.
+- **A free-form code blob** (e.g., "paste your custom YAML
+  predicate here") → don't. The protocol intentionally
+  excludes this. If you need it, you're building a
+  registry-of-registries; reconsider.
+- **A choice that depends on live remote state** (e.g.,
+  "pick from your existing GitHub Projects") →
+  `kind: single-choice` with `options-source: runtime-derived`.
+  The SKILL fetches the option list at prompt time. Be
+  conservative — runtime-derived options break offline.
+
+If none of the above five `kind` values fit, you have a
+non-standard interaction shape — exactly the per-item drift
+the protocol is designed to prevent. Push back on the
+requirement before extending the protocol.
+
+### Judgment: when "no choice made" is a valid `target_state`
+
+If the schema permits empty list / null / "no presets selected"
+as a valid value, an empty result is `completed`, not `skipped`.
+There is no "skip" lifecycle state. See
+[ADR-0023 § "Skip semantics are eliminated"](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md).
+
+This means: if your stage's schema requires a non-empty value
+(`minItems: 1`), the architect *must* make a choice — they
+cannot defer. Choose carefully whether your schema permits
+empty.
+
+## 8. `applicable_when` — when to use vs alternatives
+
+Three legal forms (per [ADR-0020](./docs/architecture/adr/0020-stage-applicability-and-not-applicable-state.md)):
+
+```yaml
+# Form 1: setting-path (preferred for declarative conditionals)
+applicable_when:
+  setting_path: m10.repo.choose-kanban-backend.target_state.backend
+  equals: github-project-v2
+
+# Form 2: board-capability (for M3-style capability dispatch)
+applicable_when:
+  board_capability: pull_request_aggregate
+
+# Form 3: Python escape hatch (last resort)
+applicable_when:
+  python: stages_lib.m3_repo_label_card_status._is_applicable
+```
+
+### Judgment matrix
+
+| Situation | Use |
+|-----------|-----|
+| "Run this stage only if the architect chose X in stage Y" | Form 1 (setting-path). Cheapest, declarative. |
+| "Run this stage only if the chosen board adapter supports capability Z" | Form 2 (board-capability). Maps cleanly to ADR-0022 capability dispatch. |
+| "Run this stage based on logic Forms 1+2 cannot express" | Form 3 (python). **Last resort.** Every Form-3 use accumulates registry-side complexity. Document why Forms 1+2 don't suffice in the per-stage Python module. |
+| "Run this stage on Codex but not CC" | NOT `applicable_when` — that's the `platforms` field (see § 9). The two compose; `platforms` filters first, `applicable_when` filters second. |
+
+### Trap: Form 1 chains
+
+If you write `applicable_when: setting_path: A → applicable_when: setting_path: B → ...` chains across multiple stages, you've built a
+mini decision tree. Two failure modes:
+
+1. **Predicate cycles**. Stage X gates on Y's settings; Y
+   gates on Z's; Z gates on X's. The hook can't make progress.
+   The JSON Schema validator catches obvious cycles, but
+   transitive cycles need design review.
+2. **The tree shape isn't visible from any single stage's
+   perspective**. An architect debugging "why didn't stage X
+   run?" has to traverse the chain. If your tree is deeper
+   than 2 levels, consolidate into one stage with a richer
+   `target_state_schema`.
+
+Rule of thumb: 1 level of `applicable_when` chaining is fine,
+2 is suspicious, 3+ requires architecture review.
+
+## 9. `platforms` — when something genuinely differs across CC and Codex
+
+The dual-platform parity contract is in
+[ADR-0016](./docs/architecture/adr/0016-cross-platform-parity-contract.md).
+
+### Judgment: when is `platforms: both` wrong?
+
+`platforms: both` is the default. It is wrong when:
+
+- **The executor depends on a CC-only env var directly**
+  (`${CLAUDE_PLUGIN_ROOT}` without going through
+  `bsp_plugin_root()`). Mark `cc-only` and provide a Codex
+  equivalent (or refactor to use `bsp_plugin_root()`).
+- **The work is a CC-only or Codex-only platform-specific
+  config write** (e.g., M9 hook registration is `codex-only`
+  because CC auto-discovers).
+- **The work depends on a SKILL invocation pattern only one
+  platform supports** (rare; check
+  [ADR-0008](./docs/architecture/adr/0008-plugin-to-plugin-skill-invocation.md)).
+
+If you find yourself reaching for `platforms: cc-only` because
+"the Codex equivalent is hard", **resist**. The CC/Codex parity
+discipline ([ADR-0016](./docs/architecture/adr/0016-cross-platform-parity-contract.md))
+demands you build the Codex path in the same PR or document
+why parity is intentionally degraded (with an ADR amendment).
+
+### Composition with `applicable_when`
+
+The hook applies `platforms` BEFORE `applicable_when` (per
+[ADR-0016 § "Composition with `applicable_when`"](./docs/architecture/adr/0016-cross-platform-parity-contract.md#decision)).
+A stage filtered out by `platforms` does not appear in any
+lifecycle state on the wrong platform — not even `not-applicable`.
+This matters because `applicable_when: setting_path: ...` would
+otherwise need to know the platform; instead, settings files
+are platform-agnostic and `platforms` does platform discrimination
+purely from runtime context.
+
+## 10. Settings layering — where `target_state` lands
+
+Per [ADR-0021](./docs/architecture/adr/0021-settings-modular-layering.md):
+
+- **4 partitioned `settings.yml` files** — one per locality
+  (host-shared, repo-shared, repo-clone; external is observed
+  not stored).
+- **Two-section split per file**:
+  - `stages_completed[]` — machine-readable, authoritative
+    (the lifecycle reads this).
+  - `modules.<id>` — architect-friendly projection (read-only
+    derived view, written by the SKILL on every successful
+    stage completion).
+- **Per-module `schema_version`** — each module evolves its
+  on-disk shape independently.
+
+### Judgment: `module_section_path` overrides
+
+Default projection: a stage's `target_state` lands at
+`modules.<derived-from-module>` (e.g., `modules.audit` for an
+M4 stage). The optional `module_section_path` overrides:
+
+```yaml
+# default — audit ddl lands at modules.audit
+stage_id: m4.repo.apply-audit-ddl
+# override — autonomy presets land at modules.autonomy_overrides
+stage_id: m8.repo.set-autonomy-presets
+module_section_path: modules.autonomy_overrides
+```
+
+**When to override**: the default is "module name = section
+name". Override when the architect-facing concept name differs
+from the internal module name (autonomy overrides, kanban
+backend choice, etc.). Don't override capriciously — the
+default is the readable contract.
+
+### Per-module `schema_version` migration
+
+Each module owns its own `schema_version`. When you bump it:
+
+1. Implement the migration *inside* the stage's
+   `compute_target_state` (read old shape, transform to new).
+2. Bump the stage's `generation` (so existing repos see
+   `stale`).
+3. The next hook tick → SKILL runs the stage → executor
+   writes the new shape → `schema_version` bumps in the
+   settings file.
+
+There is **no central migration runner**. Per-module
+schema migration is the entire migration story. If you find
+yourself reaching for a central runner, you're probably trying
+to coordinate cross-module changes — push them through
+multiple stages with `depends_on` instead.
+
+## 11. BoardAdapter capability dispatch — M3-conditioning
+
+[ADR-0022](./docs/architecture/adr/0022-boardadapter-capability-dispatch.md)
+defines:
+
+- **M10 BoardAdapter selection** — agentic stage
+  `m10.repo.choose-kanban-backend` elicits which adapter the
+  repo uses.
+- **M3 stages declare capability dependencies** — e.g.,
+  `m3.repo.label-card-status` declares
+  `applicable_when: board_capability: card_status_label`.
+  Adapters declare which capabilities they support.
+
+### Judgment: adding a new capability
+
+When adding a new M3 stage:
+
+1. Decide which capability it requires.
+2. Check whether existing adapters declare that capability.
+   If only some do, the stage gets `not-applicable` for repos
+   using non-supporting adapters — verify that's the
+   intended UX.
+3. If the capability is brand-new, add it to the canonical
+   capability list in [ADR-0022](./docs/architecture/adr/0022-boardadapter-capability-dispatch.md)
+   and update every adapter's declared capability set in the
+   same PR.
+
+### When you should NOT use capability dispatch
+
+If the M3 work is universal across all backends (e.g.,
+"create the GitHub Project itself"), it's not M3 capability
+dispatch territory — that work is part of M10 backend setup.
+Capability dispatch is for *features* the backend exposes,
+not for the backend's existence.
+
+## 12. Cross-version evolution — `generation` bumps & `schema_version`
+
+The lifecycle's three-layer fingerprint is in
+[ADR-0013](./docs/architecture/adr/0013-declarative-state-schema-and-lifecycle.md).
+What you need to know operationally:
+
+| Edit | Bump `generation`? | Bump `schema_version`? |
+|------|-------------------|------------------------|
+| Fixed a typo in a docstring | No | No |
+| Renamed a field in `target_state_schema` | **Yes** | **Yes** (if persisted shape changed) |
+| Changed `compute_target_state` to compute a new field | **Yes** | **Yes** (if persisted shape changed) |
+| Tightened the schema (added `pattern: ^[a-z]+$` to an existing field) | **Yes** (existing values may now violate) | Maybe (depends on whether old values need migration) |
+| Loosened the schema (removed a constraint) | **No** (existing values still valid) | No |
+| Added a new field to `target_state_schema` with a default | **Yes** | **Yes** |
+| Added a new option to an enum (graceful, with `introduced_in_version` tag per [ADR-0023](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md)) | No | No |
+
+### The pre-v1 breaking change rule
+
+Until v1 GA, **breaking changes are accepted without
+in-place migration**. If you're tempted to write a v0.x → v0.y
+migration helper, stop — the policy is to delete legacy state
+and re-bootstrap. See [§ "Open design choices > Decided"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#decided-by-this-draft).
+
+After v1 GA this changes — backward compatibility becomes
+load-bearing. Plan the v1 GA cutover deliberately.
+
+## 13. The canonicalization invariant — agent footguns
+
+The five canonicalization steps are in
+[§ "Canonicalization invariant for hash stability"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#canonicalization-invariant-for-hash-stability).
+
+Footguns specific to agents writing stage code:
+
+- **`yaml.dump(...)` directly** in your stage instead of going
+  through `scripts/stages_lib/_canonical.py`. The hash will
+  drift across pyyaml versions. Always use the shared helper.
+- **Inserting timestamps / correlation IDs into
+  `target_state`** without listing them in
+  `hash_excluded_fields`. Hash flap → permanent `stale`.
+- **Writing `target_state` keys in non-deterministic order**.
+  The canonicalizer sorts, so this *should* be safe, but if you
+  bypass the canonicalizer for any reason (custom emit path,
+  golden-file fixture in tests), you have to sort yourself.
+- **Treating `compute_target_state` as a free-form Python
+  function**. It must be **pure** (same input → same output)
+  and **bounded** (no unbounded recursion, no async IO). If
+  you need IO to compute target_state, that IO belongs in
+  `target_state_predicate` — `compute_target_state` declares
+  the *expected* shape, not the *observed* shape.
+
+If you think you've found a case where the canonicalization
+breaks, write a CI round-trip test that demonstrates the break
+before patching. We've been burned by "well-intentioned" hash
+fixes that broke other stages silently.
+
+## 14. Recipe — adding a new stage end-to-end
+
+The full procedure as a checklist for a PR-prep self-review:
+
+```
+□ 1. Decide axes: (module, character, locality). Re-read § 5
+     for misclassifications. Locality = where target_state lands.
+□ 2. Choose stage_id: <module>.<locality-bucket>.<verb-noun>.
+     Examples: m4.repo.apply-audit-ddl, m9.host.register-codex-hooks.
+     locality-bucket = host | repo (repo-shared and repo-clone
+     both prefix "repo"; the locality field disambiguates).
+□ 3. Write registry row in scripts/stages-registry.yml.
+     Required fields per ADR-0014; optional fields per
+     ADR-0020 (applicable_when), ADR-0021 (module_section_path),
+     ADR-0023 (interactive_prompt for agentic).
+□ 4. Write per-stage Python module at
+     scripts/stages_lib/<stage_id_slug>.py with the 5 callables.
+     Slug = stage_id with `.` and `-` → `_`.
+□ 5. If you added a new field to the registry, update
+     scripts/stages-registry.schema.json (JSON Schema gate).
+□ 6. If character: agentic, fill all 5 protocol elements
+     (§ 7). Per-prompt-renderer kind must be one of the 5.
+□ 7. If locality: external, set external_ttl_seconds (per
+     [§ "External stage TTL cache"](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md#external-stage-ttl-cache-in-repo-shared-stateyml)).
+□ 8. Set platforms (default both, see § 9). For codex-only or
+     cc-only, justify in the per-stage Python module's
+     module-level docstring.
+□ 9. depends_on — list every stage whose target_state is read
+     by your stage's compute_target_state or
+     idempotency_check or applicable_when.
+□ 10. Set generation = 1 for new stages.
+□ 11. Run CI gates locally:
+      • python3 -m json scripts/stages-registry.schema.json
+        validates scripts/stages-registry.yml
+      • Round-trip test: compute_target_state output
+        canonicalizes consistently across two runs
+      • Stage-isolated test: idempotency_check returns True
+        after one executor run
+□ 12. If your stage is agentic, hand-test the prompt path
+      in a CC and Codex session (interactive_prompt rendering
+      varies by platform).
+□ 13. Update the design doc § "Stages" table — the
+      authoritative 22-row registry view. Same PR, paired
+      diff. (The registry YAML is the runtime SoT; the design
+      doc table is the architect-facing SoT — they MUST agree.)
+□ 14. Update SKILLS.md if your stage adds a new
+      bootstrapping-repo capability that affects the SKILL's
+      role description.
+□ 15. Commit message: `feat(stages): m<N>.<locality>.<verb> —
+      <one-line>`. PR body cites the relevant ADR(s).
+```
+
+The PR review questions a reviewer should ask:
+
+1. Is this work actually a stage, or should it be one of the
+   alternatives in § 4?
+2. Are the three axes correctly chosen (§ 5)?
+3. If `character: agentic`, are all 5 protocol elements
+   filled?
+4. If `applicable_when` is used, is it the right form (§ 8)?
+5. If `platforms` is not `both`, is the justification real?
+6. Does `compute_target_state` look pure + bounded (§ 13)?
+7. Is `generation` bumped if any persisted shape changed?
+8. Is the design doc table updated to match?
+
+## 15. Testing — what CI gates and what you must hand-test
+
+CI-gated:
+
+- **JSON Schema validation** — every PR runs the schema
+  validator over `stages-registry.yml`. Catches typos,
+  missing fields, enum mismatches, dangling `depends_on`.
+- **Round-trip canonicalization** — each stage's
+  `compute_target_state` output is canonicalized twice in CI;
+  the two outputs must match byte-for-byte.
+- **Idempotency** — for stages with deterministic local
+  effects, a CI fixture runs executor twice and asserts the
+  second run is a no-op.
+- **shellcheck** over any new shell helpers.
+
+NOT CI-gated (you must hand-test):
+
+- **Architect prompt rendering** — `interactive_prompt`
+  fields render differently on CC vs Codex (CC has Skill
+  tool richer affordances; Codex is text-only). Hand-test
+  both before submitting an agentic-stage PR.
+- **External-locality stage observability** — RDBMS / GitHub
+  query failures mid-flight (network drops, auth expiry).
+  Manually simulate at least one failure mode and verify the
+  lifecycle reports `stale` rather than crashing.
+- **Mid-flow architect interrupt** — open a session, let the
+  SKILL prompt for an agentic stage's input, abandon the
+  session before answering. Reopen — the stage should be
+  re-prompted on the next session, not silently skipped.
+- **First-time bootstrap on a fresh repo** — the recipe
+  above is necessary but not sufficient; do a full clean
+  bootstrap end-to-end at least once before opening a PR
+  that adds an agentic stage.
+
+## 16. Anti-patterns
+
+### A1. "I'll add a stage just for this one debug helper."
+
+Stages are operational machinery, not tooling. Debug helpers
+go in `scripts/`, gated by an env var if needed. The stage
+registry is read on every session — every entry costs
+architect attention on every plugin upgrade.
+
+### A2. "compute_target_state can call out to GitHub for the source-of-truth value."
+
+No. `compute_target_state` is the *expected* shape; if the
+expected shape requires live IO, your stage isn't really
+declaring expectations, it's reflecting reality. That's the
+job of `target_state_predicate` (paired with
+`external_ttl_seconds` for caching).
+
+### A3. "I'll embed bash inside YAML for the executor."
+
+No. The 5-callable contract is typed Python. Bash inside YAML
+is the exact failure mode [ADR-0014 § δ](./docs/architecture/adr/0014-stage-registry-contract.md)
+rejects.
+
+### A4. "I'll have my agentic stage write a bespoke prompt and persist directly to a custom file."
+
+No. The 5-element protocol exists exactly to retire bespoke
+prompt code. If your decision shape doesn't fit one of the
+5 prompt kinds, **push back on the requirement**, don't
+extend the protocol.
+
+### A5. "I'll put credentials in `repo-shared` because they're related to this repo."
+
+No. Credentials are `repo-clone` (gitignored). The locality
+axis is about git semantics, not subject-matter.
+
+### A6. "I'll skip bumping `generation` because it's just a docstring change."
+
+If you're not sure whether your edit affects the canonicalized
+hash, run the round-trip test locally. When in doubt, bump.
+Forgotten `generation` bumps cause silent staleness — far
+worse than gratuitous re-runs.
+
+### A7. "I'll add `applicable_when: python: ...` for this case where Form 1 would also work."
+
+The Python escape hatch is permanent registry surface that
+every reader has to context-switch into Python to understand.
+Forms 1 + 2 are declarative and self-documenting; prefer them
+unless they genuinely cannot express the conditional.
+
+### A8. "I'll add a separate one-off migration script for this v0.x → v0.y schema bump."
+
+No central migration runner. Module-local migration inside
+`compute_target_state` is the only sanctioned migration
+pattern. The pre-v1 breaking-change policy means you usually
+don't need migration code at all — delete legacy state and
+re-bootstrap.
+
+### A9. "I want to gate one stage on multiple settings paths — I'll just nest applicable_when blocks."
+
+The schema permits one `applicable_when` per stage. If you
+need multi-condition logic, either:
+(a) consolidate the conditions into one stage with a richer
+`target_state_schema`, or
+(b) split into multiple stages with `depends_on` chains.
+Nested `applicable_when` is not supported and would be a
+red flag in review.
+
+### A10. "Two stages have the same `(module, character, locality)`; I'll distinguish by `stage_id` alone."
+
+The (module, character, locality) triple is the identity
+invariant. Two stages with the same triple cannot coexist;
+collapse them into one stage with richer
+`target_state_schema`, or split the module / re-classify the
+locality so the triples differ.
+
+## 17. Failure-mode philosophy — graceful degradation
+
+The setup-stages system follows a strict graceful-degradation
+discipline. Three principles:
+
+### P1. The hook NEVER blocks session start
+
+[ADR-0012](./docs/architecture/adr/0012-unified-check-script-trigger-model.md)
+mandates the hook always exits 0. If the hook can't compute
+the lifecycle diff (corrupt registry, missing settings file,
+parser failure), it emits no marker and exits 0. The
+architect sees "no progress" rather than "session frozen".
+
+If you find yourself wanting the hook to "fail loudly" for
+debuggability, write logging to stderr — never block.
+
+### P2. The SKILL fails per-stage, not whole-session
+
+If stage X's executor fails, stage X enters status `failed`
+with a captured error. The SKILL **continues** with stage Y
+(unless Y depends on X via `depends_on`). The architect sees
+a final summary listing what completed, what failed, and
+what's pending.
+
+Avoid: "if any stage fails, abort the whole flow." That makes
+debugging worse and forces architects to fix the first error
+to even see the second.
+
+### P3. External dependencies degrade to local fallback when possible
+
+The audit module is the canonical example: if the BYO RDBMS is
+unavailable, audit-log-write degrades to local jsonl + records
+the degradation in the entry's `mode` field
+([ADR-0019](./docs/architecture/adr/0019-zero-config-sqlite-default-audit-backend.md)
++ AGENTS.md root § "Architecture at a glance" item 4). The
+session continues; observability isn't lost.
+
+When designing a new stage with external dependencies, ask:
+"if the external dependency is gone, what's the smallest
+local fallback that preserves architect-visible progress?"
+That's the failure mode you build.
+
+### Architect-unreachable failure mode (CI / scripted env)
+
+Agentic stages cannot complete without architect input. In a
+CI run or scripted environment, the SKILL records
+`status: pending-architect-input` and exits cleanly. The
+stage stays pending until the next interactive session. This
+is a deliberate choice — see [ADR-0023 § Decision sub
+"Agentic, architect unreachable"](./docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md).
+
+Don't try to "handle" this with defaults / silent skips /
+auto-continue. Architect-input stages exist *because* a
+default would be wrong; substituting a default at agent-time
+defeats the protocol.
+
+## 18. Cross-cutting reading map
+
+When your work touches setup-stages, the right reading order
+depends on which seam you're modifying. Quick map:
+
+| Modifying… | Read first |
+|-----------|-----------|
+| `scripts/stages-registry.yml` | This guide § 4–5, ADR-0014, design doc § "Stage registry contract" |
+| `scripts/stages_lib/<stage_id>.py` | This guide § 6, ADR-0013, design doc § "What the lifecycle model asks of each stage" |
+| `scripts/stages-registry.schema.json` | ADR-0014, JSON Schema docs |
+| `hooks/session-start.sh` lifecycle-diff path | ADR-0012, design doc § "Trigger model > Hook flow", `hooks/AGENTS.md` |
+| `skills/bootstrapping-repo/SKILL.md` | This guide § 7 + § 17, ADR-0023, design doc § "Architect UX", `skills/AGENTS.md` Process gate |
+| `settings.yml` family layout | ADR-0021, ADR-0024, design doc § "Settings modular layering" |
+| Adding a new module (M11+) | This guide § 5, ADR-0022 (if it's BoardAdapter-shaped), design doc § "Future-module inclusion procedure" |
+| Adding a new BoardAdapter | ADR-0022, ADR-0005 (the core BoardAdapter contract) |
+| Cross-version evolution / migration | This guide § 12 + § 13, ADR-0013 |
+
+For everything else: **the design doc**
+[`docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](./docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+is the authoritative reference. The 13 setup-stages ADRs
+(0012–0024) carry the per-decision rationale.
+
+## Same-PR contract
+
+If your stage-touching change makes a contract in this guide
+stale (e.g., a new prompt-renderer kind ships, a new
+applicable_when form lands, the recipe in § 14 grows a step),
+fix this guide in the **same PR** — not a follow-up. Doc lag
+is the failure mode this whole companion-doc pattern exists to
+prevent.
+
+This guide MUST cite the design doc + ADRs as authority and
+MUST NOT carry contradictory claims. When in conflict, the
+design doc / ADR wins; patch this guide.

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md
@@ -232,12 +232,20 @@ Which subsystem does this stage configure? Nine values
   `host-shared` (uv binary), `repo-git`
   (`pyproject.toml` + `uv.lock`), and `repo-clone`
   (`.venv/`).
-- **`M3` — GitHub Project integration.** The
-  BoardAdapter's contract with the GitHub Project (13
-  standard Issue labels, 6-option Status field schema).
-  All M3 stages have `external` locality. (BoardAdapter
-  is the abstraction that makes future Linear / Jira
-  adapters possible per ADR-0005.)
+- **`M3` — Board operations (BoardAdapter-driven).**
+  Operations against the selected board backend (labels,
+  Status field schema, etc.). All M3 stages have
+  `external` locality and dispatch through the
+  BoardAdapter abstraction (ADR-0005), **not** through a
+  hard-coded backend. Each M3 stage declares an
+  `applicable_when: board_capability: <name>` predicate;
+  the stage runs only when the selected backend (per
+  M10) declares it supports that capability. v0.5.0's
+  GitHub-Project-v2 adapter declares
+  `[ensure-labels, status-field-schema]`; future Linear
+  / Jira adapters declare overlapping or different
+  capability sets, and M3 stages re-route automatically
+  via the lifecycle's `not-applicable` state.
 - **`M4` — Audit logging.** BYO RDBMS / SQLite audit-log
   subsystem (per-repo credentials + schema + flush +
   health reporting). **All M4 stages are per-repo** —
@@ -360,8 +368,8 @@ contract" below.
 | `m2.host.install-uv` | uv installer | Detect / install `uv` Python tool host-wide via `astral.sh/uv/install.sh` or PATH probe | M2 | automated | host-shared | both | `heavy`, `network-required` | v0.3.0 | — | `scripts/bootstrap-host.sh` |
 | `m2.repo.copy-uv-templates` | uv templates | Copy plugin's `pyproject.toml` + `uv.lock` from `<plugin>/scripts/templates/` into `<repo>/.board-superpowers/` | M2 | automated | repo-git | both | — | v0.3.0 | `m1.repo.write-state-yml` | `scripts/bootstrap-project.sh` |
 | `m2.repo.sync-venv` | venv sync | Run `uv sync` to materialize `<repo>/.board-superpowers/.venv/` from the copied lock | M2 | automated | repo-clone | both | `heavy` | v0.3.0 | `m2.host.install-uv`, `m2.repo.copy-uv-templates` | `scripts/bootstrap-project.sh` |
-| `m3.repo.ensure-labels` | standard labels | Ensure 13 standard GitHub Issue labels exist on the repo (idempotent via `gh` CLI); only runs when `kanban_backend == github-project-v2` | M3 | automated | external | both | — | v0.1.0-minimum | `m10.repo.choose-kanban-backend` | `scripts/setup-labels.sh` |
-| `m3.repo.validate-status-field` | status field validation | Validate the GitHub Project's 6-option Status field schema; agentic only on failure (guide architect to GitHub UI); only runs when `kanban_backend == github-project-v2` | M3 | agentic | external | both | `confirm-only`, `agentic-on-failure` | v0.1.0-minimum | `m10.repo.choose-kanban-backend` | `SKILL: bootstrapping-repo` (failure path) / `scripts/validate-status-field.sh` (read path) |
+| `m3.repo.ensure-labels` | standard labels | Ensure 13 standard board labels exist (calls `BoardAdapter.ensure_labels()`; current GitHub-Project-v2 adapter delegates to `gh` CLI). `applicable_when: board_capability=ensure-labels` (any backend declaring this capability participates) | M3 | automated | external | both | — | v0.1.0-minimum | `m10.repo.choose-kanban-backend` | `scripts/setup-labels.sh` |
+| `m3.repo.validate-status-field` | status field validation | Validate the board's Status field schema (calls `BoardAdapter.validate_status_field()`); agentic only on failure. `applicable_when: board_capability=status-field-schema` | M3 | agentic | external | both | `confirm-only`, `agentic-on-failure` | v0.1.0-minimum | `m10.repo.choose-kanban-backend` | `SKILL: bootstrapping-repo` (failure path) / `scripts/validate-status-field.sh` (read path) |
 | `m4.repo.acquire-dsn` | audit DSN | Acquire BYO RDBMS DSN; write per-repo `credentials.yml` (chmod 0600); first-time agentic, re-use automated | M4 | agentic | repo-shared | both | `confirm-only` (re-use path is automated) | v0.3.0 (host-shared); per-repo since vX.0.0 (this redesign) | `m1.repo.write-state-yml` | `SKILL: bootstrapping-repo` (first-time) / `scripts/bootstrap-project.sh` (re-use) |
 | `m4.repo.apply-audit-ddl` | audit DDL | Apply audit-log DDL to the resolved DB (3-dialect dispatch via `audit-init.sh`) | M4 | automated | external | both | — | v0.3.0 | `m4.repo.acquire-dsn` | `scripts/audit-init.sh` |
 | `m4.repo.flush-pending-audit` | audit flush | Replay `mode=bootstrap-pending` rows from jsonl into DB (idempotent via UNIQUE event_uuid) | M4 | automated | external | both | — | v0.3.0 | `m4.repo.apply-audit-ddl` | `scripts/audit-flush-pending.sh` |
@@ -731,6 +739,141 @@ hash match — forcing a fresh `gh api` call. TTL per stage
 is declared in the registry (default 86400 = 24h,
 overridable per-stage).
 
+### Settings modular layering (in-file structure)
+
+The four `settings.yml` files (one per non-`external`
+locality) each carry **two top-level data structures plus
+file-level metadata**, mirroring the VSCode settings.json /
+Helm values.yaml / Kubernetes ConfigMap convention of
+**single file, namespaced module sections**:
+
+```yaml
+# example: ~/.board-superpowers/settings.yml (host-shared)
+schema_version: 1                        # FILE-level schema version
+plugin_version: v0.5.0                   # plugin version that last wrote
+host_bootstrapped_at: 2026-04-28T...
+
+# Section 1 — flat lifecycle source-of-truth (machine view)
+stages_completed:
+  - stage_id: m1.host.create-state-dir
+    status: completed
+    generation: 1
+    target_state_hash: a1b2...
+    target_state: { ... }
+    target_state_schema_version: 1
+    completed_at: 2026-04-28T14:23:05Z
+    plugin_version: v0.5.0
+  - stage_id: m9.host.register-codex-hooks
+    ...
+
+# Section 2 — module-namespaced config-items projection (architect view)
+modules:
+  m1_plugin_runtime:
+    schema_version: 1                    # MODULE-level independent schema
+    # M1 has no architect-facing config items
+  m2_python_runtime:
+    schema_version: 1
+    uv_version: "0.4.20"
+  m8_autonomy:
+    schema_version: 1
+    presets_chosen: [allow-pr-creation]
+  m9_hook_registration:
+    schema_version: 1
+    codex_hooks_registered: true
+```
+
+The two-section split:
+
+- **`stages_completed[]`** — flat list of stage entries with
+  the three-layer fingerprint per ADR-0013. Hook reads this
+  for lifecycle diff (machine-optimized; cheap fast-path on
+  `generation` int compare).
+- **`modules.<id>`** — namespaced config-item projection.
+  Architect-friendly view; each module's section holds **only
+  the architect-facing config items** of that module's
+  stages. SKILL writes both sections atomically on stage
+  completion (mktemp + mv); architect-readable reads always
+  prefer `modules.<id>`.
+
+### Why both sections, not just one
+
+Two equally valid sources of truth would invite drift; one
+authoritative + one derived doesn't. The redesign picks
+**`stages_completed[]` as authoritative** (the full
+fingerprint lives there); `modules.<id>` is **derived**
+(re-written deterministically by SKILL whenever a stage's
+target_state changes). Architects who hand-edit `modules.<id>`
+trigger validation: SKILL's next pass detects the divergence
+between projection and source-of-truth and prompts the
+architect to either re-elicit the stage (lifecycle re-run)
+or revert the manual edit. This mirrors how Helm rejects
+divergence between `values.yaml` and chart-default values:
+projection editing has to pass through the chart's interface,
+not directly mutate values storage.
+
+### Per-module schema versioning
+
+Each `modules.<id>.schema_version` evolves **independently**
+of:
+
+- The **file-level** `schema_version` at the top of
+  `settings.yml`. (File-level only changes when the
+  flat-section `stages_completed[]` entry shape changes,
+  which is rare — additive only per
+  `0005-contracts/03-config-schemas.md` migration policy.)
+- **Other modules'** `schema_version`s. M4 changing its
+  audit DDL bumps `m4_audit.schema_version` only;
+  `m8_autonomy.schema_version` stays put.
+
+Module schema bump → all that module's stages' `target_state`
+shape changes → their `compute_target_state()` returns new
+shape → their `target_state_hash` changes → lifecycle flips
+those stages to `stale` → SKILL re-runs them (with
+human-readable structural diff for the architect).
+
+### Module naming convention
+
+`modules.<id>` follows the rule:
+
+```
+m{module_number}_{module_name_in_snake_case}
+```
+
+Examples:
+
+- `m4_audit` (M4 — Audit logging)
+- `m7_routing` (M7 — Agent routing)
+- `m8_autonomy` (M8 — Autonomy overrides)
+- `m10_kanban` (M10 — BoardAdapter selection)
+
+The number prefix preserves Axis-C module identity; the snake-case
+suffix is the architect-readable name. CI validation
+(per ADR-0014) ensures the convention is honored at
+load time.
+
+### Future-module inclusion procedure
+
+When a future plugin version (vN+1) introduces a new module:
+
+1. Add the new module's stages to `scripts/stages-registry.yml`
+   under unique `stage_id`s (`m11.host.…` / `m12.repo.…` /
+   etc.).
+2. Define the new module's settings projection schema in
+   `scripts/stages-registry.schema.json` under
+   `definitions/modules/m11_<name>` (per ADR-0014's
+   JSON-Schema gate).
+3. Implement the per-stage Python helpers in
+   `scripts/stages_lib/<stage_id>.py`.
+4. **No SKILL or hook code changes are required.** The
+   prompt-renderer + lifecycle engine consume the registry
+   declaratively; new modules land via registry-only edits.
+
+This procedure is the architectural contract that makes
+"plugin extension by registry edit" the **only** path for
+new architect-facing features. Any new module that bypasses
+the protocol re-introduces the bespoke-UX cost the redesign
+exists to eliminate.
+
 ## Repo identity
 
 Repo identity is **GitHub-based**: the host-local per-repo
@@ -910,6 +1053,8 @@ fields elaborated in supporting prose elsewhere are marked
 | `external_ttl_seconds` **(prose, external stages only)** | non-negative int | external only | TTL for external-stage validation cache. Default 86400 (24h). |
 | `kind` **(table, M7 only)** | enum `required` \| `optional` | M7 only | M7 routing-block kind tag (per architect direction). Surfaced as `kind=required` / `kind=optional` in the table's `flags` column. |
 | `block_max_bytes` **(prose, M7 only)** | non-negative int | M7 only | Per-block size cap (default 4096 bytes). Honors Codex 32 KiB AGENTS.md budget — see § "Functional modules" M7. |
+| `applicable_when` **(prose)** | predicate (declarative or callable) | no | Conditional applicability gate. When evaluated against current settings the predicate yields true → stage participates in lifecycle as normal; false → lifecycle returns `not-applicable` and the stage is silently skipped (no marker, no execution). Three forms: (1) declarative `{setting_path: <dot.path>, one_of: [<values>]}` — most stages use this; (2) declarative capability check `{board_capability: <name>}` — for stages that require a BoardAdapter capability (resolves through M10's selected backend's capability declarations); (3) Python predicate reference `applicable_when_fn: <module.callable>` — escape hatch for complex conditions. The predicate is evaluated by the hook (cheap — settings lookup + small comparisons); never by SKILL. |
+| `module_section_path` **(prose)** | string | no | If the stage's `target_state` should be projected into the settings file's `modules.<id>` section (per § "Settings modular layering"), this names the dotted path. SKILL writes both `stages_completed[].target_state` and `modules.<this_path>` synchronously on completion; reading is allowed from either (architect-facing reads prefer the projection). Default: `modules.<derived from module>` (e.g., `m4.repo.acquire-dsn` → `modules.m4_audit`). |
 
 ### Canonicalization invariant for hash stability
 
@@ -932,7 +1077,7 @@ hash stability and gets caught by CI.
 
 ### What the lifecycle model asks of each stage
 
-The 4-state lifecycle reads the registry + per-stage status
+The 5-state lifecycle reads the registry + per-stage status
 file entries to compute each stage's current state. Each
 stage MUST provide:
 
@@ -949,7 +1094,13 @@ stage MUST provide:
   time to confirm the outcome actually landed (especially
   for `external`-locality stages where local files lie).
 
-These five together form the **stage's contract with the
+Each stage MAY also provide:
+
+- An `applicable_when` predicate (or capability check) —
+  conditional gate that resolves to `not-applicable` when
+  false. Cheap to evaluate (hook-side); never blocks for IO.
+
+These together form the **stage's contract with the
 lifecycle model**. A stage that fakes any of them silently
 breaks the diff-and-replay mechanism. The
 `stages-registry.schema.json` validates the declarative
@@ -958,7 +1109,7 @@ must round-trip a known input → output).
 
 ## Stage lifecycle states
 
-Each stage's recorded state is one of four values, computed
+Each stage's recorded state is one of **five** values, computed
 deterministically by the unified check script per session
 start. The model uses a **three-layer comparison stack**
 borrowed from Kubernetes' `metadata.generation` /
@@ -992,10 +1143,11 @@ state applies — no fuzzy matching, no manual override.
 
 | State | Definition | Detection rule |
 |-------|------------|----------------|
-| **never-run** | This stage has never been recorded as completed on this `(host, repo)` pair. | No entry with this `stage_id` exists in the relevant status file. |
+| **never-run** | This stage has never been recorded as completed on this `(host, repo)` pair, AND the stage's `applicable_when` predicate evaluates true (or is absent). | No entry with this `stage_id` exists in the relevant status file; `applicable_when` (if present) → true. |
 | **completed** | Last recorded run succeeded **and** the recorded fingerprint matches the current plugin version's expectation. | Entry exists; `entry.generation == registry[stage_id].generation` (fast-path) AND `entry.target_state_hash == current_target_state_hash` (verify). Both equal → up-to-date; no re-run needed. |
 | **stale** | Last recorded run succeeded, but the current plugin version's expected target state has drifted (schema bump, content change, dep upgrade, executor change). | Entry exists; either `entry.generation != registry[stage_id].generation` OR (generation equal but) `entry.target_state_hash != current_target_state_hash`. SKILL re-runs the stage on next session start; structural diff between recorded `target_state` and current `target_state` is surfaced for diagnostics. |
 | **deprecated** | The stage existed in a prior plugin version but is no longer in the current registry. The recorded entry is preserved as history but no longer drives any execution. | `entry.stage_id ∉ current_registry`. The status file keeps the entry indefinitely (or until a manual prune); the check script ignores it for diff-computation purposes. |
+| **not-applicable** | The stage exists in the current registry but its `applicable_when` predicate evaluates false against current settings (e.g., `m3.repo.ensure-labels` is not-applicable when `kanban_backend ≠ github-project-v2`). The stage is silently skipped without re-prompt. | `applicable_when` predicate evaluates false. The hook does not emit a marker for not-applicable stages; SKILL does not execute them. If `applicable_when` later evaluates true (architect changed `kanban_backend`), state flips back to `never-run` (no historical entry) or `completed` (if entry exists from a prior applicable window). |
 
 Plus two **transient SKILL-only states** (set by the SKILL
 mid-execution; treated as effectively `never-run` /
@@ -1312,7 +1464,39 @@ Resolved (as discussion progresses, decisions move down to the
 - **M5 stage `m5.repo.set-wip-limit` is in-scope** — new
   agentic stage prompting architect for per-repo WIP limit
   (default 5; numeric-range 1-20). Persists into
-  `settings.local.yml:wip_limit` per repo-clone locality.
+  `settings.local.yml:modules.m5_repo_configuration.wip_limit`
+  per repo-clone locality.
+- **5th lifecycle state `not-applicable` introduced** —
+  alongside never-run / completed / stale / deprecated.
+  Triggered when a stage's `applicable_when` predicate
+  evaluates false. Hook does not emit a marker; SKILL does
+  not execute. Architect changing settings (e.g., kanban
+  backend) re-evaluates predicates next session, flipping
+  affected stages back to never-run / completed.
+- **`applicable_when` predicate field added to stage
+  registry** — per § "Stage registry contract" Column /
+  field semantics. Three forms: declarative
+  `setting_path + one_of`, declarative
+  `board_capability`, or escape-hatch
+  `applicable_when_fn` Python ref. Hook-side cheap
+  evaluation (no IO).
+- **M3 stages dispatch through BoardAdapter capabilities,
+  not backend names** — `m3.repo.ensure-labels` and
+  `m3.repo.validate-status-field` declare
+  `applicable_when: {board_capability: <name>}`; M3 module
+  is renamed "Board operations (BoardAdapter-driven)".
+  Resolves the implicit GitHub-Project-v2 hard-coding in
+  v0.4.0 stages. Per ADR-0005 (BoardAdapter contract) +
+  G4 (parity) + new BoardAdapter capability dispatch ADR.
+- **Settings file internal layout uses two-section split
+  with module namespacing** — flat `stages_completed[]`
+  (machine-optimized lifecycle source of truth) +
+  `modules.<id>` (architect-readable projection). Each
+  module section carries its own independent
+  `schema_version` for module-local schema migration.
+  Mirrors VSCode settings.json / Helm values.yaml
+  industry pattern. Resolved by § "Settings modular
+  layering".
 - **Repo identity is `<owner>-<repo>` from `origin` URL** —
   with `_path-...` fallback for local-only repos. Resolved by
   § "Repo identity". Triggers I-13 invariant revision.
@@ -1474,11 +1658,37 @@ Resolved (as discussion progresses, decisions move down to the
     encodes the sequential per-stage flow + the five-element
     config item protocol that future plugin features must
     honor when adding new architect-input items.
-14. Companion ADRs land in the same series (extends ADR-0012..0019
-    to also cover): (i) Architect UX + config item protocol
-    (the five-element contract); (j) settings.yml rename;
-    (k) M10 BoardAdapter selection module + M5 wip-limit
-    stage (these may be one or two ADRs depending on cohesion
-    judgement at write time).
+14. Companion ADRs in the same series, in addition to the
+    eight already drafted (ADR-0012 — ADR-0019):
+    - (i) **In-place updates** to ADR-0013 (5-state lifecycle
+      adds `not-applicable`), ADR-0014 (`applicable_when` +
+      `module_section_path` columns; settings file
+      two-section split + per-module schema_version),
+      ADR-0016 (`platforms` × `applicable_when`
+      composition rules — `platforms` is the special-cased
+      coarse predicate, `applicable_when` is the fine
+      predicate; both must be true for the stage to
+      participate).
+    - (j) **New ADR-0020** — Stage applicability +
+      `not-applicable` lifecycle state + `applicable_when`
+      predicate forms (declarative setting-path,
+      board-capability, Python escape hatch).
+    - (k) **New ADR-0021** — Settings modular layering
+      (two-section split + module namespacing + per-module
+      schema_version + future-module inclusion procedure).
+    - (l) **New ADR-0022** — BoardAdapter capability
+      dispatch (M3 stages route through
+      `BoardAdapter.<capability>()` interfaces; capability
+      declaration as part of adapter contract; M3 module
+      renamed "Board operations (BoardAdapter-driven)").
+      Cross-references ADR-0005 (BoardAdapter contract).
+    - (m) **New ADR-0023** — Architect UX + config item
+      protocol (sequential per-stage flow + 5-element
+      protocol: schema declaration / detection / interaction
+      / persistence / re-prompt trigger).
+    - (n) **New ADR-0024** — settings.yml rename + the
+      `m5.repo.set-wip-limit` and `m10.repo.choose-kanban-backend`
+      stages (may bundle as one ADR or split if review
+      finds them logically separable).
 15. This `-redesign.md` file removed; content lives in
     `05-bootstrap-surface.md`.

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md
@@ -321,6 +321,25 @@ Which subsystem does this stage configure? Nine values
   registry; brought into bootstrap per G4
   (cross-platform parity) — see the `platforms` column
   in the Stages table.
+- **`M10` — BoardAdapter selection.** The architect
+  decides which kanban backend the repo uses
+  (`github-project-v2` / `linear` / `jira` per ADR-0005's
+  BoardAdapter contract). At v0.5.0 the enum has only
+  `github-project-v2`; the future `linear` / `jira`
+  options land via registry-only edits (the option's
+  `introduced_in` field gates re-prompt: a repo whose
+  `kanban_backend` is `github-project-v2` from v0.5.0
+  remains `completed` after the v0.6.0 enum bump because
+  its `target_state` matches an extant option).
+  **Why a separate module from M3 (GitHub Project
+  integration).** M3 holds the *operations* against a
+  selected board (label management, Status field
+  validation, etc.). M10 holds the *selection* of which
+  board adapter to operate against. Future Linear / Jira
+  adapters land as new M3-pattern modules (or as additive
+  M3 implementation routes); M10 stays the single
+  selection seam. M3 stages depend on
+  `m10.repo.choose-kanban-backend`.
 
 ## Stages
 
@@ -341,33 +360,38 @@ contract" below.
 | `m2.host.install-uv` | uv installer | Detect / install `uv` Python tool host-wide via `astral.sh/uv/install.sh` or PATH probe | M2 | automated | host-shared | both | `heavy`, `network-required` | v0.3.0 | — | `scripts/bootstrap-host.sh` |
 | `m2.repo.copy-uv-templates` | uv templates | Copy plugin's `pyproject.toml` + `uv.lock` from `<plugin>/scripts/templates/` into `<repo>/.board-superpowers/` | M2 | automated | repo-git | both | — | v0.3.0 | `m1.repo.write-state-yml` | `scripts/bootstrap-project.sh` |
 | `m2.repo.sync-venv` | venv sync | Run `uv sync` to materialize `<repo>/.board-superpowers/.venv/` from the copied lock | M2 | automated | repo-clone | both | `heavy` | v0.3.0 | `m2.host.install-uv`, `m2.repo.copy-uv-templates` | `scripts/bootstrap-project.sh` |
-| `m3.repo.ensure-labels` | standard labels | Ensure 13 standard GitHub Issue labels exist on the repo (idempotent via `gh` CLI) | M3 | automated | external | both | — | v0.1.0-minimum | — | `scripts/setup-labels.sh` |
-| `m3.repo.validate-status-field` | status field validation | Validate the GitHub Project's 6-option Status field schema; agentic only on failure (guide architect to GitHub UI) | M3 | agentic | external | both | `confirm-only`, `agentic-on-failure` | v0.1.0-minimum | — | `SKILL: bootstrapping-repo` (failure path) / `scripts/validate-status-field.sh` (read path) |
+| `m3.repo.ensure-labels` | standard labels | Ensure 13 standard GitHub Issue labels exist on the repo (idempotent via `gh` CLI); only runs when `kanban_backend == github-project-v2` | M3 | automated | external | both | — | v0.1.0-minimum | `m10.repo.choose-kanban-backend` | `scripts/setup-labels.sh` |
+| `m3.repo.validate-status-field` | status field validation | Validate the GitHub Project's 6-option Status field schema; agentic only on failure (guide architect to GitHub UI); only runs when `kanban_backend == github-project-v2` | M3 | agentic | external | both | `confirm-only`, `agentic-on-failure` | v0.1.0-minimum | `m10.repo.choose-kanban-backend` | `SKILL: bootstrapping-repo` (failure path) / `scripts/validate-status-field.sh` (read path) |
 | `m4.repo.acquire-dsn` | audit DSN | Acquire BYO RDBMS DSN; write per-repo `credentials.yml` (chmod 0600); first-time agentic, re-use automated | M4 | agentic | repo-shared | both | `confirm-only` (re-use path is automated) | v0.3.0 (host-shared); per-repo since vX.0.0 (this redesign) | `m1.repo.write-state-yml` | `SKILL: bootstrapping-repo` (first-time) / `scripts/bootstrap-project.sh` (re-use) |
 | `m4.repo.apply-audit-ddl` | audit DDL | Apply audit-log DDL to the resolved DB (3-dialect dispatch via `audit-init.sh`) | M4 | automated | external | both | — | v0.3.0 | `m4.repo.acquire-dsn` | `scripts/audit-init.sh` |
 | `m4.repo.flush-pending-audit` | audit flush | Replay `mode=bootstrap-pending` rows from jsonl into DB (idempotent via UNIQUE event_uuid) | M4 | automated | external | both | — | v0.3.0 | `m4.repo.apply-audit-ddl` | `scripts/audit-flush-pending.sh` |
 | `m4.repo.audit-health-check` | audit health | Print stderr summary of audit-row landing count vs jsonl pending count | M4 | automated | repo-shared | both | — | v0.3.0 | `m4.repo.flush-pending-audit` | `scripts/bootstrap-project.sh` |
 | `m5.repo.write-config-yml` | config.yml | Write `<repo>/.board-superpowers/config.yml` with project default knobs (committed to git) | M5 | automated | repo-git | both | — | v0.1.0-minimum | — | `scripts/bootstrap-project.sh` |
 | `m5.repo.write-config-local-yml` | config.local.yml | Write `<repo>/.board-superpowers/config.local.yml` with per-architect knobs (gitignored) | M5 | automated | repo-clone | both | — | v0.1.0-minimum | — | `scripts/bootstrap-project.sh` |
+| `m5.repo.set-wip-limit` | wip limit | Prompt architect for `wip_limit` (concurrent active Consumer cap) per repo; default 5; persist into `config.local.yml:wip_limit`; architect may accept default to advance | M5 | agentic | repo-clone | both | `confirm-only` | vX.0.0 (this redesign) | `m5.repo.write-config-local-yml` | `SKILL: bootstrapping-repo` |
 | `m6.repo.append-gitignore` | gitignore entries | Append three protective entries (`*.local.*`, `claims/`, `.venv/`) to `<repo>/.gitignore` (idempotent) | M6 | automated | repo-git | both | — | v0.1.0-minimum | — | `scripts/bootstrap-project.sh` |
 | `m7.repo.detect-agentsmd-form` | agentsmd form | Detect repo's routing-target form (`cc-only` / `codex-only` / `dual` / `neither`) by scanning AGENTS.md + CLAUDE.md presence; cache result in repo-shared state | M7 | automated | repo-shared | both | — | vX.0.0 (this redesign) | `m1.repo.write-state-yml` | `scripts/bootstrap-project.sh` |
 | `m7.repo.inject-block.routing-rule` | routing-rule block | Inject `routing-rule` required block (skill-routing trigger) into target file(s) per detected form; check 4 KiB single-block size cap; honor 8 KiB total Codex AGENTS.md budget | M7 | automated | repo-git | both | `kind=required`, `block-size-capped` | v0.1.0-minimum (single-block); per-block stage since vX.0.0 (this redesign) | `m7.repo.detect-agentsmd-form` | `scripts/bootstrap-project.sh` |
 | `m7.repo.inject-block.skill-routing` | skill-routing block | Inject `skill-routing` required block (Manager / Consumer dispatch rules) into target file(s) per detected form | M7 | automated | repo-git | both | `kind=required`, `block-size-capped` | v0.1.0-minimum (single-block); per-block stage since vX.0.0 (this redesign) | `m7.repo.detect-agentsmd-form` | `scripts/bootstrap-project.sh` |
 | `m9.host.register-codex-hooks` | codex hook registration | Register `~/.codex/config.toml` `[hooks]` table to wire `SessionStart` to `hooks/session-start.sh` | M9 | automated | host-shared | codex-only | `platform-specific` | vX.0.0 (this redesign) | `m1.host.write-manifest` | `scripts/register-codex-hooks.sh` |
-| `m8.host.bootstrap-overrides-yml` | autonomy overrides | Prompt architect with curated autonomy-override presets; write `~/.board-superpowers/overrides.yml` (architect may select subset including "no presets, skip" → empty file + completed) | M8 | agentic | host-shared | both | `confirm-only` | vX.0.0 (this redesign) | `m1.host.write-manifest` | `SKILL: bootstrapping-repo` |
+| `m8.host.bootstrap-overrides-yml` | autonomy overrides | Prompt architect with curated autonomy-override presets; persist selected subset into the `host-shared` settings file (empty selection is a valid completed state) | M8 | agentic | host-shared | both | `confirm-only` | vX.0.0 (this redesign) | `m1.host.write-manifest` | `SKILL: bootstrapping-repo` |
+| `m10.repo.choose-kanban-backend` | kanban backend | Prompt architect to choose BoardAdapter backend per ADR-0005 (`github-project-v2` / `linear` / `jira`). At v0.5.0 the enum has only `github-project-v2`; M3 stages depend on this selection | M10 | agentic | repo-git | both | `confirm-only`, `single-choice-currently` | vX.0.0 (this redesign) | `m1.repo.write-state-yml` | `SKILL: bootstrapping-repo` |
 
-**20 stages** — 14 v0.4.0 baseline (M7 v0.4.0 single-block
-stage replaced) + 6 net new / restructured this redesign
+**22 stages** — 14 v0.4.0 baseline (M7 v0.4.0 single-block
+stage replaced) + 8 net new / restructured this redesign
 (`m7.repo.detect-agentsmd-form`,
 `m7.repo.inject-block.routing-rule`,
 `m7.repo.inject-block.skill-routing`,
 `m9.host.register-codex-hooks`,
-`m8.host.bootstrap-overrides-yml`, plus the M4
-`acquire-dsn` re-locality). Future `kind=optional` blocks
-add agentic stages of shape
-`m7.repo.inject-block.<name>` without registry-shape
-changes. The 32 KiB Codex AGENTS.md budget caps total
-M7 routing block size — see § "Functional modules" M7.
+`m8.host.bootstrap-overrides-yml`,
+`m5.repo.set-wip-limit`,
+`m10.repo.choose-kanban-backend`, plus the M4
+`acquire-dsn` re-locality). Future `kind=optional` M7 blocks
+or new BoardAdapter selections add agentic stages of shape
+`m7.repo.inject-block.<name>` or new M10 enum options
+without registry-shape changes. The 32 KiB Codex AGENTS.md
+budget caps total M7 routing block size — see § "Functional
+modules" M7.
 
 ### Cross-axis sparsity is the value of the table form
 
@@ -524,28 +548,53 @@ This split enables:
 
 ## Declarative state schema
 
-State is **partitioned by locality** — each of the four
-non-`external` Axis B values gets its own dedicated YAML
-status file. `external` stages cache their last-validation
-results inside `repo-shared`'s `state.yml` (no separate
-external status file).
+State is **partitioned by locality** and unified under the
+`settings.yml` family — each of the four non-`external` Axis B
+values gets its own dedicated YAML settings file. `external`
+stages cache their last-validation results inside `repo-shared`'s
+settings file (no separate external status file).
 
-### Four status files (one per locality)
+The `settings.yml` naming is the architect-facing surface (per
+§ "Architect UX"): every architect's plugin configuration is
+visible by reading the appropriate `settings.yml`. The same
+files are also the plugin runtime's lifecycle source-of-truth
+(stages_completed entries with three-layer fingerprint live
+inside). Pre-v1 breaking change: existing v0.4.0 plumbing
+filenames (`manifest.yml`, `state.yml`, `config.yml`,
+`config.local.yml`) rename to the unified family below; existing
+host-shared `overrides.yml` content folds into the host-shared
+`settings.yml` under a dedicated `autonomy_overrides` key.
 
-| File | Locality | Cross-clone? | Tracked in git? | Stage entries |
-|------|----------|--------------|-----------------|---------------|
-| `~/.board-superpowers/manifest.yml` | `host-shared` | n/a (host-wide) | No | M1 host stages, M2 install-uv, M9 codex-hook |
-| `~/.board-superpowers/repos/<repo-identity>/state.yml` | `repo-shared` | **Yes (cross-clone shared)** | No | M1 state.yml stage itself, M4 audit stages, external-stage TTL caches |
-| `<repo>/.board-superpowers/repo-state.yml` | `repo-git` | No (per-clone-physical, sync via git) | **Yes (committed)** | M2 templates, M5 config.yml, M6 gitignore, M7 routing-block stages |
-| `<repo>/.board-superpowers/clone-state.yml` | `repo-clone` | No (per-clone-physical) | No (gitignored) | M2 venv, M5 config.local.yml |
+### Four settings files (one per locality)
+
+| File | Locality | Cross-clone? | Tracked in git? | Replaces (v0.4.0) | Stage entries |
+|------|----------|--------------|-----------------|-------------------|---------------|
+| `~/.board-superpowers/settings.yml` | `host-shared` | n/a (host-wide) | No | `manifest.yml` + `overrides.yml` (folded) | M1 host stages, M2 install-uv, M8 autonomy presets, M9 codex-hook |
+| `~/.board-superpowers/repos/<repo-identity>/settings.yml` | `repo-shared` | **Yes (cross-clone shared)** | No | `state.yml` | M1 per-repo state stage itself, M4 audit stages, M7 form-detect cache, external-stage TTL caches |
+| `<repo>/.board-superpowers/settings.yml` | `repo-git` | No (per-clone-physical, sync via git) | **Yes (committed)** | `config.yml` | M2 templates, M5 config.yml, M6 gitignore, M7 routing-block stages, M10 kanban backend choice |
+| `<repo>/.board-superpowers/settings.local.yml` | `repo-clone` | No (per-clone-physical) | No (gitignored) | `config.local.yml` | M2 venv, M5 config.local.yml + WIP limit |
+
+`~/.board-superpowers/repos/<repo-identity>/credentials.yml`
+remains a separate file (mode 0600) for secret isolation; it
+is not part of the `settings.yml` family because settings files
+are mode 0644 and may be inspected casually.
 
 **Why partition?** A single monolithic state file would have
-to cross-cut localities (e.g., `<repo>/.board-superpowers/state.yml`
-holding stages whose outcomes live in `~/...` — confusing).
+to cross-cut localities (e.g., a `settings.yml` at repo root
+holding stages whose outcomes live under `~/...` — confusing).
 Partitioning makes each file's *ownership* clear: this file
 records progress for stages whose outcomes land in this
 locality. The hook reads four small files in parallel; each
 file's update path is owned by stages of one locality.
+
+**Why unify the names?** Pre-redesign v0.4.0 has four
+plumbing files with four different names (`manifest.yml`,
+`state.yml`, `config.yml`, `config.local.yml`) — the
+disparate naming reflects implementation history, not
+architectural meaning. The redesign makes `settings.yml` the
+single architect-facing concept, with `.local.yml` as the
+sole suffix variant (matching git-ignore convention). One
+mental model, one filename family.
 
 ### Per-stage entry shape
 
@@ -1036,10 +1085,139 @@ identifies." There is no separate migration code path.
 
 ## Architect UX
 
-> *To be filled in.* What architect sees on first session
-> after upgrade; how agentic stages prompt for input; how
-> automated-stage failures are surfaced; how idempotent
-> re-run is invoked.
+The architect's interaction with bootstrap is the **interactive
+configuration surface** for the plugin: every architect-facing
+decision the plugin needs to record (audit DSN scheme, autonomy
+override presets, WIP limit, kanban backend, future new
+features' configuration items) is mediated by an **agentic
+stage** in the registry. There is no separate "settings" UX —
+agentic stages *are* the settings UX. This section formalizes
+the protocol so future plugin versions can add new
+configuration items by registry-only edits, without writing
+bespoke prompt code per item.
+
+### The reframe: agentic stage = config-item elicitation flow
+
+A bootstrap stage's `character: agentic` means exactly: this
+stage requires architect input to compute its `target_state`.
+From the architect's vantage point that input is "make a
+configuration choice"; from the plugin runtime's vantage point
+it is "fill in this stage's `target_state` so the lifecycle
+flips to `completed`". The two perspectives are the same
+operation, the same persistence, the same lifecycle. Skip
+semantics evaporate — an empty / null / "no presets selected"
+choice is itself a valid `target_state` and produces
+`completed`. The lifecycle's 4 states (never-run / completed /
+stale / deprecated) cover all observable architect states; no
+fifth "skipped" or "deferred" state is introduced.
+
+### Sequential per-stage flow (decision: B)
+
+The SKILL handles agentic stages **one at a time**, not in a
+batch wizard. Flow:
+
+1. Hook emits `INVOKE: bootstrapping-repo + REASON: <N> stages
+   need running` (per § "Trigger model").
+2. SKILL is woken. Reads partitioned settings files; recomputes
+   lifecycle diff; topologically orders pending stages by
+   `depends_on`.
+3. SKILL iterates pending stages in topological order:
+   - For `automated` stages: invokes the stage's `executor`
+     via `Bash` tool autonomously; no architect attention.
+     Records completion in the appropriate settings file.
+   - For `agentic` stages: renders the stage's
+     `interactive_prompt` to the architect using the prompt
+     kind (single-choice / multi-choice / free-text /
+     boolean / numeric-range); waits for response; validates
+     against the stage's `target_state_schema`; persists
+     `target_state` into the settings file; marks completed.
+   - For `agentic` stages where the architect is unreachable
+     (CI, scripted environment): SKILL records
+     `status: pending-architect-input` and the stage stays
+     pending until next session.
+4. SKILL emits final summary: "N stages completed; M skipped
+   due to depends_on chain breakage (dependencies unmet); K
+   pending-architect-input."
+
+The sequential model means architects who interrupt mid-flow
+return to a partial state next session — pending stages that
+weren't reached pick up from where they left off; completed
+stages stay completed. There is no "wizard restart"; the
+lifecycle model is the resume primitive.
+
+### Config item protocol — the five required elements
+
+Every config item that the plugin elicits from the architect
+is encoded as an agentic stage that satisfies all five of the
+following protocol elements. New plugin features that need
+architect input add a registry entry that fills in all five;
+no bespoke prompt code is written per item.
+
+| Element | What it is | Where it lives | Reuses |
+|---------|-----------|----------------|--------|
+| **1. Schema declaration** | The stage's `target_state_schema` declares the shape of the architect's choice. Examples: `{wip_limit: int (1..20)}`; `{kanban_backend: enum [github-project-v2, linear, jira]}`; `{presets_chosen: list of enum [allow-pr-creation, ...]}`. Plus required-or-optional, default value, enum option list (with `introduced_in_version` per option for graceful enum-bump compat). | Stage registry entry's `target_state_schema` field (per ADR-0014). | ADR-0014 stage registry contract; ADR-0014 JSON Schema validation gate. |
+| **2. Detection** | "Has this config item already been set?" The lifecycle 4-state model answers this purely from local settings files. `never-run` / `stale` ⇒ needs eliciting; `completed` ⇒ already set; `deprecated` ⇒ ignore. | Lifecycle compute function (per ADR-0013) reads stage entries from settings files. | ADR-0013 4-state lifecycle + three-layer fingerprint. |
+| **3. Interaction** | How the agent prompts the architect. The stage registry's new `interactive_prompt` field declares the prompt template + kind (`single-choice` / `multi-choice` / `free-text` / `boolean` / `numeric-range`) + options-source (literal list, or computed-from-`target_state_schema.enum`, or runtime-derived). SKILL's prompt-renderer is generic — given an `interactive_prompt` declaration it generates the architect-facing question without per-stage code. | Stage registry entry's new `interactive_prompt` field. SKILL `prompt-renderer.py` is the single implementation. | The `interactive_prompt` field is added to the registry contract per this section. |
+| **4. Persistence** | "Where does the choice land on disk?" The stage's `locality` (Axis B) decides which settings file. `host-shared` → `~/.board-superpowers/settings.yml`; `repo-shared` → `~/.board-superpowers/repos/<id>/settings.yml`; `repo-git` → `<repo>/.board-superpowers/settings.yml`; `repo-clone` → `<repo>/.board-superpowers/settings.local.yml`. | Stage registry entry's `locality` field; SKILL writes the resolved settings file with atomic mktemp+mv. | Axis B locality semantics; § "Declarative state schema" partitioned files. |
+| **5. Re-prompt trigger** | When does the plugin ask again? Three triggers, all derived from the lifecycle: (a) plugin upgrade bumps the stage's `generation` int (e.g., new enum option added) → flips to `stale` → re-prompts; (b) architect manually edits the settings file in a way that no longer matches `target_state_schema` → load-time validation rejects, stage flips to `stale`; (c) architect explicitly invokes `scripts/bsp-stage-rerun.sh <stage_id>` → forces stage to `never-run`. | Lifecycle stale-detection rule + SKILL's response to stale entries. | ADR-0013 lifecycle; no new mechanism. |
+
+### Future-feature inclusion procedure
+
+When a future plugin version (vN+1) introduces a new feature
+that needs architect input:
+
+1. Author the new agentic stage's registry entry in
+   `scripts/stages-registry.yml`, filling all five protocol
+   elements (`target_state_schema`, `interactive_prompt`,
+   `locality`, `generation`, `introduced_in_version`).
+2. Author the per-stage Python helpers in
+   `scripts/stages_lib/<stage_id>.py` (per ADR-0014 naming
+   convention) implementing `compute_target_state`,
+   `idempotency_check`, `target_state_predicate`, `executor`.
+3. Bump the SKILL test fixture (a settings file fixture +
+   expected `target_state` after architect responds) so the
+   prompt-renderer + persistence path is regression-tested.
+4. **No SKILL code changes are required.** The
+   prompt-renderer reads the new stage's `interactive_prompt`
+   declaration and renders the question generically.
+
+This is the architectural contract the design relies on:
+**adding a config item is a registry edit + Python helpers,
+not a SKILL feature**. Failing to honor this constraint
+produces SKILL prompt-code drift across config items and
+re-introduces the per-feature bespoke-UX cost the redesign
+exists to eliminate.
+
+### Settings file naming
+
+Per decision: existing plumbing files are renamed to a
+unified `settings.yml` family (one per non-`external`
+locality). See § "Declarative state schema" for the rename
+table and the in-file structure (each `settings.yml` carries
+`schema_version` + `plugin_version` + `stages_completed[]` +
+optional human-readable `config_items` projection).
+
+### Failure surfaces (architect-facing)
+
+- **Automated stage failure** (executor non-zero exit):
+  SKILL records `status: failed` + `last_error` in the
+  appropriate settings file. Lifecycle treats `failed` as
+  effectively `never-run` for the next session. SKILL surfaces
+  a brief failure summary at end of current session: "stage X
+  failed: <one-line>; will retry next session". After 3
+  consecutive failed runs, SKILL emits a special
+  `INVOKE: bootstrapping-repo / REASON: stage X needs
+  troubleshooting` marker on next hook tick to escalate.
+- **Agentic stage abandoned** (architect leaves session
+  without responding): SKILL records
+  `status: pending-architect-input` so the next session's
+  hook re-emits the marker.
+- **Registry validation failure** (settings file violates
+  `target_state_schema`): hook detects via load-time JSON
+  Schema; emits a special marker
+  `INVOKE: bootstrapping-repo / REASON: settings.yml
+  validation failed for <stage_id>`; SKILL guides the
+  architect to inspect / repair / re-elicit.
 
 ## Open design choices
 
@@ -1101,11 +1279,40 @@ Resolved (as discussion progresses, decisions move down to the
   partitioned status, runs lifecycle diff, emits marker; SKILL
   is the single executor for all stages. Resolved by § "Trigger
   model".
-- **Status storage is partitioned by locality** — four files
-  (`manifest.yml`, `state.yml`, `repo-state.yml`,
-  `clone-state.yml`), one per non-`external` locality;
-  `external` stages cache TTL'd validation in `repo-shared`'s
-  `state.yml`. Resolved by § "Declarative state schema".
+- **Status storage is partitioned by locality, unified under
+  the `settings.yml` family** — four files (`settings.yml`
+  per locality + `settings.local.yml` for `repo-clone`), one
+  per non-`external` locality; `external` stages cache TTL'd
+  validation in `repo-shared`'s settings file. Pre-v1 breaking
+  rename of v0.4.0 plumbing names (manifest.yml / state.yml /
+  config.yml / config.local.yml). Resolved by § "Declarative
+  state schema".
+- **Architect UX uses sequential per-stage flow with config
+  item protocol (decision: B)** — SKILL processes pending
+  agentic stages one at a time in topological order; no batch
+  wizard. Every architect-facing decision is mediated by an
+  agentic stage that satisfies the five-element config item
+  protocol (schema declaration / detection / interaction /
+  persistence / re-prompt trigger). Resolved by § "Architect
+  UX".
+- **Skip semantics are eliminated** — an empty / null / "no
+  presets selected" choice is itself a valid `target_state`
+  and produces `completed`. The 4-state lifecycle (never-run
+  / completed / stale / deprecated) covers all observable
+  architect states; no fifth "skipped" / "deferred" state is
+  introduced. Resolved by § "Architect UX" reframe.
+- **M10 (BoardAdapter selection) is in-scope** — new module
+  with stage `m10.repo.choose-kanban-backend` (agentic,
+  repo-git, single-choice for v0.5.0 enum
+  `[github-project-v2]`; future Linear / Jira options land via
+  registry-only enum extension). M3's GitHub-Project-specific
+  stages depend on `m10.repo.choose-kanban-backend`, so non-GH
+  backends will skip M3 cleanly when their stages land. Per
+  ADR-0005's BoardAdapter contract.
+- **M5 stage `m5.repo.set-wip-limit` is in-scope** — new
+  agentic stage prompting architect for per-repo WIP limit
+  (default 5; numeric-range 1-20). Persists into
+  `settings.local.yml:wip_limit` per repo-clone locality.
 - **Repo identity is `<owner>-<repo>` from `origin` URL** —
   with `_path-...` fallback for local-only repos. Resolved by
   § "Repo identity". Triggers I-13 invariant revision.
@@ -1247,5 +1454,31 @@ Resolved (as discussion progresses, decisions move down to the
    `m8.host.bootstrap-overrides-yml` becomes a first-run
    guided agentic stage with curated presets list (presets
    list itself defined in registry).
-10. This `-redesign.md` file removed; content lives in
+10. M5 WIP-limit stage added — `m5.repo.set-wip-limit`
+    becomes an agentic stage persisting into
+    `settings.local.yml:wip_limit` (default 5; numeric-range
+    1-20).
+11. M10 BoardAdapter-selection module + stage added —
+    `m10.repo.choose-kanban-backend` (agentic, repo-git);
+    M3 stages gain `depends_on:
+    [m10.repo.choose-kanban-backend]`. Future Linear / Jira
+    enum options land via registry-only edits.
+12. Settings.yml rename — v0.4.0 plumbing names
+    (`manifest.yml`, `state.yml`, `config.yml`,
+    `config.local.yml`, host-shared `overrides.yml`)
+    rename to the unified `settings.yml` family per
+    § "Declarative state schema" → "Four settings files".
+    Pre-v1 breaking change; architects delete legacy files
+    on upgrade.
+13. Architect UX section formalized — § "Architect UX"
+    encodes the sequential per-stage flow + the five-element
+    config item protocol that future plugin features must
+    honor when adding new architect-input items.
+14. Companion ADRs land in the same series (extends ADR-0012..0019
+    to also cover): (i) Architect UX + config item protocol
+    (the five-element contract); (j) settings.yml rename;
+    (k) M10 BoardAdapter selection module + M5 wip-limit
+    stage (these may be one or two ADRs depending on cohesion
+    judgement at write time).
+15. This `-redesign.md` file removed; content lives in
     `05-bootstrap-surface.md`.

--- a/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md
+++ b/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md
@@ -1,0 +1,1251 @@
+### 1.5 Bootstrap surface — redesign
+
+> **Status — design draft.** This file captures the in-progress
+> systematic redesign of the bootstrap mechanism. It is **not**
+> the source of truth yet. The currently-shipped contract still
+> lives in [`05-bootstrap-surface.md`](./05-bootstrap-surface.md).
+>
+> **Terminal state.** Once this draft is approved and the
+> companion ADR(s) are recorded, this file's content **replaces**
+> `05-bootstrap-surface.md`. The replacement happens in a single
+> PR that also fans out the spec change-impact matrix updates
+> listed in [`../AGENTS.md`](../AGENTS.md) § "Spec
+> change-impact matrix" (the row keyed on `05-bootstrap-surface.md`).
+> At that point this `-redesign` file is removed (or
+> `git mv`'d to `05-bootstrap-surface.md`, overwriting the old
+> body).
+>
+> **Read order.** Read this file in pair with the existing
+> `05-bootstrap-surface.md`. Where this draft contradicts the
+> existing surface, this draft expresses **future intent** and
+> the existing surface expresses **shipped behavior**. The gap
+> between the two is exactly the redesign work.
+
+---
+
+## Why a redesign
+
+Today's bootstrap mechanism (per
+[`05-bootstrap-surface.md`](./05-bootstrap-surface.md)) has
+four structural weaknesses that v0.4.0 makes acutely visible:
+
+1. **Implicit completion state** — "is bootstrapped" is
+   inferred from "file exists with valid `schema_version`".
+   No record of which sub-step ran, when, or under which
+   plugin version. Mid-bootstrap interruption recovers only
+   via each step's hand-rolled idempotency.
+2. **Bootstrap and migration are separate skills** — F-B1/F-B2
+   (first-time) and F-B3/F-B4 (version transition) are two
+   parallel families today; the deferred `migrating-repo-version`
+   skill duplicates the dispatch logic that bootstrap already
+   needs. The two collapse into one mechanism: "current state
+   vs target state diff, run the missing steps."
+3. **Automated and agentic execution are not separated** — the
+   `bootstrapping-repo` SKILL today runs ~11 steps in one
+   undifferentiated flow, including ~8 that need no architect
+   input. The skill is forced to mediate work that a
+   non-interactive script could finish before session start.
+4. **Cross-platform parity is ad-hoc** — Claude Code
+   auto-discovers `hooks/hooks.json`; Codex CLI requires the
+   architect to manually run `scripts/register-codex-hooks.sh`
+   per the README. The asymmetry is documented in prose, not
+   modeled as a stage in the bootstrap mechanism. Any new
+   capability that needs platform-specific registration repeats
+   the same out-of-band-instruction pattern.
+5. **Audit-log host-vs-repo bucket drift** — `credentials.yml`
+   today is host-shared (one DSN serves every repo on the
+   host); audit rows from multiple repos land in one DB. The
+   architect intent is per-repo isolation (each repo carries
+   its own audit credentials + DB), but the shipped contract
+   has not caught up. See § "Functional modules" M4 below
+   and the spec change-impact matrix entries it triggers.
+
+## Goals
+
+The redesign pursues four architect-stated goals:
+
+**G1 — hook-driven unified check script (bootstrap + migration
+collapsed into one mechanism).** Every session start runs a
+single `check` script. The script knows the target state for
+every stage at the current plugin version, compares against
+on-disk declared state, computes the diff, and triggers the
+missing or stale stages. The script is itself versioned and
+maintained across plugin releases — adding a new stage in a
+future plugin version causes existing bootstrapped repos to
+auto-detect and run the new stage on next session start. The
+deferred `migrating-repo-version` skill is **absorbed** into
+this mechanism (migration = current state vs target state
+diff). See § "Trigger model" below.
+
+**G2 — efficient execution along two orthogonal axes.**
+
+- **Axis A — execution character**: each stage is either
+  *automated* (deterministic, no architect attention required —
+  agent or script may execute, the architect is not interrupted)
+  or *agentic* (requires architect decision, input, confirmation,
+  or remote-side repair guidance — only an agent in a SKILL
+  flow can mediate). The boundary is "does this stage need the
+  architect's attention?" not "does this stage enter an agent
+  session?" — automated stages may pass through a SKILL flow
+  unobserved by the architect.
+- **Axis B — locality**: each stage's writes land in one of
+  five buckets — `host-shared` (entire host shares one copy),
+  `repo-shared` (per-repo host-local but cross-clone-shared
+  via GitHub identity), `repo-git` (committed into the repo's
+  git history), `repo-clone` (per-clone physical copy in repo
+  but git-ignored), or `external` (side-effect outside local
+  filesystem — GitHub state or external RDBMS — whose
+  completion cannot be inferred from local files alone). See
+  § "Axis B — Locality" for the full definitions.
+
+The 2D classification governs *where the stage's progress is
+recorded* and *who runs it*. See § "Stage taxonomy" below.
+
+**G3 — declarative state recording independent of repo path.**
+Bootstrap progress is recorded as explicit
+`{stage_id, status, completed_at, completed_by_version}`
+entries in declarative state files, not inferred from file
+existence. `status` is a 4-state enum (see § "Stage lifecycle
+states"). State files live under `~/.board-superpowers/`,
+keyed in a way that does not bind to the absolute on-disk path
+of the repo (the exact identity scheme is open — see
+§ "Repo identity"). A new architect session on the same
+(host, repo) pair sees a consistent snapshot regardless of
+where the repo is checked out.
+
+**G4 — cross-platform capability parity (Claude Code ↔ Codex
+CLI).** Every bootstrap stage that has a CC-side surface has
+a parity Codex-side surface, and the parity is modeled
+explicitly in the stage registry's `platforms` field — not
+delegated to README prose. Where a stage is intrinsically
+platform-specific (e.g., Codex hook registration via
+`register-codex-hooks.sh`, vs. CC's auto-discovery of
+`hooks/hooks.json`), the registry expresses that asymmetry as
+a `platforms: [codex]` constraint on the stage rather than
+silently shipping a CC-only flow. Dual-platform support is a
+first-class design constraint, not an afterthought.
+
+## The three axes
+
+A stage's complete identity is a 3-tuple `(module, character,
+locality)`. Each axis answers a distinct question about a
+stage; together they pin down where the stage's progress is
+recorded, who runs it, and what subsystem it configures.
+
+### Axis A — Execution character
+
+What kind of execution does this stage need?
+
+- **`automated`** — purely deterministic; runs without
+  architect input. Script-owned. Includes file writes,
+  idempotent CLI calls, atomic state updates, schema
+  migrations. Sub-flag `heavy` may apply (significant
+  network or IO cost — installer downloads, venv syncs)
+  which the trigger model treats differently from light
+  automated.
+- **`agentic`** — requires architect interaction at
+  execution time: decision (pick a DSN scheme), input
+  (enter a credential), confirmation (accept an optional
+  content block), or remote-side repair guidance (fix
+  Status field in GitHub UI). Routes through a SKILL
+  because only an agent can mediate the human-in-the-loop
+  turn. Sub-flag `confirm-only` distinguishes "agent must
+  confirm before proceeding" from "agent must elicit free
+  input."
+
+**Why two values, not three?** Earlier drafts considered an
+"automated-but-architect-confirms" middle tier; collapsed
+into `agentic + flag=confirm-only` because the routing path
+(skill required) is the same.
+
+### Axis B — Locality
+
+Where does this stage's outcome land? **Five values** —
+the locality axis distinguishes by both *which subject the
+outcome belongs to* (host vs repo) and *how the outcome is
+shared across machines / clones / architects*:
+
+- **`host-shared`** — written at the host root
+  (`~/.board-superpowers/<files>` or `~/.codex/config.toml`);
+  one copy per host, **shared across every repo** on this
+  host. Examples: plugin's host manifest, host-wide tool
+  installation (uv binary), Codex hook registration in
+  Codex's own config.
+- **`repo-shared`** (per-repo, host-local, **cross-clone
+  shared**) — written under
+  `~/.board-superpowers/repos/<repo-identity>/`; one copy
+  per `(host, GitHub repo)` pair, **shared across every
+  local clone** of the same GitHub repo on this host.
+  Examples: `state.yml`, per-repo `credentials.yml`, audit
+  `jsonl` + `sqlite` DB. (See § "Repo identity" for the
+  identity scheme — `<repo-identity>` is `<owner>-<repo>`
+  derived from the GitHub remote URL.)
+- **`repo-git`** (per-repo, **git-tracked**) — written
+  under `<repo>/.board-superpowers/<file>` and
+  **committed to the repo's git history**; shared with
+  every collaborator of that repo via git. Examples:
+  `config.yml`, `pyproject.toml`, `uv.lock`, routing
+  blocks injected into `AGENTS.md` / `CLAUDE.md`,
+  `.gitignore` append entries.
+- **`repo-clone`** (per-repo, **per-clone physical
+  copy**) — written under `<repo>/.board-superpowers/<file>`
+  but **git-ignored**; each clone of the same repo on the
+  same host has its own physical copy. Examples:
+  `config.local.yml` (per-architect override), `.venv/`
+  (per-clone Python venv).
+- **`external`** (side-effect outside the local
+  filesystem) — outcome lives in GitHub state (labels,
+  Project field schema) or external RDBMS (audit DDL,
+  audit row inserts). Completion **cannot be inferred
+  from local files alone** — the stage's
+  `target_state_predicate` performs an external query.
+  External-locality stages typically cache their last
+  validation timestamp + outcome hash in `repo-shared`
+  state to avoid hammering the external system every
+  hook tick (TTL-based re-validation).
+
+**Why the cross-clone vs per-clone split matters.** Two
+clones of the same repo at `~/Dev/repos/foo` and
+`~/Sandbox/foo` on the same host: their `repo-shared`
+files (state.yml, credentials.yml) are the **same physical
+file** (one source of truth); their `repo-clone` files
+(config.local.yml, .venv/) are **independent copies**.
+This matches the architect's intent that bootstrap progress
++ audit credentials follow the GitHub repo identity, while
+per-clone tooling state (which the architect may diverge
+between clones for testing) follows physical path.
+
+### Axis C — Functional module
+
+Which subsystem does this stage configure? Nine values
+(M1..M9):
+
+- **`M1` — plugin-runtime infra.** The plugin's own
+  bookkeeping state files and directory skeleton
+  (`manifest.yml`, `state.yml`, host state dir). The
+  "plumbing" the plugin needs to record its own progress.
+  Without M1 stages no other module can record completion.
+- **`M2` — Python runtime.** The execution environment
+  for the plugin's own Python dependencies (`uv` tool
+  host-side + per-repo venv with `pyproject.toml` /
+  `uv.lock` / `.venv/`). Cross-locality: M2 stages span
+  `host-shared` (uv binary), `repo-git`
+  (`pyproject.toml` + `uv.lock`), and `repo-clone`
+  (`.venv/`).
+- **`M3` — GitHub Project integration.** The
+  BoardAdapter's contract with the GitHub Project (13
+  standard Issue labels, 6-option Status field schema).
+  All M3 stages have `external` locality. (BoardAdapter
+  is the abstraction that makes future Linear / Jira
+  adapters possible per ADR-0005.)
+- **`M4` — Audit logging.** BYO RDBMS / SQLite audit-log
+  subsystem (per-repo credentials + schema + flush +
+  health reporting). **All M4 stages are per-repo** —
+  each repo carries its own audit credentials + DB. The
+  shipped v0.4.0 contract has `credentials.yml`
+  host-shared; this redesign moves it to per-repo to
+  match architect intent and resolve the cross-repo
+  audit pollution surfaced in #43.
+- **`M5` — Repo configuration.** The plugin's user-facing
+  knobs (`config.yml` git-shared defaults +
+  `config.local.yml` per-architect overrides). The only
+  module today with both git-shared and host-local
+  stages.
+- **`M6` — Gitignore hygiene.** Prevent plugin files
+  from polluting git (protect `*.local.*`, `claims/`,
+  `.venv/`). Single git-shared stage; idempotent append.
+- **`M7` — Agent routing.** Inject the plugin's
+  skill-routing metadata into the user's `AGENTS.md` +
+  `CLAUDE.md` so the agent (CC / Codex) knows the plugin
+  is active. **Per-block multi-stage architecture** (per
+  architect direction):
+  - `m7.repo.detect-agentsmd-form` is a prerequisite stage
+    that detects which routing-target file(s) exist
+    (`cc-only` = only CLAUDE.md; `codex-only` = only
+    AGENTS.md; `dual` = both; `neither` = no target file).
+    The detected `form` is cached in repo-shared
+    `state.yml` and propagated through the `target_state`
+    of every downstream `m7.repo.inject-block.*` stage,
+    so any later change to the repo's file structure (user
+    adds AGENTS.md to a previously CC-only repo, etc.)
+    flips every M7 inject stage to `stale` and triggers
+    a full re-injection.
+  - Each routing block (`routing-rule`, `skill-routing`,
+    plus future blocks) is a separate stage with shape
+    `m7.repo.inject-block.<name>`. Each block has a
+    `kind: required | optional` flag — required blocks
+    are auto-injected by script; optional blocks
+    (recommended-but-not-load-bearing prompt hints that
+    improve agent effectiveness) are injected only after
+    the agent surfaces them and the architect explicitly
+    accepts. Per-block marker pair, content hash, and
+    version make M7 stages re-evaluate independently when
+    the plugin upgrades.
+  - "User has modified the block" detection operates
+    per-block via marker-pair content hash, not on the
+    file as a whole.
+  - **Codex `project_doc_max_bytes` constraint**: Codex
+    CLI reads AGENTS.md (and walks root-to-cwd
+    concatenating multiple AGENTS.md files) up to
+    32 KiB total before truncating
+    (PLUGIN_DEVELOPMENT.md § "Codex AGENTS.md lookup").
+    M7 must honor this hard limit:
+    - **single-block size cap**: ≤ 4 KiB per block
+    - **plugin total budget on AGENTS.md**: ≤ 8 KiB across
+      all M7 blocks plus all sub-directory AGENTS.md
+      contributions (leaves ≥ 24 KiB headroom for
+      architect content)
+    - The `m7.repo.detect-agentsmd-form` stage measures
+      total AGENTS.md size after concat-walk and refuses
+      to inject if it would push total over budget — it
+      surfaces a warning marker for architect attention
+      instead.
+  - **Optional-block list is currently empty in
+    v0.4.0+redesign** but the SKILL flow MUST contain a
+    `for each optional block in registry → prompt
+    architect` loop (a no-op when list is empty) so
+    future optional blocks can be added by registry edit
+    alone, with no SKILL code change.
+- **`M8` — Autonomy overrides.**
+  `~/.board-superpowers/overrides.yml` +
+  `config.local.yml:autonomy_overrides[]` (D-AUTONOMY-1
+  user / project-layer override of the autonomy class
+  matrix). **Currently outside bootstrap** — architect
+  hand-edits. Whether to add a guided agentic stage at
+  first-run is an open question (§ "Open design
+  choices").
+- **`M9` — Hook registration.** Platform-specific hook
+  event registration (Codex CLI:
+  `register-codex-hooks.sh`; Claude Code: auto-discover
+  via `hooks/hooks.json`). Codex-only stage in the
+  registry; brought into bootstrap per G4
+  (cross-platform parity) — see the `platforms` column
+  in the Stages table.
+
+## Stages
+
+The stages registry. Each row is a stage; the table is the
+machine-readable source of truth that the unified check
+script walks every session start. **Add a new stage = add a
+new row. Remove = set `deprecated_in_version`. Migrate = bump
+the stage's `target_state_hash_fn` so the lifecycle model
+(§ "Stage lifecycle states") flips affected entries to
+`stale`.** Column semantics live in § "Stage registry
+contract" below.
+
+| stage_id | stage_name | description | module | character | locality | platforms | flags | introduced_in | depends_on | executor |
+|----------|------------|-------------|--------|-----------|----------|-----------|-------|---------------|------------|----------|
+| `m1.host.create-state-dir` | host state dir | Create `~/.board-superpowers/` (mode 0700) + `__host__/` sentinel subdir | M1 | automated | host-shared | both | — | v0.1.0-minimum | — | `scripts/bootstrap-host.sh` |
+| `m1.host.write-manifest` | manifest.yml | Atomic write of host-level `manifest.yml` (`schema_version: 2`, `last_seen_version`, `uv_version`) | M1 | automated | host-shared | both | — | v0.1.0-minimum (schema 2 since v0.3.0) | `m1.host.create-state-dir` | `scripts/bootstrap-host.sh` |
+| `m1.repo.write-state-yml` | state.yml | Atomic write of per-repo `state.yml` (`schema_version: 1`, `stages_completed[]`, `routing_blocks[]`) | M1 | automated | repo-shared | both | — | v0.1.0-minimum | `m1.host.write-manifest` | `scripts/bootstrap-project.sh` |
+| `m2.host.install-uv` | uv installer | Detect / install `uv` Python tool host-wide via `astral.sh/uv/install.sh` or PATH probe | M2 | automated | host-shared | both | `heavy`, `network-required` | v0.3.0 | — | `scripts/bootstrap-host.sh` |
+| `m2.repo.copy-uv-templates` | uv templates | Copy plugin's `pyproject.toml` + `uv.lock` from `<plugin>/scripts/templates/` into `<repo>/.board-superpowers/` | M2 | automated | repo-git | both | — | v0.3.0 | `m1.repo.write-state-yml` | `scripts/bootstrap-project.sh` |
+| `m2.repo.sync-venv` | venv sync | Run `uv sync` to materialize `<repo>/.board-superpowers/.venv/` from the copied lock | M2 | automated | repo-clone | both | `heavy` | v0.3.0 | `m2.host.install-uv`, `m2.repo.copy-uv-templates` | `scripts/bootstrap-project.sh` |
+| `m3.repo.ensure-labels` | standard labels | Ensure 13 standard GitHub Issue labels exist on the repo (idempotent via `gh` CLI) | M3 | automated | external | both | — | v0.1.0-minimum | — | `scripts/setup-labels.sh` |
+| `m3.repo.validate-status-field` | status field validation | Validate the GitHub Project's 6-option Status field schema; agentic only on failure (guide architect to GitHub UI) | M3 | agentic | external | both | `confirm-only`, `agentic-on-failure` | v0.1.0-minimum | — | `SKILL: bootstrapping-repo` (failure path) / `scripts/validate-status-field.sh` (read path) |
+| `m4.repo.acquire-dsn` | audit DSN | Acquire BYO RDBMS DSN; write per-repo `credentials.yml` (chmod 0600); first-time agentic, re-use automated | M4 | agentic | repo-shared | both | `confirm-only` (re-use path is automated) | v0.3.0 (host-shared); per-repo since vX.0.0 (this redesign) | `m1.repo.write-state-yml` | `SKILL: bootstrapping-repo` (first-time) / `scripts/bootstrap-project.sh` (re-use) |
+| `m4.repo.apply-audit-ddl` | audit DDL | Apply audit-log DDL to the resolved DB (3-dialect dispatch via `audit-init.sh`) | M4 | automated | external | both | — | v0.3.0 | `m4.repo.acquire-dsn` | `scripts/audit-init.sh` |
+| `m4.repo.flush-pending-audit` | audit flush | Replay `mode=bootstrap-pending` rows from jsonl into DB (idempotent via UNIQUE event_uuid) | M4 | automated | external | both | — | v0.3.0 | `m4.repo.apply-audit-ddl` | `scripts/audit-flush-pending.sh` |
+| `m4.repo.audit-health-check` | audit health | Print stderr summary of audit-row landing count vs jsonl pending count | M4 | automated | repo-shared | both | — | v0.3.0 | `m4.repo.flush-pending-audit` | `scripts/bootstrap-project.sh` |
+| `m5.repo.write-config-yml` | config.yml | Write `<repo>/.board-superpowers/config.yml` with project default knobs (committed to git) | M5 | automated | repo-git | both | — | v0.1.0-minimum | — | `scripts/bootstrap-project.sh` |
+| `m5.repo.write-config-local-yml` | config.local.yml | Write `<repo>/.board-superpowers/config.local.yml` with per-architect knobs (gitignored) | M5 | automated | repo-clone | both | — | v0.1.0-minimum | — | `scripts/bootstrap-project.sh` |
+| `m6.repo.append-gitignore` | gitignore entries | Append three protective entries (`*.local.*`, `claims/`, `.venv/`) to `<repo>/.gitignore` (idempotent) | M6 | automated | repo-git | both | — | v0.1.0-minimum | — | `scripts/bootstrap-project.sh` |
+| `m7.repo.detect-agentsmd-form` | agentsmd form | Detect repo's routing-target form (`cc-only` / `codex-only` / `dual` / `neither`) by scanning AGENTS.md + CLAUDE.md presence; cache result in repo-shared state | M7 | automated | repo-shared | both | — | vX.0.0 (this redesign) | `m1.repo.write-state-yml` | `scripts/bootstrap-project.sh` |
+| `m7.repo.inject-block.routing-rule` | routing-rule block | Inject `routing-rule` required block (skill-routing trigger) into target file(s) per detected form; check 4 KiB single-block size cap; honor 8 KiB total Codex AGENTS.md budget | M7 | automated | repo-git | both | `kind=required`, `block-size-capped` | v0.1.0-minimum (single-block); per-block stage since vX.0.0 (this redesign) | `m7.repo.detect-agentsmd-form` | `scripts/bootstrap-project.sh` |
+| `m7.repo.inject-block.skill-routing` | skill-routing block | Inject `skill-routing` required block (Manager / Consumer dispatch rules) into target file(s) per detected form | M7 | automated | repo-git | both | `kind=required`, `block-size-capped` | v0.1.0-minimum (single-block); per-block stage since vX.0.0 (this redesign) | `m7.repo.detect-agentsmd-form` | `scripts/bootstrap-project.sh` |
+| `m9.host.register-codex-hooks` | codex hook registration | Register `~/.codex/config.toml` `[hooks]` table to wire `SessionStart` to `hooks/session-start.sh` | M9 | automated | host-shared | codex-only | `platform-specific` | vX.0.0 (this redesign) | `m1.host.write-manifest` | `scripts/register-codex-hooks.sh` |
+| `m8.host.bootstrap-overrides-yml` | autonomy overrides | Prompt architect with curated autonomy-override presets; write `~/.board-superpowers/overrides.yml` (architect may select subset including "no presets, skip" → empty file + completed) | M8 | agentic | host-shared | both | `confirm-only` | vX.0.0 (this redesign) | `m1.host.write-manifest` | `SKILL: bootstrapping-repo` |
+
+**20 stages** — 14 v0.4.0 baseline (M7 v0.4.0 single-block
+stage replaced) + 6 net new / restructured this redesign
+(`m7.repo.detect-agentsmd-form`,
+`m7.repo.inject-block.routing-rule`,
+`m7.repo.inject-block.skill-routing`,
+`m9.host.register-codex-hooks`,
+`m8.host.bootstrap-overrides-yml`, plus the M4
+`acquire-dsn` re-locality). Future `kind=optional` blocks
+add agentic stages of shape
+`m7.repo.inject-block.<name>` without registry-shape
+changes. The 32 KiB Codex AGENTS.md budget caps total
+M7 routing block size — see § "Functional modules" M7.
+
+### Cross-axis sparsity is the value of the table form
+
+A single 3D matrix (5 localities × 2 characters × 9 modules =
+90 conceptual cells) is mostly empty. The table form lets you
+scan by row without manually computing the 3D index. Common
+queries the table answers at a glance:
+
+- *"What stages does M4 own?"* — filter `module=M4` → 4 rows.
+- *"What runs only on Codex?"* — filter `platforms=codex-only`
+  → 1 row (`m9.host.register-codex-hooks`).
+- *"What stages need network egress?"* — filter `flags`
+  contains `network-required` → 1 row
+  (`m2.host.install-uv`).
+- *"What's the dependency chain into `m4.repo.apply-audit-ddl`?"*
+  — read `depends_on` columns transitively.
+- *"What stages are agentic and therefore require entering
+  the `bootstrapping-repo` SKILL?"* — filter `character=agentic`
+  → 3 rows (`m3.repo.validate-status-field` failure path,
+  `m4.repo.acquire-dsn` first-time, `m8.host.bootstrap-overrides-yml`).
+  Future `kind=optional` M7 blocks add agentic rows.
+
+## Trigger model
+
+The trigger model is **hook-minimal with partitioned status
+storage**: the SessionStart hook never runs stages itself —
+it reads the partitioned status files (one per locality), runs
+the 4-state lifecycle diff against the registry, and emits a
+single `INVOKE: bootstrapping-repo` marker if any stage needs
+running. The `bootstrapping-repo` SKILL is the **single
+executor** for every stage (automated and agentic alike).
+
+### Why hook-minimal beats hook-runs-stages
+
+The earlier draft considered three options:
+
+- **α**: hook minimal (only diff + marker), SKILL runs all
+  stages.
+- **β**: hook runs all automated stages synchronously, SKILL
+  runs only agentic.
+- **γ**: hook runs "light automated" only, SKILL runs heavy
+  automated + agentic.
+
+β is rejected by CC's SessionStart synchronous-blocking
+constraint (uv install + venv sync can total 30-50s, well
+past the ≤5s soft limit). γ was the leading candidate but
+adds dual-track complexity (hook needs run + write + retry +
+concurrency logic; the runtime split between hook and SKILL
+fragments error handling).
+
+α wins after re-reading G2 carefully: G2 says automated
+stages should run *without architect attention*, not *without
+entering an agent session*. An agent autonomously dispatching
+`Bash` tool calls to executors inside the SKILL flow is
+"automated" by G2's intent — the architect doesn't decide,
+input, or wait between stages; they see a single "bootstrap
+running" surface and watch agent + scripts handle it. The
+SKILL is the single executor path; light vs heavy automated
+just differ in elapsed time, not in execution mechanism.
+
+### Hook flow (pseudocode)
+
+```bash
+#!/bin/bash
+# hooks/session-start.sh — α model with partitioned status
+set +e   # never block session
+
+PLUGIN_VERSION=$(read_plugin_json_version)
+REPO_IDENTITY=$(compute_repo_identity)  # <owner>-<repo> or fallback
+
+# Step 1: read four partitioned status files (each cheap, ~10ms each)
+HOST_STATUS=$(read_yaml ~/.board-superpowers/manifest.yml stages_completed)
+REPO_SHARED_STATUS=$(read_yaml ~/.board-superpowers/repos/${REPO_IDENTITY}/state.yml stages_completed)
+REPO_GIT_STATUS=$(read_yaml ${REPO_ROOT}/.board-superpowers/repo-state.yml stages_completed)
+REPO_CLONE_STATUS=$(read_yaml ${REPO_ROOT}/.board-superpowers/clone-state.yml stages_completed)
+
+# Step 2: compute lifecycle for every stage in the registry
+PENDING=()
+for stage in $(registry_iter); do
+  bucket=$(stage_locality "$stage")  # host-shared | repo-shared | repo-git | repo-clone | external
+  status_entry=$(lookup_in_bucket "$bucket" "$stage")
+  state=$(compute_lifecycle "$stage" "$status_entry" "$PLUGIN_VERSION")
+  case "$state" in
+    completed|deprecated) continue ;;
+    never-run|stale) PENDING+=("${stage}:${state}") ;;
+  esac
+done
+
+# Step 3: emit marker if any pending
+if [ ${#PENDING[@]} -gt 0 ]; then
+  echo "INVOKE: bootstrapping-repo"
+  echo "REASON: ${#PENDING[@]} stages need running (${PENDING[*]})"
+fi
+
+exit 0
+```
+
+Total hook time budget: **~200ms** (4 small YAML reads + 18
+hash comparisons + emit). Far below CC's ≤5s soft limit.
+
+### SKILL flow (when marker fires)
+
+The `bootstrapping-repo` SKILL is awakened only when the hook
+emits a marker (i.e., something needs running). Inside:
+
+1. **Re-read** the four partitioned status files (fresh
+   snapshot — another session might have updated since hook
+   ran).
+2. **Re-compute** the lifecycle diff (must match hook's diff
+   ± any concurrent updates).
+3. **Topologically sort** pending stages by `depends_on`.
+4. **Execute** stage by stage:
+   - `automated` stages: agent calls executor via `Bash`
+     tool (light = synchronous, heavy = with progress
+     surface). No architect interaction.
+   - `agentic` stages: agent surfaces decision / input /
+     confirmation request to the architect, waits for reply,
+     then executes.
+5. **Update status** atomically after each stage (write to
+   the appropriate partitioned status file; mktemp + mv +
+   read-merge-write for concurrency).
+6. **Surface summary** at end: "N stages completed; M
+   skipped; K still need attention."
+
+### Hook–SKILL contract
+
+The hook is **observation-only**: it reads, diffs, emits a
+marker. It never writes. It never executes a stage.
+
+The SKILL is **execution-only**: it never decides whether to
+run (the hook + lifecycle diff already decided). It runs the
+listed stages, records completion, and surfaces results.
+
+This split enables:
+- **Single-direction state flow**: hook reads → SKILL writes
+  → next hook reads. No interleaved hook/SKILL writes to fight.
+- **Hook idempotency by construction**: a hook that doesn't
+  write is trivially safe to re-run (multiple sessions, hook
+  retries, etc.).
+- **Error-handling concentration**: all "what went wrong" /
+  "how to recover" logic lives in the SKILL with full agent
+  context (not split between hook log + SKILL retry).
+
+### Failure modes
+
+| Failure | Hook behavior | SKILL behavior |
+|---------|---------------|----------------|
+| Status file missing / corrupt | Treat as `never-run` for affected stages; emit marker | First action is to (re-)create the file via `m1.host.write-manifest` / `m1.repo.write-state-yml` etc. |
+| Hook takes >2s (CC slow-hook warning) | Already cheap by design; if observed, partitioned files are too large or registry is too big — escalate to ADR | n/a |
+| Stage executor fails | n/a (hook doesn't run executors) | Log structured failure to status file (`status: failed`, `last_error`); leave entry in `never-run` / `stale`; next session re-attempts |
+| Agentic stage abandoned mid-flow | n/a | SKILL records `status: pending-architect-input`; lifecycle keeps surfacing via marker on next session |
+| Concurrent SKILL invocations (two sessions) | n/a | Per-status-file `flock` while updating; reread + merge before write |
+| External stage's TTL expired | Lifecycle returns `stale` for that stage; hook emits marker | Re-runs the stage's `target_state_predicate` (e.g., `gh api` to re-validate labels) and refreshes the cached hash |
+
+## Declarative state schema
+
+State is **partitioned by locality** — each of the four
+non-`external` Axis B values gets its own dedicated YAML
+status file. `external` stages cache their last-validation
+results inside `repo-shared`'s `state.yml` (no separate
+external status file).
+
+### Four status files (one per locality)
+
+| File | Locality | Cross-clone? | Tracked in git? | Stage entries |
+|------|----------|--------------|-----------------|---------------|
+| `~/.board-superpowers/manifest.yml` | `host-shared` | n/a (host-wide) | No | M1 host stages, M2 install-uv, M9 codex-hook |
+| `~/.board-superpowers/repos/<repo-identity>/state.yml` | `repo-shared` | **Yes (cross-clone shared)** | No | M1 state.yml stage itself, M4 audit stages, external-stage TTL caches |
+| `<repo>/.board-superpowers/repo-state.yml` | `repo-git` | No (per-clone-physical, sync via git) | **Yes (committed)** | M2 templates, M5 config.yml, M6 gitignore, M7 routing-block stages |
+| `<repo>/.board-superpowers/clone-state.yml` | `repo-clone` | No (per-clone-physical) | No (gitignored) | M2 venv, M5 config.local.yml |
+
+**Why partition?** A single monolithic state file would have
+to cross-cut localities (e.g., `<repo>/.board-superpowers/state.yml`
+holding stages whose outcomes live in `~/...` — confusing).
+Partitioning makes each file's *ownership* clear: this file
+records progress for stages whose outcomes land in this
+locality. The hook reads four small files in parallel; each
+file's update path is owned by stages of one locality.
+
+### Per-stage entry shape
+
+Each `stages_completed[]` entry has the same shape regardless
+of which file it lives in. The shape carries the
+**three-layer fingerprint** (generation + hash + structured
+target_state) plus identification + diagnostic fields:
+
+```yaml
+stages_completed:
+  - stage_id: m1.host.write-manifest
+    status: completed              # 4-state lifecycle enum (+ 2 transient)
+    completed_at: 2026-04-28T14:23:05Z
+    plugin_version: v0.5.0         # the version that ran it
+    generation: 3                  # K8s-style integer (registry-bumped)
+    target_state_hash: a1b2c3...   # derived from canonical(target_state)
+    target_state:                  # structured ground truth (per-stage shape)
+      manifest_path: ~/.board-superpowers/manifest.yml
+      schema_version: 2
+      fields_present: [last_seen_version, host_bootstrapped_at, uv_version]
+      mode: 0644
+    target_state_schema_version: 1 # schema of the target_state field itself
+    last_error: null               # populated on `failed` status
+  - stage_id: m4.repo.apply-audit-ddl
+    status: completed
+    completed_at: 2026-04-28T14:23:12Z
+    plugin_version: v0.5.0
+    generation: 7
+    target_state_hash: d4e5f6...
+    target_state:
+      audit_log:
+        schema_version: 2
+        columns_required: [event_id, event_uuid, action_id, ts, ...]
+        indexes_required: [idx_event_uuid_unique]
+      audit_outbox:
+        columns_required: [...]
+      audit_schema_meta:
+        columns_required: [version, applied_at]
+    target_state_schema_version: 1
+    last_error: null
+```
+
+| Field | Type | Required? | Semantics |
+|-------|------|-----------|-----------|
+| `stage_id` | string | yes | Lookup key (matches registry). |
+| `status` | enum `completed` \| `never-run` \| `stale` \| `deprecated` \| `failed` \| `pending-architect-input` | yes | The 4-state lifecycle plus two transient states (`failed`, `pending-architect-input`) the SKILL may write while a stage is mid-flow. The lifecycle model treats `failed` and `pending-architect-input` as effectively `never-run` (re-attempt next session). |
+| `completed_at` | ISO 8601 UTC | when status=completed | Wall-clock observability; never used for trigger logic. |
+| `plugin_version` | semver | when status=completed | The plugin version whose registry executed this stage. Used for the lifecycle's composite key. |
+| `generation` | non-negative int | when status=completed | Monotonic integer bumped by the registry when the stage's expected target changes (schema, executor, content template). Layer-1 of three-layer fingerprint (cheap fast-path). Always increases; never decreases (rollback unsupported). |
+| `target_state_hash` | hex string (sha256) | when status=completed | sha256 of canonical YAML emit of `target_state` (sorted keys, fixed indent, normalized newlines, hash-allowlist excluded). Layer-2 of three-layer fingerprint — catches "developer forgot to bump generation" cases. |
+| `target_state` | structured YAML (per-stage shape) | when status=completed | Layer-3 of three-layer fingerprint — full structured ground truth of what was done. SKILL diffs current registry's `target_state` against recorded for human-readable migration messages. |
+| `target_state_schema_version` | non-negative int | when status=completed | Schema version of the `target_state` field's *own shape*. Bumped when the stage author changes the structure of `target_state` itself (additive only, lazy-on-read). |
+| `last_error` | string | when status=failed | Short failure summary; pointer to log file for details. |
+
+### Hash-allowlist (fields excluded from hash)
+
+The `target_state_hash` is computed over canonical YAML
+emit of `target_state` *with the following fields excluded*
+(allowlist enforced by canonicalization helper in
+`stages_lib/<stage_id>.py`):
+
+- `last_validated_at` (timestamp; non-deterministic)
+- `last_run_id` (uuid; per-run unique)
+- Any field annotated `[hash-excluded]` in the stage's
+  registry entry
+
+Excluded fields still appear in the recorded `target_state`
+(for forensics) but don't affect hash equality. Architects
+adding a new excluded field MUST add it to the registry's
+hash-allowlist, or hash will become unstable across runs.
+
+### Schema versioning
+
+Each status file carries a top-level `schema_version: <int>`
+field. Per-file schema versioning lets each file evolve
+independently (e.g., `state.yml` schema bumps don't cascade
+to `manifest.yml`). Migration policy is **lazy-on-read +
+versioned-and-additive only**, per
+[`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+§ "Migration policy". A status file with a higher
+`schema_version` than the running plugin understands fails
+loudly (architect downgraded plugin — manual recovery).
+
+### Why schema_version is per-file AND per-stage-target
+
+Two different schemas evolve independently:
+
+- **File-level `schema_version`** (top of each status file)
+  — controls the shape of the file as a whole (the
+  `stages_completed[]` entry shape, top-level fields).
+  Bumped when the entry's universal fields change (e.g.,
+  if a future redesign adds `priority: <int>` to every
+  entry).
+- **Stage-target `target_state_schema_version`** (per-entry)
+  — controls the shape of *that stage's* `target_state`
+  blob. Each stage author bumps their own when they evolve
+  their target_state structure. Independent per stage.
+
+This separation prevents M4's DDL evolution from forcing a
+manifest.yml file-schema bump, and lets each stage author
+own their target shape's lifecycle.
+
+### External stage TTL cache (in repo-shared state.yml)
+
+External-locality stages (M3 labels, M3 Status field, M4
+DDL, M4 audit-flush) cache their last validation outcome in
+`repo-shared`'s `state.yml` to avoid hitting GitHub / DB on
+every session start. Entry shape extends with two extra
+fields:
+
+```yaml
+- stage_id: m3.repo.ensure-labels
+  status: completed
+  completed_at: 2026-04-28T14:23:08Z
+  plugin_version: v0.5.0
+  generation: 2
+  target_state_hash: 7e8f9a...
+  target_state:
+    labels_required:
+      - {name: "type:bug", color: "d73a4a"}
+      - {name: "type:feature", color: "0075ca"}
+      # ... 11 more
+    labels_present_check: gh-cli-v2-list
+  target_state_schema_version: 1
+  external_validated_at: 2026-04-28T14:23:08Z  # [hash-excluded]
+  external_ttl_seconds: 86400                  # [hash-excluded]
+```
+
+`external_validated_at` and `external_ttl_seconds` are in
+the hash-allowlist (excluded from hash). If
+`now > external_validated_at + external_ttl_seconds`, the
+lifecycle returns `stale` regardless of generation /
+hash match — forcing a fresh `gh api` call. TTL per stage
+is declared in the registry (default 86400 = 24h,
+overridable per-stage).
+
+## Repo identity
+
+Repo identity is **GitHub-based**: the host-local per-repo
+state directory is keyed by `<owner>-<repo>` derived from the
+repo's `origin` remote URL, not by the on-disk absolute path.
+
+### Identity scheme: `<owner>-<repo>` from origin URL
+
+```
+git remote get-url origin
+  → https://github.com/PanQiWei/board-superpowers.git
+  → git@github.com:PanQiWei/board-superpowers.git
+
+bsp_compute_repo_identity()
+  → strip scheme prefix and `.git` suffix
+  → extract <owner>/<repo> path component
+  → replace `/` with `-`
+  → "PanQiWei-board-superpowers"
+```
+
+Per-repo host-local state lives at:
+
+```
+~/.board-superpowers/repos/PanQiWei-board-superpowers/
+├── state.yml             ← bootstrap progress (repo-shared)
+├── credentials.yml       ← per-repo audit DSN (repo-shared)
+├── audit.db              ← optional per-repo SQLite (repo-shared)
+└── audit-local.jsonl     ← per-repo audit fallback (repo-shared)
+```
+
+### Edge cases
+
+- **Local-only repo (no `origin` remote)** — fallback to the
+  current path-based normalization (`bsp_normalize_repo_path`
+  on the absolute repo path). State for this repo lives at
+  `~/.board-superpowers/repos/_path-Users-foo-myproj/` with
+  the `_path-` prefix to distinguish from GitHub identities.
+  When the architect later adds an `origin` remote pointing
+  to GitHub, the `m1.host.migrate-repo-identity` stage (TBD)
+  detects the transition and migrates the state directory to
+  the new identity.
+- **HTTPS vs SSH URL form** — both
+  `https://github.com/A/B.git` and `git@github.com:A/B.git`
+  resolve to identity `A-B`. URL form is normalized away.
+- **Multi-remote repos** — `origin` is the canonical source.
+  If `origin` points to a non-GitHub host (e.g., GitLab),
+  identity is derived analogously (`<host>-<owner>-<repo>`)
+  but BoardAdapter behavior depends on the configured
+  adapter (per ADR-0005).
+- **Forks** — fork's `origin` typically points to the fork
+  (`<your-name>/<their-repo>`), so fork has its own identity
+  separate from upstream. State (audit DSN, bootstrap
+  progress) does not transfer between fork and upstream.
+- **Repo rename on GitHub** — origin URL no longer matches
+  identity. The `bsp-relocate-repo.sh <old> <new>` helper
+  atomically `mv`s the state directory; architect runs
+  it once after the rename. (Possible future enhancement: a
+  stage that detects the mismatch on session start and
+  prompts.)
+- **All worktrees share identity** — `git rev-parse
+  --git-common-dir` resolves any worktree to the primary
+  repo, which has the canonical `origin`. Worktrees of the
+  same primary repo share state, which is the correct
+  behavior for multi-card-multi-worktree workflows.
+
+### I-13 invariant revision (cross-clone state sharing)
+
+The current spec [`../07-cross-cutting-invariants.md`](../0002-product-features-and-flows/07-cross-cutting-invariants.md)
+§ "I-13" reads (paraphrased): "Each architect's clone of the
+same repo gets a SEPARATE state.yml because their clones have
+different absolute paths."
+
+This redesign **revises I-13**:
+
+> **I-13 (revised).** Each `(host, GitHub repo)` pair shares
+> a single host-local per-repo state directory at
+> `~/.board-superpowers/repos/<repo-identity>/`, regardless
+> of how many physical clones exist on the host. Per-clone
+> physical isolation is preserved only for `repo-clone`
+> locality stages (`.venv/`, `config.local.yml`).
+
+Implications:
+
+- Two clones at `~/Dev/foo` and `~/Sandbox/foo` on the same
+  host **share** their `state.yml`, `credentials.yml`, audit
+  DB. Changes from one clone are immediately visible to the
+  other.
+- Two architects on the same host who each clone the same
+  repo **share** their host-local per-repo state (audit
+  credentials, bootstrap progress). This is intentional —
+  the per-`(host, repo)` configuration should be one
+  authoritative copy. Per-architect divergence is preserved
+  via `repo-clone` locality (each architect's `config.local.yml`
+  is in their own clone path).
+- Worktrees behave correctly without special handling
+  (worktrees inherit primary repo's identity).
+
+The revision lands as **a new ADR** in
+[`../adr/`](../0002-product-features-and-flows/../adr/) +
+edits to `07-cross-cutting-invariants.md` § I-13 in the
+replacement PR.
+
+## Stage registry contract
+
+The Stages table above is the **rendered view** of an
+underlying registry. The registry is the single declaration
+of every stage; the table renders selected columns for
+human reading. Adding a stage means adding a registry entry;
+the table is regenerated (mechanically or by hand-edit
+discipline).
+
+### Storage: YAML metadata + Python helpers + JSON Schema validation
+
+Per industry pattern (Tekton CRDs, Helm Chart.yaml, npm
+package.json, Cargo.toml, Ansible playbooks all use
+declarative-markup + sibling source-files), the registry
+splits into two artifacts plus a validation schema:
+
+- **`scripts/stages-registry.yml`** — declarative metadata
+  for every stage (all `(table)` fields below + the
+  per-stage `target_state` schema definition). Single file;
+  bash hooks parse it directly via `pyyaml` (already in the
+  per-repo venv) without invoking Python helpers.
+- **`scripts/stages_lib/<stage_id>.py`** — one Python
+  module per stage; provides callables (`idempotency_check`,
+  `target_state_predicate`, `executor`,
+  `compute_target_state`). Naming convention:
+  `stages_lib/m4_repo_apply_audit_ddl.py` (stage_id with
+  `.` and `-` replaced by `_`).
+- **`scripts/stages-registry.schema.json`** — JSON Schema
+  for `stages-registry.yml`. Load-time validation
+  (CI-gated and runtime-gated): catches typos in
+  `module` / `locality` / `platforms` enums, missing
+  required fields, malformed `depends_on` entries, and
+  per-stage `target_state` shape divergence. Pattern is
+  identical to Tekton's OpenAPI-v3-in-CRDs and Helm's
+  `values.schema.json`.
+
+Decision rationale: bash hooks are the lowest-common-denominator
+consumer of stage metadata; YAML is the only format bash can
+parse cheaply (pyyaml + python3 wrapper). Python is the
+right home for callables that need typed function refs
+(predicates / hash-fns / executors). JSON Schema gates the
+gap. Pure-Python decorator registry (Dagster / Prefect
+pattern) is rejected because it would force bash hooks to
+shell out to Python just to enumerate stage IDs, breaking
+the hook-cheap invariant.
+
+### Column / field semantics
+
+Every stage in the registry has the following fields. Fields
+shown as columns in the Stages table are marked **(table)**;
+fields elaborated in supporting prose elsewhere are marked
+**(prose)**.
+
+| Field | Type | Required? | Semantics |
+|-------|------|-----------|-----------|
+| `stage_id` **(table)** | string, `<module>.<scope>.<verb>` | yes | Globally unique identifier. `<scope>` is `host` or `repo` (matching Axis B). The lookup key in status files' `stages_completed[]` entries. |
+| `stage_name` **(table)** | string, ≤30 chars | yes | Short human-readable display name; appears in CLI output and error messages. |
+| `description` **(table)** | string, one line | yes | Statement of *what the stage produces* — its work product, not its mechanics. (Mechanics belong in the executor's source code.) |
+| `module` **(table)** | enum M1..M9 | yes | Functional module ownership (Axis C). |
+| `character` **(table)** | enum `automated` \| `agentic` | yes | Execution character (Axis A). |
+| `locality` **(table)** | enum `host-shared` \| `repo-shared` \| `repo-git` \| `repo-clone` \| `external` | yes | Outcome's locality (Axis B). `repo-shared` = host-local but cross-clone-shared at `~/.board-superpowers/repos/<repo-identity>/`; `repo-clone` = git-ignored, per-clone physical copy at `<repo>/.board-superpowers/`. |
+| `platforms` **(table)** | enum `cc` \| `codex` \| `both` \| `cc-only` \| `codex-only` | yes | Cross-platform parity declaration (G4). `both` = identical behavior on both; `cc-only` / `codex-only` = intentionally platform-specific. |
+| `flags` **(table)** | string list | no | Free-form binary tags. Reserved tokens: `heavy` (network/IO heavy), `network-required`, `kind=required` / `kind=optional` (M7 only), `confirm-only`, `agentic-on-failure`, `platform-specific`, `block-size-capped` (M7 inject stages). |
+| `introduced_in_version` **(table)** | semver string | yes | Plugin version that first shipped this stage's *semantic work* (not when the registry-modeled stage_id concept was introduced). Used by the lifecycle model to detect cohort introduction. |
+| `deprecated_in_version` **(table)** | semver string | no | Plugin version where the stage was removed from the registry. When set, lifecycle state for any recorded entry flips to `deprecated`. |
+| `depends_on` **(table)** | list of stage_ids | no | Stages that must be `completed` before this one runs. Forms an explicit DAG; the trigger script topologically sorts. |
+| `executor` **(table)** | `scripts/<path>` \| `SKILL: <skill-name>` | yes | Where the stage's execution lives. Script paths are relative to plugin root; skill markers are emitted via `INVOKE: <skill-name>` to drive the agent path. |
+| `generation` **(prose, registry)** | non-negative int | yes | Monotonic integer; bumped by the registry maintainer whenever any aspect of the stage's expected target changes (schema, executor, content template). Layer-1 of the three-layer fingerprint (cheap fast-path; see § "Stage lifecycle states"). |
+| `target_state_schema` **(prose)** | JSON-Schema-style declaration | yes | Per-stage shape declaration for the structured `target_state` field that gets persisted to status files. Validated by `stages-registry.schema.json` at load-time. |
+| `target_state_schema_version` **(prose)** | non-negative int | yes | Schema version of the `target_state_schema` itself. Bumped when the stage author evolves the target_state shape (additive only). |
+| `compute_target_state` **(prose, callable)** | function ref returning structured data | yes | Returns the *current expected target state* (computed from the registry + repo context). Output validated against `target_state_schema`. Layer-3 (ground truth) of the three-layer fingerprint. |
+| `idempotency_check` **(prose, callable)** | function ref returning bool | yes | "Has this stage been run successfully?" — pure function from local state to bool. Cheap; runs every check. |
+| `target_state_predicate` **(prose, callable)** | function ref returning bool | yes | "Is the world in the state this stage targets?" — may include external queries (GitHub / DB) for `external`-locality stages. The seam where re-validation happens. |
+| `hash_excluded_fields` **(prose)** | list of dotted paths into target_state | no | Fields excluded from the canonical-YAML hash (e.g., `external_validated_at`, `last_run_id`). Allowlist enforced by canonicalization helper; see § "Per-stage entry shape" hash-allowlist. |
+| `external_ttl_seconds` **(prose, external stages only)** | non-negative int | external only | TTL for external-stage validation cache. Default 86400 (24h). |
+| `kind` **(table, M7 only)** | enum `required` \| `optional` | M7 only | M7 routing-block kind tag (per architect direction). Surfaced as `kind=required` / `kind=optional` in the table's `flags` column. |
+| `block_max_bytes` **(prose, M7 only)** | non-negative int | M7 only | Per-block size cap (default 4096 bytes). Honors Codex 32 KiB AGENTS.md budget — see § "Functional modules" M7. |
+
+### Canonicalization invariant for hash stability
+
+The hash is computed over canonical YAML emit of
+`compute_target_state()` output:
+
+1. Deep-sort all keys alphabetically.
+2. Use fixed indent (2 spaces) and fixed flow style (block).
+3. Normalize all line endings to `\n`; strip trailing
+   whitespace per line.
+4. Strip the `hash_excluded_fields` paths before hashing.
+5. sha256 the resulting string.
+
+The canonicalization helper lives in
+`scripts/stages_lib/_canonical.py` (shared by all stages).
+A stage's `compute_target_state()` must be deterministic
+given identical inputs — non-determinism (random keys, set
+iteration order, timestamps inside the structure) breaks
+hash stability and gets caught by CI.
+
+### What the lifecycle model asks of each stage
+
+The 4-state lifecycle reads the registry + per-stage status
+file entries to compute each stage's current state. Each
+stage MUST provide:
+
+- A `generation` int — bumped by the maintainer when the
+  expected target changes (the **declarative knob** that
+  drives the lifecycle).
+- A `target_state_schema` — declarative shape of the
+  stage's expected outcome.
+- A `compute_target_state()` callable — produces the
+  current expected target_state for diffing.
+- An `idempotency_check()` callable — used by the executor
+  to short-circuit "I just ran, no need to re-run."
+- A `target_state_predicate()` callable — used at re-run
+  time to confirm the outcome actually landed (especially
+  for `external`-locality stages where local files lie).
+
+These five together form the **stage's contract with the
+lifecycle model**. A stage that fakes any of them silently
+breaks the diff-and-replay mechanism. The
+`stages-registry.schema.json` validates the declarative
+fields; CI tests validate the callable contracts (each
+must round-trip a known input → output).
+
+## Stage lifecycle states
+
+Each stage's recorded state is one of four values, computed
+deterministically by the unified check script per session
+start. The model uses a **three-layer comparison stack**
+borrowed from Kubernetes' `metadata.generation` /
+`status.observedGeneration` pattern and Terraform's
+`serial` + structured state pattern (verified against
+industry practice — both systems pair structured state with
+a cheap monotonic primitive for fast-path diff):
+
+1. **`generation` integer** (cheap fast-path, O(1)
+   comparison) — incremented monotonically by the registry
+   when *any* aspect of the stage's expected target changes
+   (schema bump, executor change, content template change).
+   Hook compares `entry.generation == registry[stage_id].generation`
+   first; if equal, skip without further work.
+2. **`target_state_hash`** (medium fast-path; derived
+   automatically from `target_state` via canonical YAML
+   emit + sha256) — distinguishes accidental generation
+   non-bumps (developer forgot to bump) from genuine
+   identity. Hook computes current hash from canonical
+   target_state; compares against recorded
+   `entry.target_state_hash`.
+3. **`target_state`** (ground truth — full structured
+   data) — used by SKILL's structural diff to surface
+   "what specifically changed" for migration logic
+   derivation and architect-readable error messages. Not
+   read by hook (hook never goes deeper than hash).
+
+The `(stage_id, plugin_version, generation, target_state_hash)`
+quartet plus the `target_state` ground-truth determine which
+state applies — no fuzzy matching, no manual override.
+
+| State | Definition | Detection rule |
+|-------|------------|----------------|
+| **never-run** | This stage has never been recorded as completed on this `(host, repo)` pair. | No entry with this `stage_id` exists in the relevant status file. |
+| **completed** | Last recorded run succeeded **and** the recorded fingerprint matches the current plugin version's expectation. | Entry exists; `entry.generation == registry[stage_id].generation` (fast-path) AND `entry.target_state_hash == current_target_state_hash` (verify). Both equal → up-to-date; no re-run needed. |
+| **stale** | Last recorded run succeeded, but the current plugin version's expected target state has drifted (schema bump, content change, dep upgrade, executor change). | Entry exists; either `entry.generation != registry[stage_id].generation` OR (generation equal but) `entry.target_state_hash != current_target_state_hash`. SKILL re-runs the stage on next session start; structural diff between recorded `target_state` and current `target_state` is surfaced for diagnostics. |
+| **deprecated** | The stage existed in a prior plugin version but is no longer in the current registry. The recorded entry is preserved as history but no longer drives any execution. | `entry.stage_id ∉ current_registry`. The status file keeps the entry indefinitely (or until a manual prune); the check script ignores it for diff-computation purposes. |
+
+Plus two **transient SKILL-only states** (set by the SKILL
+mid-execution; treated as effectively `never-run` /
+`stale` by the lifecycle model on next session):
+
+- **`failed`** — stage executor returned non-zero; SKILL
+  records `last_error` for diagnostic. Re-attempted next
+  session.
+- **`pending-architect-input`** — agentic stage waiting for
+  architect to respond (e.g., DSN prompt unanswered, optional
+  block confirmation pending). Re-surfaced on next session.
+
+### Why three layers, not just hash
+
+A pure-hash model loses the diff-explainability that
+`structured target_state` provides. A pure-structured-diff
+model wastes hook cycles re-computing structural equality.
+The three-layer stack mirrors what production systems do:
+
+- **K8s `metadata.generation` vs `observedGeneration`** —
+  fast-path integer compare; structural deep-equal only on
+  mismatch.
+- **Terraform `serial` + JSON state** — same pattern
+  applied to IaC.
+- **Pulumi stack checkpoints** — same.
+- **Nix derivation hash** — pure-hash, but only because Nix
+  is immutable build (no need to diff "what changed in
+  production"). Bootstrap stages are stateful, so Nix's
+  model doesn't transfer.
+
+The hook stays cheap because layer 1 (generation int compare)
+absorbs most "stage hasn't changed" cases; layer 2 (hash)
+catches developer-forgot-to-bump bugs; layer 3 (structured
+diff) is invoked only by SKILL when re-running and is where
+architects see human-readable "what changed."
+
+### Schema-migration seam
+
+**Per-stage `target_state` evolution is the schema-migration
+seam.** When module M4 changes its DDL, M4's stage registry
+entries bump their `generation` AND get a new derived hash;
+M4's recorded entries flip to `stale`; SKILL structural-diffs
+the old vs new target_state ("audit_log table needs column
+`event_uuid`") and runs M4's stages re-runs which apply the
+new target_state. *Module-local schema migration* — no
+central migration runner needed (per architect direction;
+resolves the M10 question).
+
+**Canonicalization invariant**: hash is computed from a
+canonical YAML emit (sorted keys, fixed indentation,
+trailing newline normalized). Non-canonical YAML serialization
+is forbidden in the executor — see § "Stage registry
+contract" for the canonicalization contract. Fields excluded
+from hash (timestamps, last_run_id, schema_version itself)
+live in an explicit allowlist.
+
+## Cross-version evolution
+
+Cross-version evolution is mechanically implied by the 4-state
+lifecycle model above:
+
+- **Adding a new stage** in plugin version `N+1`: the new
+  stage_id is absent from `state.yml`'s entries → check script
+  reads it as `never-run` on next session start → triggers
+  execution. No explicit "upgrade" action required.
+- **Changing a stage's behavior** in plugin version `N+1`: the
+  stage's `target_state_hash_fn` returns a different value →
+  recorded entries flip to `stale` → check script re-runs.
+  This is the single mechanism for what F-B3/F-B4 used to
+  describe as "version transition."
+- **Removing a stage** in plugin version `N+1`: the stage_id
+  no longer appears in the current registry → recorded entries
+  flip to `deprecated` → no further execution. State file
+  preserves history; reverse-migration is not supported in
+  v1 (architect downgrade requires manual cleanup).
+- **Breaking changes** (e.g., a stage rename, a behavior
+  change that cannot be expressed as a hash bump alone) still
+  require a new ADR + deprecation window per existing
+  [`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+  § "Migration policy". The 4-state model handles
+  versioned-and-additive evolution; breaking changes are
+  out of band.
+
+The deferred `migrating-repo-version` skill is fully absorbed:
+"migration" is just "running the diff that the lifecycle model
+identifies." There is no separate migration code path.
+
+## Architect UX
+
+> *To be filled in.* What architect sees on first session
+> after upgrade; how agentic stages prompt for input; how
+> automated-stage failures are surfaced; how idempotent
+> re-run is invoked.
+
+## Open design choices
+
+Resolved (as discussion progresses, decisions move down to the
+"Decided" subsection below; this list narrows over time).
+
+### Still open
+
+- **Concurrency on `repo-shared` status writes** — the
+  redesign relies on per-status-file `flock` (per § "Trigger
+  model" failure-modes table); confirm `flock` semantics
+  (advisory vs mandatory) work identically on macOS / Linux
+  for both CC and Codex hooks. May require an explicit ADR
+  pinning the implementation choice (`flock(2)` vs
+  `fcntl(F_SETLK)` vs file-based atomic-rename lock).
+- **M7 optional-block content list** — protocol + 4 KiB /
+  8 KiB size caps decided. Concrete optional blocks: zero
+  in v0.4.0+redesign; each future optional block addition
+  is a registry edit, not a SKILL change. Open until first
+  optional block is proposed.
+- **External-stage TTL per-stage overrides** — default
+  86400 (24h) decided. Per-stage override mechanism still
+  open: registry field
+  (`external_ttl_seconds: 3600` per stage) vs runtime
+  override via `config.yml`. I lean registry-field-only
+  for simplicity; flagging for confirmation.
+- **Hash-allowlist enforcement at CI** — canonicalization
+  + hash-stability is critical (Agent 1 flagged
+  non-deterministic field ordering as well-known edge
+  case). Need a CI test that round-trips
+  `compute_target_state()` outputs and asserts hash
+  stability. Open: should the test live in
+  `tests/test-stages-canonical-hash.sh` (general) or
+  per-stage in `stages_lib/<id>_test.py`?
+
+### Decided (by this draft)
+
+- **Pre-v1 breaking changes are accepted** — board-superpowers
+  has not had a formal release yet; existing local state on
+  architect machines may be deleted on upgrade. This unlocks:
+  (a) M4 host-shared → per-repo `credentials.yml` migration
+  needs no copy-or-prompt logic — the architect deletes
+  `~/.board-superpowers/credentials.yml` + `~/.board-superpowers/repos/<old-id>/state.yml`
+  and re-bootstraps; (b) local-only repo → GitHub-origin
+  identity transition needs no auto-migration stage — the
+  architect deletes the `_path-<...>/` directory once and
+  the next session creates fresh state under `<owner>-<repo>/`.
+  Replacement plan items reflect this (no migration ADR
+  required for either).
+- **M8 (autonomy overrides) is in-scope** — adds one stage
+  (`m8.host.bootstrap-overrides-yml`, agentic + confirm-only,
+  host-shared) that prompts the architect with a small set of
+  curated autonomy-override presets at first run. Architect
+  may select any subset, including "no presets, skip" (writes
+  empty `overrides.yml` and marks completed). Plugin upgrade
+  with new presets bumps the stage's `target_state`, flipping
+  the entry to `stale` and re-prompting on next session.
+- **Trigger model is hook-minimal (α)** — hook reads
+  partitioned status, runs lifecycle diff, emits marker; SKILL
+  is the single executor for all stages. Resolved by § "Trigger
+  model".
+- **Status storage is partitioned by locality** — four files
+  (`manifest.yml`, `state.yml`, `repo-state.yml`,
+  `clone-state.yml`), one per non-`external` locality;
+  `external` stages cache TTL'd validation in `repo-shared`'s
+  `state.yml`. Resolved by § "Declarative state schema".
+- **Repo identity is `<owner>-<repo>` from `origin` URL** —
+  with `_path-...` fallback for local-only repos. Resolved by
+  § "Repo identity". Triggers I-13 invariant revision.
+- **Cross-clone state sharing (I-13 revised)** — same
+  `(host, GitHub repo)` pair, regardless of clone path,
+  shares one host-local state directory. Triggers ADR.
+- **Axis B is 5 values, not 4** — `host-shared`,
+  `repo-shared`, `repo-git`, `repo-clone`, `external`. The
+  cross-clone vs per-clone distinction inside per-repo is the
+  fifth value's reason. Resolved by § "Axis B — Locality".
+- **Single migration runner is rejected** (M10 candidate
+  removed) — each module owns its schema migration via its
+  stages' `compute_target_state()` + `target_state_hash`.
+  Resolved by § "Stage lifecycle states" + § "Cross-version
+  evolution".
+- **Stage lifecycle uses K8s-style three-layer fingerprint**
+  — `generation` integer (cheap fast-path, registry-bumped) +
+  derived `target_state_hash` (canonical YAML emit + sha256,
+  catches forgotten generation bumps) + structured
+  `target_state` (ground truth, fuels SKILL's structural diff
+  for human-readable migration messages). Verified against
+  K8s `metadata.generation` / Terraform `serial` / Pulumi
+  stack-checkpoint patterns. Pure-hash rejected (Nix-style,
+  doesn't transfer to stateful resources). Pure-structured
+  rejected (no fast-path).
+- **Stage registry storage is YAML metadata + Python helpers
+  + JSON Schema validation** — `scripts/stages-registry.yml`
+  for declarative metadata; `scripts/stages_lib/<stage_id>.py`
+  for callables; `scripts/stages-registry.schema.json` for
+  load-time validation. Verified against industry pattern
+  (Tekton CRDs, Helm Chart.yaml, npm package.json,
+  Cargo.toml). Pure-Python decorator registry rejected
+  because it would force bash hooks to shell out to Python
+  for stage enumeration, breaking hook-cheap invariant.
+- **M7 honors Codex 32 KiB AGENTS.md budget** — single
+  block ≤ 4 KiB; total M7 inject + sub-dir AGENTS.md
+  contributions ≤ 8 KiB on AGENTS.md (≥ 24 KiB headroom for
+  architect content). `m7.repo.detect-agentsmd-form` measures
+  total size after Codex's root-to-cwd concat-walk and
+  refuses to inject if budget would be exceeded.
+- **M7 architecture is per-block multi-stage with prerequisite
+  form-detect** — `m7.repo.detect-agentsmd-form` is a
+  prerequisite stage that caches the repo's routing-target
+  form (`cc-only` / `codex-only` / `dual` / `neither`) in
+  repo-shared `state.yml`; downstream
+  `m7.repo.inject-block.<name>` stages depend on it and
+  inherit `form` into their `target_state`, so any change
+  to the repo's routing-target file structure flips every
+  M7 inject stage to `stale` and triggers full re-injection.
+- **Per-repo audit DB defaults to zero-config SQLite** at
+  `~/.board-superpowers/repos/<repo-identity>/audit.db`. No
+  prompt at first bootstrap. Architects pick PG/MySQL by
+  editing per-repo `credentials.yml` post-bootstrap. First-run
+  bootstrap prints a one-line note pointing at the override
+  path. WAL mode default; spec already forbids audit.db inside
+  project tree (07-path-conventions.md).
+- **M9 (hook registration) is in-scope** — Codex-only stage
+  with `platforms: [codex]`. Resolved by G4.
+- **M4 audit module is per-repo, not host-shared** — including
+  `credentials.yml`. Triggers `0005-contracts/03-config-schemas.md`
+  + `07-path-conventions.md` updates in the replacement PR.
+- **M7 routing-block protocol is multi-block with required /
+  optional kinds** — required auto-injected, optional
+  agent-confirmed before injection. Per-block versioning +
+  hash + marker pair.
+- **Stage lifecycle is a 4-state model** (never-run /
+  completed / stale / deprecated). Three-layer fingerprint
+  comparison: `generation` int → `target_state_hash` →
+  `target_state` structural diff. Plus two transient states
+  (`failed`, `pending-architect-input`) the SKILL writes
+  mid-flow. See above "K8s-style three-layer fingerprint".
+- **M3 Status field validation uses TTL caching** in
+  `repo-shared`'s `state.yml`, not every-session re-check.
+  Default TTL 24h per § "Declarative state schema" external
+  cache.
+- **Heavy-automated has no special hook treatment** — α model
+  retired the γ "hook runs light, SKILL runs heavy" split;
+  `heavy` flag is now informational (UX progress surfacing)
+  rather than execution-routing.
+
+## Replacement plan (when this draft is approved)
+
+1. Companion ADRs recorded under
+   [`../adr/`](../adr/) — one each for: (a) unified check-script
+   trigger model (absorbing `migrating-repo-version`); (b)
+   declarative state schema + 4-state lifecycle + K8s-style
+   three-layer fingerprint (generation + hash + structured
+   target_state); (c) stage registry contract (YAML metadata +
+   Python helpers + JSON Schema validation); (d) M4 audit
+   per-repo locality (replaces host-shared `credentials.yml`
+   semantics — pre-v1 breaking change, no in-place migration
+   logic); (e) G4 cross-platform parity contract (modeling
+   platform-asymmetric stages explicitly via `platforms`
+   field); (f) I-13 invariant revision (cross-clone state
+   sharing via GitHub-based identity); (g) M7 multi-stage
+   per-block protocol with form-detect prerequisite + Codex
+   32 KiB AGENTS.md budget enforcement; (h) per-repo zero-config
+   SQLite as default audit backend. Decisions immutable once
+   accepted.
+2. Spec change-impact matrix in
+   [`../AGENTS.md`](../AGENTS.md) § "Spec change-impact
+   matrix" walked top-to-bottom — every row that cites
+   `05-bootstrap-surface.md` or `~/.board-superpowers/`
+   path layout updated in the same PR as the replacement.
+3. `0005-contracts/03-config-schemas.md` schemas bumped
+   (additive fields only) — adds `stages_completed[]` to
+   `state.yml` + `manifest.yml`; relocates `credentials.yml`
+   from host-shared to per-repo per M4 decision.
+   `07-path-conventions.md` updated for the new
+   `credentials.yml` location and (if changed) the repo
+   identity scheme.
+4. Skill catalog ([`../../SKILLS.md`](../../../SKILLS.md))
+   updated — `migrating-repo-version` removed (absorbed);
+   `bootstrapping-repo` description narrows to "agentic-only
+   stages + first-run guidance"; entries audited for any
+   stage that gains a `platforms: [codex]` constraint.
+5. Hook contract ([`../0005-contracts/02-hook-contracts.md`](../0005-contracts/02-hook-contracts.md))
+   updated with the unified check-script protocol — including
+   how the hook surfaces `never-run` / `stale` lifecycle states
+   (likely as `INVOKE: bootstrap-check / REASON:` markers, but
+   exact grammar follows trigger-model decision).
+6. Pre-v1 breaking-change procedure documented — release notes
+   instruct architects to delete
+   `~/.board-superpowers/credentials.yml` (host-shared) +
+   any `~/.board-superpowers/repos/_path-<...>/` directories
+   (path-based fallback) and re-run bootstrap. No in-place
+   migration logic ships.
+7. M7 routing-block tooling refactored — `bsp_inject_routing_block`
+   helper extended to per-block injection with `kind` flag;
+   `agentsmd-routing.md` template restructured into N labeled
+   blocks with required/optional metadata each. M7 stage list
+   expands per § "M7 routing-block protocol" (one stage per
+   block + one form-detect stage).
+8. M9 codex-hook stage added — `register-codex-hooks.sh`
+   becomes the executor for the M9 stage; the README's
+   manual-instruction section deletes (replaced by automatic
+   bootstrap behavior).
+9. M8 overrides-bootstrap stage added —
+   `m8.host.bootstrap-overrides-yml` becomes a first-run
+   guided agentic stage with curated presets list (presets
+   list itself defined in registry).
+10. This `-redesign.md` file removed; content lives in
+    `05-bootstrap-surface.md`.

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -10,8 +10,9 @@
 > 2. If your change makes a contract in any of
 >    [`../../PLUGIN_DEVELOPMENT.md`](../../PLUGIN_DEVELOPMENT.md),
 >    [`../../MULTI_AGENT_DEVELOPMENT.md`](../../MULTI_AGENT_DEVELOPMENT.md),
+>    [`../../SKILL_DEVELOPMENT.md`](../../SKILL_DEVELOPMENT.md),
 >    or
->    [`../../SKILL_DEVELOPMENT.md`](../../SKILL_DEVELOPMENT.md)
+>    [`../../SETUP_STAGES_DEVELOPMENT.md`](../../SETUP_STAGES_DEVELOPMENT.md)
 >    stale, fix the companion in the **same PR** — not a
 >    follow-up. Doc lag is the primary failure mode that makes
 >    this pattern decay over time.
@@ -62,6 +63,7 @@ preparation:
 | ADR-0007 plugin-runtime constraint set (C-PLUGIN-1/-2/-3) | Every Producer / Consumer feature with verbs like *monitor*, *detect*, *trigger automatically*. The preflight-piggyback idiom citation. |
 | ADR-0008 plugin-to-plugin SKILL invocation | `0005-contracts/04-skill-contracts.md` (sibling-skill classification table); `consuming-card` skill spec (F-C4 fallback rule). |
 | `0002-product-features-and-flows/05-bootstrap-surface.md` (state file path / schema) | `0003-domain-model/02-bounded-contexts.md` § 3.2.3; `0003-domain-model/03-aggregates-and-entities.md` § RepoBootstrap / HostBootstrap; `0005-contracts/03-config-schemas.md` + `07-path-conventions.md`; `bootstrapping-repo` + `migrating-repo-version` skill specs. |
+| `0002-product-features-and-flows/05-bootstrap-surface-redesign.md` (any section — three axes, stages registry, trigger model, lifecycle, settings layering, repo identity, architect UX) OR any of ADR-0012..ADR-0024 (the setup-stages ADR family) | **`../../SETUP_STAGES_DEVELOPMENT.md`** in the SAME PR — the navigation guide cites these sections as authority and goes stale on every edit. Plus: `../../scripts/stages-registry.yml` + `../../scripts/stages_lib/**` + `../../scripts/stages-registry.schema.json` (the runtime registry); `../../skills/bootstrapping-repo/SKILL.md` (the SKILL that consumes the registry); the four `settings.yml` templates if their layout changes; `../../SKILLS.md` if the SKILL's role description shifts. |
 | `0002-product-features-and-flows/08-pr-contract.md` (three-section shape) | `consuming-card` skill spec (F-C12); `enforcing-pr-contract` skill spec; `managing-board` Review Queue routine spec (F-02 violation flagging). |
 | Skill catalog (add / rename / split / merge any of the 10 v1 skills) | **`../../SKILLS.md` FIRST** (per its Source-of-truth contract — do not touch `../../skills/` until SKILLS.md is updated); then `0004-component-architecture.md` Decision 2 (capability → slot table); `0005-contracts/04-skill-contracts.md` (sibling-skill classification; v1 catalog table); the trigger row above; `../../README.md` and `../../README.zh-CN.md` if user-facing trigger phrases change. |
 | Hook intent-injection marker grammar (`INVOKE:` / `REASON:`) | `0004-component-architecture.md` § "Hook intent injection pattern"; `0005-contracts/02-hook-contracts.md` § "Intent-injection markers"; `using-board-superpowers` entry-skill spec. |
@@ -87,3 +89,7 @@ changes → re-read every `skills/*/SKILL.md` frontmatter").
   [`../../SKILL_DEVELOPMENT.md`](../../SKILL_DEVELOPMENT.md).
 - Skill catalog / call graph / topology →
   [`../../SKILLS.md`](../../SKILLS.md).
+- Setup-stages development (registry, 5-callable contract,
+  agentic config-item protocol, partitioned settings layering,
+  anti-patterns) →
+  [`../../SETUP_STAGES_DEVELOPMENT.md`](../../SETUP_STAGES_DEVELOPMENT.md).

--- a/docs/architecture/adr/0012-unified-check-script-trigger-model.md
+++ b/docs/architecture/adr/0012-unified-check-script-trigger-model.md
@@ -48,7 +48,7 @@ a stateless **check script** runs on every `SessionStart` hook,
 computes the diff between the current plugin's stage registry
 and the recorded per-stage status entries, and emits an
 `INVOKE: bootstrapping-repo` marker if any stage is `never-run`
-or `stale` (per the 4-state lifecycle defined in ADR-0013).
+or `stale` (per the 5-state lifecycle defined in ADR-0013).
 
 Concretely:
 
@@ -175,7 +175,7 @@ Invariants 1-3.
 
 ## Related
 
-- ADR-0013 — Declarative state schema + 4-state lifecycle +
+- ADR-0013 — Declarative state schema + 5-state lifecycle +
   K8s-style three-layer fingerprint (the lifecycle model this
   trigger consults).
 - ADR-0014 — Stage registry contract (the source of truth

--- a/docs/architecture/adr/0012-unified-check-script-trigger-model.md
+++ b/docs/architecture/adr/0012-unified-check-script-trigger-model.md
@@ -1,0 +1,194 @@
+# ADR 0012: Unified check-script trigger model (absorbs `migrating-repo-version`)
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+Today's bootstrap mechanism (per
+[`../0002-product-features-and-flows/05-bootstrap-surface.md`](../0002-product-features-and-flows/05-bootstrap-surface.md))
+splits "first-time bootstrap" and "version transition" into two
+parallel families that share most of their dispatch logic but
+no implementation:
+
+- **F-B1 / F-B2** (host bootstrap + per-repo bootstrap) ship today;
+  driven by the `bootstrapping-repo` SKILL.
+- **F-B3 / F-B4** (host version transition + per-repo version
+  transition) are designed in spec but **not implemented at
+  v0.4.0**; reserved for the deferred `migrating-repo-version`
+  SKILL.
+
+This split has three structural weaknesses surfaced by the
+v0.4.0 ship and the #43 bootstrap-audit-contract drift work:
+
+1. **Implicit completion state.** "Is bootstrapped" is inferred
+   from "file exists with a valid `schema_version`". No record of
+   which sub-step ran, when, or under which plugin version.
+   Mid-bootstrap interruption recovers only via each step's
+   hand-rolled idempotency check; cross-version drift detection
+   is impossible from local files.
+2. **Duplicate dispatch logic.** F-B3 / F-B4 (migration) need the
+   same "compute diff between current state and target state"
+   primitive that F-B1 / F-B2 (bootstrap) need — only with
+   different starting states (existing partial vs nothing). A
+   separate `migrating-repo-version` SKILL would re-implement
+   what `bootstrapping-repo` already needs internally.
+3. **Hook is observation-blind to version drift.** At v0.4.0
+   `hooks/session-start.sh` checks file *presence* only
+   (`manifest.yml` exists; `state.yml` exists). It does not
+   compare the recorded `last_seen_version` against the current
+   `plugin.json:version`. Architects upgrading the plugin rely
+   on out-of-band release notes or manual re-bootstrap.
+
+## Decision
+
+Bootstrap and migration are **unified** into a single mechanism:
+a stateless **check script** runs on every `SessionStart` hook,
+computes the diff between the current plugin's stage registry
+and the recorded per-stage status entries, and emits an
+`INVOKE: bootstrapping-repo` marker if any stage is `never-run`
+or `stale` (per the 4-state lifecycle defined in ADR-0013).
+
+Concretely:
+
+- The deferred `migrating-repo-version` SKILL is **absorbed
+  and removed from the v1 catalog**. Migration becomes "running
+  the diff that the lifecycle model identifies as `stale`."
+  There is no separate migration code path.
+- The hook is **observation-only**: reads partitioned status
+  files, runs the lifecycle diff, emits a marker if needed.
+  Never writes status. Never executes a stage.
+- The `bootstrapping-repo` SKILL is the **single executor** for
+  every stage that needs running — automated and agentic alike.
+- Status drift (architect upgraded plugin → some stages
+  `stale`) and first-time bootstrap (no entries → all stages
+  `never-run`) are handled by the **same code path**. The
+  lifecycle finds different state distributions but the dispatch
+  logic is one.
+
+The hook's pseudo-code is captured in
+[`05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+§ "Trigger model" → "Hook flow (pseudocode)".
+
+## Consequences
+
+### Positive
+
+- **Single mechanism, fewer moving parts.** No separate
+  `migrating-repo-version` SKILL to maintain. The
+  [`SKILLS.md`](../../SKILLS.md) catalog drops one entry.
+- **Hook permanently cheap.** ~200ms (four small YAML reads +
+  ~20 hash comparisons + emit). Comfortably under CC's ≤5s soft
+  limit and well within Codex's no-documented-timeout window.
+- **Plugin upgrades auto-detected.** Adding a new stage in
+  plugin v(N+1) → existing repos see `never-run` for that
+  `stage_id` on next session → triggered automatically. No
+  "what's new" architect prompt required; no manual
+  re-bootstrap.
+- **Schema migration auto-detected.** Changing a stage's
+  expected target (DDL bump, content template change) bumps the
+  registry's `generation` integer (per ADR-0013) → `stale` →
+  re-run. Schema migration is **module-local** (each module
+  owns its migration via its `compute_target_state()`),
+  removing the need for a central migration runner.
+- **Single-direction state flow.** Hook reads → SKILL writes →
+  next hook reads. No interleaved hook-and-SKILL writes to
+  fight; concurrency reduces to "multiple hooks reading + one
+  SKILL writing", which is trivial.
+
+### Negative
+
+- **Architect enters a SKILL session for every cohort change.**
+  Any new stage triggers SKILL entry, even when the stage is
+  fully automated (e.g., `m1.repo.write-state-yml` writing an
+  empty file). Mitigated by the SKILL flow running automated
+  stages without architect input — perceived cost is one
+  SKILL banner + a few seconds, not an interactive interruption.
+- **Hook depends on registry availability.** A corrupted or
+  absent `stages-registry.yml` makes the hook unable to compute
+  the diff. Hook still exits 0 (per Invariant 3) but emits no
+  marker, so the architect sees no progress until the registry
+  is repaired. Mitigation: load-time JSON Schema validation
+  (per ADR-0014) catches malformed registries at CI time, not
+  at hook time.
+- **Pre-v1 breaking change.** Switching to this model breaks
+  the file-presence-based detection that v0.4.0 ships with.
+  Per the design doc's "Pre-v1 breaking changes accepted"
+  Decided item, architects delete existing host-local state
+  (`~/.board-superpowers/credentials.yml` + any
+  `~/.board-superpowers/repos/*/state.yml`) on upgrade and
+  re-bootstrap. No in-place migration logic ships.
+
+## Alternatives considered
+
+### α — Hook runs nothing; SKILL handles everything (chosen)
+
+This ADR's decision. SKILL is the single executor.
+
+### β — Hook synchronously runs all automated stages; SKILL handles only agentic
+
+Rejected. CC's `SessionStart` is synchronous-blocking — the
+session UI does not start rendering until the hook exits.
+Heavy automated stages (`m2.host.install-uv` at 5-15s,
+`m2.repo.sync-venv` at 5-30s) would push hook execution past
+30-50s on a fresh-bootstrap session. Architects would
+experience "session frozen on startup" the first time they
+bootstrap a repo. The CC-documented ≤5s soft limit is
+conclusive against this option.
+
+### γ — Hook runs "light automated" stages synchronously; SKILL handles "heavy automated" + agentic
+
+Rejected after re-reading G2 carefully. G2's "automated stages
+should run without architect attention" was clarified to mean
+*without architect attention*, not *without entering an agent
+session*. Since SKILL-driven automated execution requires no
+architect attention (the agent invokes the executor via `Bash`
+tool autonomously), the additional complexity of dual-track
+execution (hook executes some stages, SKILL executes others)
+is not justified. The split would also fragment error handling
+between two surfaces.
+
+### δ — Keep `migrating-repo-version` as a standalone skill
+
+Rejected. The dispatch logic for "diff current state vs target
+state, run the missing or stale parts" is identical for
+first-time bootstrap and version transition. Maintaining two
+code paths for the same primitive is the exact tech debt this
+redesign exists to eliminate.
+
+## Notes
+
+The marker grammar emitted by the hook follows the
+`INVOKE: <skill> / REASON: <one-line>` convention from
+[`../0005-contracts/02-hook-contracts.md`](../0005-contracts/02-hook-contracts.md)
+§ "Intent-injection markers". The REASON wording is left to
+the implementer; the design doc shows a canonical form
+("`<N> stages need running (<list>)`"), but variations that
+remain inside the sanitization rules are permitted.
+
+The hook contract (always exit 0; never block session start;
+self-contained — must not source `scripts/lib/common.sh`)
+remains unchanged from
+[`../0005-contracts/02-hook-contracts.md`](../0005-contracts/02-hook-contracts.md)
+Invariants 1-3.
+
+## Related
+
+- ADR-0013 — Declarative state schema + 4-state lifecycle +
+  K8s-style three-layer fingerprint (the lifecycle model this
+  trigger consults).
+- ADR-0014 — Stage registry contract (the source of truth
+  this trigger reads).
+- ADR-0007 — Plugin-runtime-derived constraints; CC's
+  SessionStart synchronous-blocking is the C-PLUGIN constraint
+  that eliminates option β.
+- ADR-0011 — Defer Producer routines to v1.x; this ADR removes
+  `migrating-repo-version` from the deferred list (absorbed,
+  not deferred).
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc carrying the full context;
+  § "Trigger model" is this ADR's authoritative reference.
+- [`../0005-contracts/02-hook-contracts.md`](../0005-contracts/02-hook-contracts.md)
+  — Hook contract that constrains the check script's
+  observation-only / always-exit-0 invariants.

--- a/docs/architecture/adr/0013-declarative-state-schema-and-lifecycle.md
+++ b/docs/architecture/adr/0013-declarative-state-schema-and-lifecycle.md
@@ -1,0 +1,253 @@
+# ADR 0013: Declarative state schema + 4-state lifecycle + K8s-style three-layer fingerprint
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+Today's bootstrap mechanism (per
+[`../0002-product-features-and-flows/05-bootstrap-surface.md`](../0002-product-features-and-flows/05-bootstrap-surface.md))
+infers completion from file presence — "is bootstrapped" =
+"`manifest.yml` exists with valid `schema_version`". Per
+[`05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+§ "Why a redesign" item 1, this implicit-state model has three
+structural costs: no sub-step granularity (interruption
+recovery relies on per-executor idempotency hacks), no
+cross-version drift detection (a plugin upgrade that changes a
+stage's expected target leaves the file present and the system
+thinks the repo is current), and no declarative migration seam
+(F-B3 / F-B4 version transition needs a "what changed between
+version N and N+1" primitive that file-presence cannot supply).
+
+ADR-0012 collapses bootstrap and migration into a single "diff
+current vs target, run the missing or stale parts" mechanism.
+That decision is only realizable if state is declarative —
+explicit `{stage_id, status, fingerprint, target_state}`
+entries — and if "current vs target" is cheap enough to run
+on every `SessionStart` hook (≤200ms budget per ADR-0012). Per
+design doc § "Goals" → G3 state must also be independent of
+repo on-disk path so a fresh clone of the same
+`(host, GitHub repo)` sees a consistent snapshot. ADR-0014
+records the registry contract that supplies the target state;
+this ADR records the *recorded state* shape and the lifecycle
+that compares the two.
+
+## Decision
+
+Bootstrap progress is recorded declaratively as per-stage
+entries in partitioned status files. Each entry carries a
+**three-layer fingerprint** — `generation` integer
+(fast-path) + derived `target_state_hash` (verification) +
+structured `target_state` (ground truth) — that the unified
+check script (ADR-0012) compares against the stage registry
+(ADR-0014) to compute one of four lifecycle states.
+
+The four states (per design doc § "Stage lifecycle states"):
+
+- **`never-run`** — no entry exists for this `stage_id`.
+- **`completed`** — entry exists; recorded `generation` and
+  `target_state_hash` both match the current registry.
+- **`stale`** — entry exists; `generation` differs (maintainer
+  bumped it) OR `target_state_hash` differs (semantics changed
+  without a bump). SKILL re-runs; structural diff between
+  recorded and current `target_state` surfaces diagnostics.
+- **`deprecated`** — recorded `stage_id` no longer appears in
+  the current registry. Entry preserved as history.
+
+Plus two **transient SKILL-only states** the SKILL writes
+mid-flow and the lifecycle treats as effectively `never-run`:
+`failed` (executor returned non-zero, `last_error` recorded)
+and `pending-architect-input` (agentic stage waiting for
+architect response).
+
+Per design doc § "Per-stage entry shape", each entry is:
+
+```yaml
+- stage_id: m4.repo.apply-audit-ddl
+  status: completed
+  completed_at: 2026-04-28T14:23:12Z
+  plugin_version: v0.5.0
+  generation: 7                    # Layer 1 — registry-bumped int
+  target_state_hash: d4e5f6...     # Layer 2 — sha256(canonical target_state)
+  target_state:                    # Layer 3 — structured ground truth
+    audit_log: { schema_version: 2, columns_required: [event_id, ...] }
+  target_state_schema_version: 1
+  last_error: null
+```
+
+The three layers map onto the check loop:
+
+1. **Layer 1 — `generation` int compare** (O(1)). Hook reads
+   `entry.generation == registry[stage_id].generation`; if
+   equal, skip without further work. Borrowed directly from
+   Kubernetes' `metadata.generation` /
+   `status.observedGeneration` pattern.
+2. **Layer 2 — `target_state_hash` compare** (O(YAML emit)).
+   Catches the failure mode where a maintainer changed
+   `target_state` semantics without bumping `generation`.
+3. **Layer 3 — structured `target_state` diff** (deep-equality,
+   O(state size)). Never read by the hook; invoked only by
+   the SKILL when re-running a `stale` stage to produce
+   human-readable migration diagnostics ("audit_log needs
+   column `event_uuid`").
+
+The hash is computed over a **canonical YAML emit** per design
+doc § "Canonicalization invariant for hash stability":
+deep-sorted keys; fixed 2-space block indent; `\n`-normalized
+line endings with trailing-whitespace strip; per-stage
+hash-allowlist paths stripped before hashing
+(`last_validated_at`, `last_run_id`, `external_validated_at`,
+`external_ttl_seconds`, any `[hash-excluded]` field); sha256
+the result. Excluded fields still appear in recorded
+`target_state` for forensics but do not contribute to identity.
+
+Schema migration is **module-local** (per design doc
+§ "Schema-migration seam" + § "Cross-version evolution"). When
+a module's `compute_target_state()` semantics change, the
+maintainer bumps that stage's `generation`; recorded entries
+flip to `stale`; the SKILL re-runs and uses Layer 3 diff for
+"what changed" messages. No central migration runner — each
+module owns its evolution through its registry entry plus its
+`stages_lib/<stage_id>.py` callables (per ADR-0014).
+
+## Consequences
+
+### Positive
+
+- **Sub-step granularity recovers cleanly from interruption.**
+  A mid-bootstrap crash leaves entries for stages that ran;
+  next session sees unfinished as `never-run`, finished as
+  `completed`. No per-executor idempotency hacks.
+- **Cross-version drift is automatically detected.** Plugin
+  upgrade bumps a stage's `generation` → recorded entry no
+  longer matches → flips to `stale` → SKILL re-runs.
+  ADR-0012's unified-trigger model relies entirely on this.
+- **Hook stays cheap.** Layer 1 absorbs the steady-state in
+  O(1); Layer 2 only runs on generation match; Layer 3 never
+  runs in the hook. The ≤200ms budget holds.
+- **Migration messages are architect-readable.** When a stage
+  goes `stale`, the SKILL has both old and new `target_state`
+  and produces a concrete diff, not "version mismatch, please
+  re-bootstrap." Layer 2 also backstops forgotten-generation-
+  bump bugs by catching content drift.
+- **Module-local migration eliminates a central runner.** Each
+  module's `compute_target_state()` IS the migration spec for
+  that module. No `migrations/` directory; no ordered registry.
+
+### Negative
+
+- **YAML verbosity.** Each entry carries three layers; stages
+  with large target states (M4 audit DDL: ~30 columns × 3
+  tables) run hundreds of YAML lines. Mitigated by
+  partitioning status files by locality (design doc § "Four
+  status files (one per locality)").
+- **Canonicalization discipline is non-negotiable.**
+  `compute_target_state()` MUST be deterministic — embedded
+  timestamps or set iteration order break hash stability and
+  produce false-`stale` on every session. CI must round-trip
+  each stage's output and assert hash stability (test
+  placement is tracked in design doc § "Open design choices").
+- **Hash-allowlist is a per-stage maintenance burden.** Adding
+  a non-deterministic field without registering it in
+  `hash_excluded_fields` silently breaks hash equality.
+  Mitigated by JSON Schema validation (per ADR-0014).
+- **`deprecated` entries accumulate without auto-prune.** v1
+  ships no auto-prune; status files grow over plugin lifetime.
+  A future `bsp-prune-deprecated.sh` helper can land if
+  accumulation becomes a problem.
+
+## Alternatives considered
+
+### α — Three-layer fingerprint stack (chosen)
+
+The decision recorded above. `generation` + derived hash +
+structured ground truth is the canonical pattern in production
+stateful-resource systems. Kubernetes' `metadata.generation`
+increments on each spec mutation; controllers compare against
+`status.observedGeneration` as a fast-path before structural
+reconciliation. Terraform's `serial` integer increments on
+each state mutation; the JSON state file carries the
+structured ground truth. Pulumi stack checkpoints follow the
+same pattern. board-superpowers borrows this shape directly,
+adding Layer 2 (hash) because K8s controllers re-reconcile on
+every tick (a forgotten bump self-corrects) but
+board-superpowers' hook does not — the hash backstop is
+required.
+
+### β — Pure-hash (Nix-style)
+
+Rejected. Nix derivations are pure-hash because Nix builds
+are immutable: a hash mismatch means "rebuild from scratch
+into a new store path," with no "what changed" to explain.
+That does not transfer to stateful resources. Bootstrap
+stages mutate a long-lived audit DB, `manifest.yml`, and
+routing-block injection; when a stage goes `stale` the
+architect needs to know *what specifically changed* so a delta
+migration ("add column `event_uuid`") is possible instead of a
+destructive replace. Pure-hash collapses every change into
+"hashes differ, re-run from scratch," losing the delta and the
+diagnostic. Hash's verification value is preserved as Layer 2,
+not as a replacement for structured ground truth.
+
+### γ — Pure-structured (no fast-path hash)
+
+Rejected. A pure-structured model forces the hook to
+deep-equal `compute_target_state()` against `entry.target_state`
+on every session for every stage. With ~14 stages and audit
+DDL target states running into hundreds of structured fields,
+that is ms-scale work per stage × every hook tick — wasted in
+the dominant steady-state case once a repo is bootstrapped.
+Layer 1's integer compare absorbs the steady-state in O(1);
+skipping the fast-path makes the hook do work it does not need
+to do. ADR-0012's ≤200ms budget might hold at v0.4.0 scale,
+but the design would not survive registry growth.
+
+### δ — Boolean "is bootstrapped" with timestamp (status quo at v0.4.0)
+
+Rejected. This is the model the redesign exists to replace. A
+single `bootstrapped_at: <timestamp>` cannot express sub-step
+granularity, cannot detect cross-version drift (the timestamp
+does not change when an expected target changes), and cannot
+drive ADR-0012's unified bootstrap-and-migration mechanism.
+Mid-bootstrap interruption is also unrecoverable: if the file
+exists the system assumes complete even when only half the
+stages ran. Per design doc § "Why a redesign" item 1, this is
+the structural weakness the redesign explicitly targets.
+
+## Notes
+
+**Ansible check-mode** is a fourth surveyed pattern that does
+not apply: Ansible diffs "current vs declared" at execution
+time but has no persistent state file between runs —
+check-mode re-derives current state from each target host on
+every invocation. board-superpowers needs persistent state
+because per-repo RDBMS schema and external GitHub state are
+too expensive to re-query on every hook tick. The two
+transient SKILL-only states (`failed`,
+`pending-architect-input`) are not part of the lifecycle's
+comparison logic; the hook treats them as effectively
+`never-run` and their purpose is operational diagnostics.
+
+## Related
+
+- ADR-0012 — Unified check-script trigger model; this ADR
+  supplies the lifecycle states that the trigger consults.
+- ADR-0014 — Stage registry contract; this ADR consumes the
+  registry's `generation`, `target_state_schema`,
+  `compute_target_state()`, and `hash_excluded_fields` fields.
+- [ADR-0007](./0007-plugin-runtime-derived-constraints.md) —
+  Plugin-runtime-derived constraints; the hook-cheapness
+  invariant (C-PLUGIN) drives the requirement that Layer 1
+  be O(1).
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Per-stage entry shape" +
+  § "Stage lifecycle states" +
+  § "Hash-allowlist (fields excluded from hash)" +
+  § "Why three layers, not just hash" +
+  § "Schema-migration seam" + § "Cross-version evolution"
+  are this ADR's authoritative references.
+- [`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+  — Config-schema migration policy (versioned-and-additive,
+  lazy-on-read) that per-stage `target_state_schema_version`
+  evolution inherits.

--- a/docs/architecture/adr/0013-declarative-state-schema-and-lifecycle.md
+++ b/docs/architecture/adr/0013-declarative-state-schema-and-lifecycle.md
@@ -1,4 +1,4 @@
-# ADR 0013: Declarative state schema + 4-state lifecycle + K8s-style three-layer fingerprint
+# ADR 0013: Declarative state schema + 5-state lifecycle + K8s-style three-layer fingerprint
 
 **Status:** proposed
 **Date:** 2026-04-28
@@ -41,11 +41,13 @@ entries in partitioned status files. Each entry carries a
 (fast-path) + derived `target_state_hash` (verification) +
 structured `target_state` (ground truth) — that the unified
 check script (ADR-0012) compares against the stage registry
-(ADR-0014) to compute one of four lifecycle states.
+(ADR-0014) to compute one of five lifecycle states.
 
-The four states (per design doc § "Stage lifecycle states"):
+The five states (per design doc § "Stage lifecycle states"):
 
-- **`never-run`** — no entry exists for this `stage_id`.
+- **`never-run`** — no entry exists for this `stage_id` AND
+  the stage's `applicable_when` predicate (per ADR-0020) is
+  true (or absent).
 - **`completed`** — entry exists; recorded `generation` and
   `target_state_hash` both match the current registry.
 - **`stale`** — entry exists; `generation` differs (maintainer
@@ -54,6 +56,12 @@ The four states (per design doc § "Stage lifecycle states"):
   recorded and current `target_state` surfaces diagnostics.
 - **`deprecated`** — recorded `stage_id` no longer appears in
   the current registry. Entry preserved as history.
+- **`not-applicable`** — the stage's `applicable_when`
+  predicate evaluates false against current settings (per
+  ADR-0020). Hook does not emit a marker; SKILL does not
+  execute. State flips back to `never-run` (no historical
+  entry) or `completed` (prior applicable-window entry exists)
+  when the predicate later evaluates true.
 
 Plus two **transient SKILL-only states** the SKILL writes
 mid-flow and the lifecycle treats as effectively `never-run`:

--- a/docs/architecture/adr/0014-stage-registry-contract.md
+++ b/docs/architecture/adr/0014-stage-registry-contract.md
@@ -221,7 +221,7 @@ schema gates the gap.
   through it.
 - ADR-0012 — unified check-script trigger model; hook consumes
   this registry every `SessionStart`.
-- ADR-0013 — 4-state lifecycle + three-layer fingerprint;
+- ADR-0013 — 5-state lifecycle + three-layer fingerprint;
   defines what the lifecycle asks, this ADR specifies how it
   is stored.
 - ADR-0015..ADR-0019 — companion bootstrap-redesign ADRs (audit

--- a/docs/architecture/adr/0014-stage-registry-contract.md
+++ b/docs/architecture/adr/0014-stage-registry-contract.md
@@ -56,8 +56,11 @@ each consumer reads only what it needs:
    `depends_on`, `executor`, `generation`, `target_state_schema`,
    `target_state_schema_version`, `hash_excluded_fields`,
    `external_ttl_seconds`, plus M7-only `kind` /
-   `block_max_bytes`). Bash hooks parse it with `pyyaml` (in the
-   per-repo venv) without invoking any stage module.
+   `block_max_bytes`, plus the conditional-applicability
+   `applicable_when` predicate and the architect-projection
+   `module_section_path` field per ADR-0020 / ADR-0021).
+   Bash hooks parse it with `pyyaml` (in the per-repo venv)
+   without invoking any stage module.
 2. **`scripts/stages_lib/<stage_id>.py`** — one Python module
    per stage with four typed callables: `executor`,
    `idempotency_check`, `target_state_predicate`,
@@ -106,6 +109,17 @@ lifecycle model asks of each stage"):
 - `target_state_predicate()` — confirms the outcome landed; on
   `external`-locality stages it performs the GitHub / RDBMS
   query feeding the lifecycle's layer-3 structural diff.
+
+Each stage MAY additionally provide (per ADR-0020 / ADR-0021):
+
+- An `applicable_when` predicate (declarative setting-path,
+  declarative board-capability, or Python escape hatch) —
+  conditional gate that resolves to `not-applicable` when
+  false. Cheap to evaluate (hook-side); never blocks for IO.
+- A `module_section_path` — overrides the default
+  `modules.<derived>` projection target if the stage's
+  `target_state` should be visible to architects under a
+  custom path in the settings file's modular layering.
 
 The schema validates declarative fields; CI round-trip-tests
 each callable to validate the dynamic contract.

--- a/docs/architecture/adr/0014-stage-registry-contract.md
+++ b/docs/architecture/adr/0014-stage-registry-contract.md
@@ -1,0 +1,220 @@
+# ADR 0014: Stage registry contract — YAML metadata + Python helpers + JSON Schema validation
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+The unified check-script trigger model (ADR-0012) walks a stage
+registry every `SessionStart` and emits an
+`INVOKE: bootstrapping-repo` marker for any stage the lifecycle
+model (ADR-0013) reports as `never-run` or `stale`. The registry
+is the single declaration of every bootstrap stage — its
+`(module, character, locality)` 3-tuple identity (per
+[`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+§ "The three axes"), dependencies, executor, and the five
+callables the lifecycle requires from each stage.
+
+Three constraints shape how it must be stored:
+
+1. **Multiple consumers, one source of truth.** Read by (a)
+   `hooks/session-start.sh` — bash that must stay cheap (~200ms
+   per ADR-0012 § "Positive"), (b) the `bootstrapping-repo`
+   SKILL — Python needing typed function references for
+   `idempotency_check`, `target_state_predicate`,
+   `compute_target_state`, `executor`, and (c) architects
+   auditing the Stages table without launching Python. No
+   single language owns discovery.
+2. **Hash stability across runtimes.** ADR-0013's layer-2
+   fingerprint is sha256 of canonical YAML emit of
+   `compute_target_state()` output. Python emits, bash hashes;
+   a format that lets them diverge silently breaks the
+   lifecycle.
+3. **Load-time validation.** Enum typos, missing `depends_on`
+   targets, malformed per-stage `target_state` shapes must fail
+   at CI time, not hook time, so a corrupt registry never
+   reaches a session start (per ADR-0012's hook-always-exits-0
+   invariant).
+
+These constraints place the registry in the
+**markup-as-contract** family — declarative YAML for the cheap
+consumer, sibling source files for typed callables, JSON Schema
+gating the seam.
+
+## Decision
+
+The stage registry is stored as **three artifacts**, split so
+each consumer reads only what it needs:
+
+1. **`scripts/stages-registry.yml`** — single declarative
+   metadata file carrying every `(table)` column plus the
+   `(prose, registry)` fields enumerated in design doc § "Column
+   / field semantics" (`stage_id`, `stage_name`, `description`,
+   `module`, `character`, `locality`, `platforms`, `flags`,
+   `introduced_in_version`, `deprecated_in_version`,
+   `depends_on`, `executor`, `generation`, `target_state_schema`,
+   `target_state_schema_version`, `hash_excluded_fields`,
+   `external_ttl_seconds`, plus M7-only `kind` /
+   `block_max_bytes`). Bash hooks parse it with `pyyaml` (in the
+   per-repo venv) without invoking any stage module.
+2. **`scripts/stages_lib/<stage_id>.py`** — one Python module
+   per stage with four typed callables: `executor`,
+   `idempotency_check`, `target_state_predicate`,
+   `compute_target_state`. Naming: stage_id with `.` and `-`
+   replaced by `_` (e.g., `m4_repo_apply_audit_ddl.py` for
+   `m4.repo.apply-audit-ddl`). Shared canonicalization helper:
+   `scripts/stages_lib/_canonical.py`.
+3. **`scripts/stages-registry.schema.json`** — JSON Schema
+   validating `stages-registry.yml` at load time. CI-gated
+   (every PR) and runtime-gated (SKILL re-validates before the
+   first executor invocation each session). Catches enum typos,
+   missing required fields, `depends_on` references to
+   nonexistent stage_ids, `target_state_schema` divergence.
+
+**Canonicalization invariant for hash stability.** Hashes
+into ADR-0013's layer-2 fingerprint come from canonical YAML
+emit of `compute_target_state()` output, computed in five
+steps (per design doc § "Canonicalization invariant for hash
+stability"):
+
+1. Deep-sort all keys alphabetically.
+2. Fixed indent (2 spaces), fixed flow style (block).
+3. Normalize line endings to `\n`; strip trailing whitespace.
+4. Strip `hash_excluded_fields` paths.
+5. sha256 the result.
+
+`scripts/stages_lib/_canonical.py` is the **single producer**;
+stages bypassing it (ad-hoc `yaml.dump`, hand-rolled templates)
+break hash stability silently and get caught by CI round-trip
+tests.
+
+**Five-callable contract.** Each stage MUST provide what the
+lifecycle model requires (ADR-0013 + design doc § "What the
+lifecycle model asks of each stage"):
+
+- A `generation` int — declared in YAML; bumped when *any*
+  aspect of the expected target changes (schema, executor,
+  content template). Layer-1 fast-path.
+- A `target_state_schema` — declarative JSON-Schema-style shape
+  embedded in the registry entry, validated at load time.
+- `compute_target_state()` — returns current expected
+  `target_state`; output validated against the schema and fed
+  to `_canonical.py` for the layer-2 hash.
+- `idempotency_check()` — pure function from local state to
+  bool; cheap; lets the executor short-circuit re-runs.
+- `target_state_predicate()` — confirms the outcome landed; on
+  `external`-locality stages it performs the GitHub / RDBMS
+  query feeding the lifecycle's layer-3 structural diff.
+
+The schema validates declarative fields; CI round-trip-tests
+each callable to validate the dynamic contract.
+
+## Consequences
+
+### Positive
+
+- **Hook stays cheap.** Bash reads YAML directly and never
+  imports a per-stage Python module; ADR-0012's hook-cheap
+  invariant is structurally preserved.
+- **Typed callables where they belong.** Python sees ordinary
+  functions with type hints — no reflection, no string-keyed
+  dispatch, no embedded shell-in-YAML; `mypy` and IDE
+  autocomplete work.
+- **Errors fail at CI, not session start.** Schema catches
+  malformed registries in PR review; combined with ADR-0012's
+  hook-always-exits-0, the architect sees a working marker or a
+  clear upstream CI failure — never a silent broken hook.
+- **Adding a stage is one PR with three matched edits.** YAML
+  row + `stages_lib/` module + occasional schema update; CI
+  gates the seams; per-stage boundary makes review natural.
+- **Registry is human-readable.** Architects see the same
+  fields they read in markdown.
+
+### Negative
+
+- **Three artifacts to keep aligned.** Discipline cost bounded
+  by the schema (gates two of three seams); only Python ↔ YAML
+  stage_id naming is CI-test-enforced.
+- **Two parsers must agree on canonical form.** Bash hashes
+  what Python emits; `_canonical.py` drift breaks layer-2
+  fingerprints. Mitigated by single-producer + CI round-trip.
+- **No decorator ergonomics.** Authors edit YAML and the paired
+  module separately rather than `@stage(...)` above a function.
+  Sacrificed to keep bash cheap.
+
+## Alternatives considered
+
+The chosen option (α — YAML + Python + JSON Schema) is in § Decision.
+
+### β — Pure-Python decorator registry (Dagster `@op`, Prefect `@flow`, Airflow `@dag`, Click commands)
+
+Rejected. Decorator-as-registry is correct when one Python
+runtime owns discovery — Dagster's job graph, Prefect's flow
+registry, Airflow's DAGbag, Click's command tree are all walked
+by a single process importing every module to find decorated
+callables. Bootstrap has multi-runtime consumers (bash hooks,
+Python executors, markdown-reading humans); forcing every
+consumer to shell out to Python for stage enumeration would
+push hook latency into seconds (Python startup alone ~50-150ms)
+and break ADR-0012's hook-cheap invariant. Right pattern, wrong
+niche.
+
+### γ — Embedded shell array (bash `declare -A` or `stages.sh` table)
+
+Rejected. Bash makes multi-line nested data structurally
+painful — `declare -A` is flat key-value; the workarounds
+(`IFS`-parsed records, here-docs populating parallel arrays)
+are well-known footguns. Per-stage `target_state_schema` is
+nested data bash cannot represent without inventing a
+serialization on top of bash. No IDE / autocomplete /
+type-check support. A malformed `stages.sh` at session start
+is exactly the failure mode this redesign exists to eliminate.
+
+### δ — Pure-YAML with executor inline as shell snippet
+
+Rejected. The five-callable contract needs
+`idempotency_check`, `target_state_predicate`,
+`compute_target_state`, `executor` as type-checked function
+references with structured I/O — they read configuration, query
+GitHub / RDBMS, emit structured `target_state` dicts. Embedding
+bash snippets in YAML inverts the seam: cheap consumer stays
+cheap, expensive consumer now shells out to evaluate snippets —
+the tradeoff that made β untenable, applied in reverse.
+
+## Notes
+
+The three-artifact pattern matches mature multi-consumer
+markup-as-contract registries: **Tekton CRDs** (OpenAPI v3 in
+the CRD; admission-time validation), **Helm `Chart.yaml` +
+`values.schema.json`**, **npm `package.json`**, **Cargo
+`Cargo.toml`**, **Poetry `pyproject.toml`** (each paired with
+sibling source files), **Ansible playbooks** with Python under
+`library/`. Each chose the same split for the same reason:
+cheap consumer reads markup, expensive consumer reads code,
+schema gates the gap.
+
+## Related
+
+- [ADR-0006](./0006-producer-autonomy-boundary.md) — registry's
+  `character` axis (`automated` / `agentic`) declares which
+  stages need agent mediation.
+- [ADR-0007](./0007-plugin-runtime-derived-constraints.md) — CC
+  `SessionStart` ≤5s soft limit is the C-PLUGIN constraint
+  driving bash-reads-YAML-only.
+- [ADR-0008](./0008-plugin-to-plugin-skill-invocation.md) —
+  SKILL invocation contract; `executor: SKILL: ...` routes
+  through it.
+- ADR-0012 — unified check-script trigger model; hook consumes
+  this registry every `SessionStart`.
+- ADR-0013 — 4-state lifecycle + three-layer fingerprint;
+  defines what the lifecycle asks, this ADR specifies how it
+  is stored.
+- ADR-0015..ADR-0019 — companion bootstrap-redesign ADRs (audit
+  per-repo locality, repo identity, M7 routing-block protocol,
+  M8 autonomy presets, M9 hook registration); each adds stages
+  this contract describes.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  § "Stage registry contract" — authoritative reference for
+  column semantics, canonicalization invariant, five-callable
+  contract.

--- a/docs/architecture/adr/0015-m4-audit-per-repo-locality.md
+++ b/docs/architecture/adr/0015-m4-audit-per-repo-locality.md
@@ -1,0 +1,180 @@
+# ADR 0015: M4 audit module per-repo locality (replaces host-shared credentials.yml)
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+The audit log persistence target was set by [ADR-0006](./0006-producer-autonomy-boundary.md) §5
+(BYO RDBMS) and extended by [ADR-0009](./0009-allow-sqlite-as-byo-audit-db.md)
+(SQLite as a 6th allowlisted scheme). Both ADRs treated the
+audit destination as **per-architect / per-host** infrastructure:
+the v0.3.0 implementation writes a single
+`~/.board-superpowers/credentials.yml` (mode `0600`) and every
+repo on the host resolves its DSN from that one file.
+
+The v0.4.0 ship and the #43 bootstrap-audit-contract drift
+work surfaced a structural consequence the original ADRs did
+not anticipate. One DSN per host means one audit DB per host:
+architects running board-superpowers across multiple repos on
+the same workstation have audit rows from every repo landing
+in the same database. The `project` column (per ADR-0006 §5
+schema) distinguishes them logically, but physical isolation
+is absent — credential rotation, DB corruption, backup, and
+debugging dumps are all-repos-or-nothing. Architect intent is
+per-repo isolation: each repo carries its own credentials, DB,
+and backend choice. The #43 evaluation classified this as a
+bug, not a quirk — drift between architect intent and shipped
+contract. The fix is contract-level: the locality of every M4
+stage needs to be per-repo, uniformly.
+
+The bootstrap-redesign design doc
+([`05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+§ "Why a redesign" item 5; § "Functional modules" M4;
+§ "Stages" table M4 rows; § "Decided" → "M4 audit module is
+per-repo, not host-shared") consolidates this. This ADR
+formalizes that decision.
+
+## Decision
+
+**Every M4 stage's locality is `repo-shared`** (per-repo,
+host-local, cross-clone-shared via GitHub identity), uniformly.
+The host-shared `credentials.yml` is **removed**; it is
+replaced by per-repo `credentials.yml` keyed by repo identity.
+
+Concretely: `credentials.yml` relocates from
+`~/.board-superpowers/credentials.yml` (host-shared) to
+`~/.board-superpowers/repos/<repo-identity>/credentials.yml`
+(per-repo, mode `0600`); repo identity is `<owner>-<repo>`
+resolved from the repo's `origin` URL (per the redesign's
+§ "Repo identity"). All four M4 stages —
+`m4.repo.acquire-dsn`, `m4.repo.apply-audit-ddl`,
+`m4.repo.flush-pending-audit`, `m4.repo.audit-health-check` —
+bind to per-repo identity: `acquire-dsn` writes the per-repo
+credentials file, the other three resolve the DSN from that
+path, and no M4 stage reads or writes any host-shared
+credential location. Each repo's audit log lives independently
+(separate DSN, separate DB or SQLite file at
+`~/.board-superpowers/repos/<repo-identity>/audit.db`,
+separate jsonl fallback at the same parent's
+`audit-local.jsonl`). Cross-repo isolation is guaranteed by
+construction.
+
+The behavioral forces preserved by ADR-0006 §5 + ADR-0009
+(BYO opt-in, R-class degradation when DB unavailable, no
+public destinations, no project-tree files, two-entry rule,
+friction-as-feature) are unchanged. Only the per-repo-vs-host
+bucket of `credentials.yml` and its downstream M4 stages
+changes.
+
+## Consequences
+
+**What this enables:**
+
+- **Cross-repo audit isolation by construction.** Credential
+  rotation, DB corruption, backup, debugging dump, backend
+  swap (SQLite → Postgres) — all scoped to one repo at a time.
+- **Per-repo backend choice.** One repo on Postgres, another
+  on the zero-config SQLite default. No host-level coupling.
+- **M4 siblings co-locate with M1's `state.yml`** under one
+  normalized-name parent at mode `0700` — matching ADR-0009's
+  path convention.
+
+**What this constrains:**
+
+- **`bootstrap-project.sh` step 2e (M4 `acquire-dsn`) writes
+  per-repo, not host.** Cross-repo DSN reuse becomes the
+  architect's explicit choice, not a default.
+- **No host-shared credential resolution path remains.** The
+  `auditing-actions` skill's DB-write helper resolves DSN
+  exclusively from per-repo `credentials.yml`. Any reference
+  to host-shared `credentials.yml` in shipped code is a bug.
+- **Spec contract updates land in the same replacement PR** —
+  [`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+  (credentials.yml relocation) and
+  [`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)
+  (per-repo path layout for the M4 sibling set).
+
+**Trade-off explicitly registered: pre-v1 breaking change.**
+
+Per the design doc's § "Decided" → "Pre-v1 breaking changes
+are accepted", **no in-place migration logic ships**.
+Architects upgrading from v0.4.0 (or any earlier version with
+host-shared `credentials.yml`):
+
+1. Delete `~/.board-superpowers/credentials.yml`.
+2. Re-bootstrap each repo. The unified check script (per
+   ADR-0012) sees `m4.repo.acquire-dsn` as `never-run` and
+   triggers the agentic prompt on next session start.
+
+Architect-machine state is small and easily recreated;
+migration code is complexity without value before v1 GA.
+
+## Alternatives considered
+
+**α — Per-repo `credentials.yml` + breaking-change procedure
+(chosen).** This ADR's decision. Cross-repo isolation by
+construction; no migration code; release notes carry the
+deletion procedure.
+
+**β — Keep host-shared `credentials.yml` + per-repo override
+file.** Rejected. The host-shared default leaves cross-repo
+pollution as the path of least resistance — most architects
+never write the override, and the #43 bug persists. Two-layer
+override also complicates `m4.repo.acquire-dsn`'s idempotency
+for no material safety gain.
+
+**γ — In-place migration script that copies the host-shared
+DSN into each known repo's per-repo `credentials.yml`.**
+Rejected. board-superpowers has not had a formal release;
+architect-machine state is small; the re-bootstrap path
+already exists. Shipping run-once-then-dead-weight migration
+code is the exact pre-v1-breaking-change rationale the design
+doc formalizes.
+
+**δ — Continue host-shared, document the cross-repo audit
+pollution as a known limitation.** Rejected. Conflicts with
+architect intent (per-repo isolation is the explicit goal)
+and with the #43 evaluation, which classified the drift as a
+real bug. Documenting a contract violation as a feature of
+the contract is a design code-smell — the contract is what's
+wrong, and the contract is what gets fixed.
+
+## Notes
+
+The audit-entry `project` column from ADR-0006 §5 schema
+remains useful — a single repo's audit DB still scopes rows
+by GitHub Project number (one repo can host multiple
+board-tracked projects); only the host-level disambiguation
+case it was previously load-bearing for goes away. This ADR
+does not change the audit DDL, write mechanism, two-entry
+rule, or any other ADR-0006 §5 + ADR-0009 decision — locality
+alone is the surface this ADR moves.
+
+## Related
+
+- [ADR-0006](./0006-producer-autonomy-boundary.md) §5 — audit
+  log persistence. This ADR refines §5's locality from
+  per-host to per-repo; the rest of §5 stands.
+- [ADR-0009](./0009-allow-sqlite-as-byo-audit-db.md) — SQLite
+  as a first-class scheme + `audit.db` default path under
+  `~/.board-superpowers/repos/<normalized>/`. ADR-0009
+  anticipated the per-repo parent for `audit.db` /
+  `audit-local.jsonl`; this ADR moves `credentials.yml` to it.
+- ADR-0012 — Unified check-script trigger model. The
+  breaking-change procedure relies on the lifecycle diff
+  seeing `m4.repo.acquire-dsn` as `never-run` after the
+  architect deletes host-shared state.
+- ADR-0013 — Declarative state schema + 4-state lifecycle. M4
+  stages' `target_state` carries per-repo identity into their
+  hash, making per-repo isolation observable from the diff.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Why a redesign" item 5 + § "Functional
+  modules" M4 + § "Stages" M4 rows + § "Decided" entries
+  ("M4 audit module is per-repo" + "Pre-v1 breaking changes
+  are accepted") are this ADR's authoritative references.
+- [`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+  + [`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)
+  — credentials.yml relocation + per-repo path layout land in
+  the replacement PR.

--- a/docs/architecture/adr/0015-m4-audit-per-repo-locality.md
+++ b/docs/architecture/adr/0015-m4-audit-per-repo-locality.md
@@ -166,7 +166,7 @@ alone is the surface this ADR moves.
   breaking-change procedure relies on the lifecycle diff
   seeing `m4.repo.acquire-dsn` as `never-run` after the
   architect deletes host-shared state.
-- ADR-0013 — Declarative state schema + 4-state lifecycle. M4
+- ADR-0013 — Declarative state schema + 5-state lifecycle. M4
   stages' `target_state` carries per-repo identity into their
   hash, making per-repo isolation observable from the diff.
 - [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)

--- a/docs/architecture/adr/0016-cross-platform-parity-contract.md
+++ b/docs/architecture/adr/0016-cross-platform-parity-contract.md
@@ -65,6 +65,33 @@ whose `platforms` does not match. A `codex-only` stage is
 invisible to a CC session's lifecycle diff; `never-run` /
 `stale` / `deprecated` never apply on the wrong platform.
 
+**Composition with `applicable_when`** (per ADR-0020):
+`platforms` is the **coarse special-case predicate** — a
+fixed enum of platform identities that the hook resolves
+purely from runtime context (no settings lookup). The
+generic `applicable_when` predicate (declarative
+setting-path / board-capability / Python escape hatch)
+runs *after* `platforms` filtering. Both must evaluate true
+for a stage to participate in the lifecycle. Concretely:
+
+1. Hook detects platform (`cc` vs `codex`).
+2. Hook drops stages whose `platforms` does not match
+   (these never appear in any lifecycle state on this
+   platform — not even `not-applicable`).
+3. For surviving stages, hook evaluates `applicable_when`
+   (if present). False → stage enters `not-applicable`
+   state per ADR-0020. True / absent → stage participates
+   normally (`never-run` / `completed` / `stale` /
+   `deprecated`).
+
+This split keeps `platforms` cheap and registry-static
+(no settings dependency for the platform decision) while
+letting `applicable_when` handle the data-driven
+conditionals (kanban backend, capability presence, etc.).
+Conflating the two would force the hook to load settings
+just to compute platform applicability, breaking the
+hook-cheap invariant.
+
 Concrete v0.4.0-redesign consequences:
 
 - **`m9.host.register-codex-hooks` is `platforms:

--- a/docs/architecture/adr/0016-cross-platform-parity-contract.md
+++ b/docs/architecture/adr/0016-cross-platform-parity-contract.md
@@ -1,0 +1,170 @@
+# ADR 0016: Cross-platform parity contract via the platforms field on every stage
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+board-superpowers is a dual-platform plugin — every shipped
+capability must run on both Claude Code and OpenAI Codex CLI.
+The runtimes converge on most contracts (`SessionStart`,
+`SKILL.md` body, project-instructions auto-load) but diverge
+in load-bearing places. Two divergences the bootstrap
+mechanism trips over today:
+
+- **Hook registration is asymmetric.** CC auto-discovers
+  `<plugin-root>/hooks/hooks.json` when the plugin loads —
+  no architect action. Codex has no plugin-level
+  auto-discovery; the architect must run
+  `scripts/register-codex-hooks.sh --install-user`
+  out-of-band per the README, which writes
+  `~/.codex/config.toml`'s `[hooks]` table.
+- **`${CLAUDE_PLUGIN_ROOT}` is CC-only.** Codex has no
+  equivalent env var; scripts derive their own paths via
+  `BASH_SOURCE` (abstracted in
+  `scripts/lib/common.sh:bsp_plugin_root()`). Logic
+  reaching for `${CLAUDE_PLUGIN_ROOT}` directly is
+  implicitly CC-only.
+
+The status quo documents the asymmetry in prose only
+(README, `PLUGIN_DEVELOPMENT.md`); neither divergence is
+modeled in any machine-readable artifact. This is the
+failure mode flagged by
+[`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+§ "Why a redesign" item 4 — *cross-platform parity is
+ad-hoc*. G4 of the redesign promotes parity to a
+first-class design constraint and demands it be modeled.
+Closely related:
+[ADR-0007](./0007-plugin-runtime-derived-constraints.md)
+already names this asymmetry as a C-PLUGIN constraint in
+prose; this ADR is the data-shape encoding.
+
+## Decision
+
+Every stage in the bootstrap stage registry MUST declare a
+`platforms` field. Legal values:
+
+- **`both`** — identical behavior on CC and Codex. Default
+  for platform-agnostic primitives (file writes, GitHub API
+  calls, DDL applies). Most v0.4.0-baseline stages.
+- **`cc-only`** — intentionally CC-only (primitive depends
+  on a CC-specific affordance, e.g., `${CLAUDE_PLUGIN_ROOT}`
+  reachable directly). Silently skipped on Codex.
+- **`codex-only`** — intentionally Codex-only (configures
+  something CC handles automatically, e.g., hook
+  registration). Silently skipped on CC.
+- **`cc`** / **`codex`** — variant spellings, functionally
+  identical to `cc-only` / `codex-only`. The schema accepts
+  both so authors pick what reads naturally.
+
+The unified check script (per
+[ADR-0012](./0012-unified-check-script-trigger-model.md))
+detects the running platform at startup and ignores stages
+whose `platforms` does not match. A `codex-only` stage is
+invisible to a CC session's lifecycle diff; `never-run` /
+`stale` / `deprecated` never apply on the wrong platform.
+
+Concrete v0.4.0-redesign consequences:
+
+- **`m9.host.register-codex-hooks` is `platforms:
+  codex-only`.** Runs `register-codex-hooks.sh
+  --install-user` semantics from inside the bootstrap flow;
+  what was a README-instructed manual step becomes an
+  automated stage on Codex. The README instruction deletes.
+- **Stages requiring `${CLAUDE_PLUGIN_ROOT}` directly
+  declare `cc-only`.** The Codex equivalent uses
+  `bsp_plugin_root()` self-derivation; v0.4.0-redesign
+  avoids introducing such stages but `cc-only` is reserved
+  for genuine future asymmetries.
+- **Validation is load-time.** The registry's JSON Schema
+  (per [ADR-0014](./0014-stage-registry-contract.md)) marks
+  `platforms` required and enumerates the five legal
+  values; missing or misspelled declarations fail CI before
+  any hook reads the registry.
+
+## Consequences
+
+**Positive.** Platform asymmetry is first-class — every
+reader of the registry sees the constraint alongside
+`module` / `character` / `locality`; PR review has a
+closed-form question for any new stage. README ceases to
+be a load-bearing instruction surface — the m9 stage
+automates what was prose. CI catches divergence at the
+schema gate; no silent-CC-only regressions. The trigger
+model is dead-simple — filter by running platform at
+startup, no conditional branches inside executors.
+
+**Negative.** One more required field on every stage —
+most repeat `platforms: both`, which feels like ceremony.
+Justified because no stage is added without the author
+considering the platform question, even for "obviously
+both" stages whose primitive may rely on a CC-only
+affordance. The trigger model needs a reliable
+platform-detection primitive at startup —
+`${CLAUDE_PLUGIN_ROOT}` presence is the signal,
+`bsp_plugin_root()` abstracts it; a future CC env-var
+contract change is patched in the same PR.
+
+## Alternatives considered
+
+**α — Explicit `platforms` field on every stage (chosen).**
+Every stage declares; load-time schema validates; trigger
+model filters.
+
+**β — Implicit "all stages run on both unless special",
+flag platform-specific via the `flags` list.** Rejected.
+`flags` is free-form binary tags — easy to forget to set,
+easy to typo; the absence of a flag means "behaves on
+both" silently rather than "the author considered the
+question and concluded both." Silent platform divergence
+is the failure mode this ADR exists to eliminate; an
+opt-in flag scheme reproduces it.
+
+**γ — Two parallel stage registries (one per platform).**
+Rejected. Most stages run identically on both; duplicating
+forces two sources of truth in sync for every common stage
+with no benefit the α schema gate does not provide, and
+complicates the lifecycle model — a stage `completed` in
+one but absent from the other has no clear meaning.
+
+**δ — Document platform asymmetry only in README (status
+quo).** Rejected. README docs decay — the existing "run
+register-codex-hooks.sh" line was already drifting; the
+gap surfaced only when an architect noticed the missing
+hook. G4 promotes parity to first-class; relegating to
+README prose contradicts the goal. Load-time schema
+validation catches violations at PR time.
+
+## Notes
+
+The five legal values include intentional redundancy (`cc`
+≡ `cc-only`, `codex` ≡ `codex-only`) so authors pick the
+naturally-reading spelling; matching is set-membership.
+`m9.host.register-codex-hooks`'s `flags:
+[platform-specific]` is informational; the authoritative
+declaration is `platforms: codex-only`. A future third
+platform adds an enum value additively — the ADR-0013
+fingerprint flips affected stages to `stale`, no separate
+migration logic.
+
+## Related
+
+- [ADR-0007](./0007-plugin-runtime-derived-constraints.md)
+  — Plugin-runtime-derived constraints; the CC ↔ Codex
+  asymmetry this ADR formalizes is a direct consequence of
+  the C-PLUGIN constraints there. ADR-0007 is the prose
+  statement; ADR-0016 is the data-shape encoding.
+- ADR-0012 — Unified check-script trigger model; consumer
+  of the `platforms` filter.
+- ADR-0013 — Declarative state schema + 4-state lifecycle.
+- ADR-0014 — Stage registry contract; the JSON Schema
+  that enforces `platforms`-required at load time.
+- ADR-0015, ADR-0017, ADR-0018, ADR-0019 — sibling
+  redesign ADRs.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Why a redesign" item 4, § "Goals"
+  G4, the Stages table's `platforms` column, and § "Stage
+  registry contract" `platforms` row are authoritative.
+- `PLUGIN_DEVELOPMENT.md` (root) — canonical reference for
+  the CC and Codex plugin contracts this ADR encodes.

--- a/docs/architecture/adr/0016-cross-platform-parity-contract.md
+++ b/docs/architecture/adr/0016-cross-platform-parity-contract.md
@@ -184,7 +184,7 @@ migration logic.
   statement; ADR-0016 is the data-shape encoding.
 - ADR-0012 — Unified check-script trigger model; consumer
   of the `platforms` filter.
-- ADR-0013 — Declarative state schema + 4-state lifecycle.
+- ADR-0013 — Declarative state schema + 5-state lifecycle.
 - ADR-0014 — Stage registry contract; the JSON Schema
   that enforces `platforms`-required at load time.
 - ADR-0015, ADR-0017, ADR-0018, ADR-0019 — sibling

--- a/docs/architecture/adr/0017-i13-invariant-revision-cross-clone-state-sharing.md
+++ b/docs/architecture/adr/0017-i13-invariant-revision-cross-clone-state-sharing.md
@@ -1,0 +1,246 @@
+# ADR 0017: I-13 invariant revision — cross-clone state sharing via GitHub-based identity
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+The v0.4.0 spec
+[`../0002-product-features-and-flows/07-cross-cutting-invariants.md`](../0002-product-features-and-flows/07-cross-cutting-invariants.md)
+§ I-13 places per-repo bootstrap state at
+`~/.board-superpowers/repos/<normalized>/state.yml`, where
+`<normalized>` is the repo's **absolute on-disk path** with the
+leading `/` stripped and remaining `/` replaced by `-` (per
+[`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)).
+Identity is path-derived; two clones of the same GitHub repo at
+different paths produce two independent host-local state
+directories.
+
+The bootstrap-redesign work
+([`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md))
+surfaces three structural weaknesses:
+
+1. **Architect intent is per-`(host, repo)`, not per-clone.**
+   The audit DSN, the bootstrap progress, the cached GitHub
+   Project field IDs are facts about *the repo as a coordination
+   object*, not facts about a particular working copy. An
+   architect with primary `~/Dev/foo` and sandbox `~/Sandbox/foo`
+   should not have to bootstrap twice or hand-sync
+   `credentials.yml`.
+2. **Worktrees of the same primary repo collide with path
+   normalization.** A worktree at
+   `~/.config/superpowers/worktrees/foo/feat-x` produces a
+   different identity than its primary `~/Dev/foo`, even though
+   both share `origin` and the same `(host, repo)` scope. Each
+   worktree ends up with its own `state.yml`, `credentials.yml`,
+   and audit DB — the opposite of what worktree-per-Consumer
+   (ADR-0003) needs.
+3. **Manual sync cost grows with clone count.** Every additional
+   clone (or worktree) on the same host multiplies the surface
+   area the architect must keep coherent; the path *is* the
+   identity, with no programmatic way to express "this is the
+   same repo as that one."
+
+The redesign doc § "Repo identity" + § "Edge cases" + § "I-13
+invariant revision (cross-clone state sharing)" + § "Decided"
+formalize a replacement scheme. This ADR records the decision
+so the same-PR contract update to `07-cross-cutting-invariants.md`
+§ I-13 has a citable anchor.
+
+## Decision
+
+Repo identity is **GitHub-based**, derived from the `origin`
+remote URL. The directory key is computed as:
+
+```
+git remote get-url origin
+  → https://github.com/PanQiWei/board-superpowers.git
+  → git@github.com:PanQiWei/board-superpowers.git
+
+bsp_compute_repo_identity()
+  → strip scheme prefix and `.git` suffix
+  → extract <owner>/<repo> path component
+  → replace `/` with `-`
+  → "PanQiWei-board-superpowers"
+```
+
+Per-repo host-local state lives at
+`~/.board-superpowers/repos/<owner>-<repo>/`, regardless of how
+many physical clones of the repo exist on the host. I-13 is
+**revised** to:
+
+> **I-13 (revised).** Each `(host, GitHub repo)` pair shares a
+> single host-local per-repo state directory at
+> `~/.board-superpowers/repos/<repo-identity>/`, regardless of
+> how many physical clones exist on the host. Per-clone
+> physical isolation is preserved only for `repo-clone`
+> locality stages (`.venv/`, `config.local.yml`).
+
+The identity scheme handles edge cases as follows (per redesign
+doc § "Edge cases"):
+
+- **Local-only repo (no `origin`)** — fallback to path-based
+  normalization with a `_path-` prefix
+  (`~/.board-superpowers/repos/_path-Users-foo-myproj/`). The
+  prefix prevents collision with GitHub identities. When the
+  architect later adds a GitHub `origin`, the pre-v1
+  breaking-change posture (per redesign § "Decided") permits
+  deleting the `_path-...` directory and re-bootstrapping; no
+  auto-migration stage ships.
+- **HTTPS vs SSH URL form** — both `https://github.com/A/B.git`
+  and `git@github.com:A/B.git` resolve to identity `A-B`. URL
+  form is normalized away.
+- **Multi-remote repos** — `origin` is the canonical source;
+  non-`origin` remotes do not influence identity.
+- **Forks** — fork's `origin` points to the fork
+  (`<your-name>/<their-repo>`), so the fork has its own
+  identity separate from upstream. State does not transfer
+  between fork and upstream — a fork is a different
+  coordination object.
+- **Repo rename on GitHub** — `origin` URL no longer matches
+  the existing identity directory. The `bsp-relocate-repo.sh
+  <old-identity> <new-identity>` helper atomically `mv`s the
+  state directory; the architect runs it once after the rename.
+- **All worktrees share identity** — `git rev-parse
+  --git-common-dir` resolves every worktree to the primary
+  clone, which is where `origin` lives. Worktrees of the same
+  primary repo share state, which is the correct behavior for
+  worktree-per-Consumer (ADR-0003).
+
+## Consequences
+
+### Positive
+
+- **One bootstrap per `(host, repo)` pair.** Two clones at
+  `~/Dev/foo` and `~/Sandbox/foo` share `state.yml`,
+  `credentials.yml`, and audit DB. Changes from one clone are
+  immediately visible to the other; the architect bootstraps
+  once and gains uniform behavior across every working copy.
+- **Worktrees behave correctly with no special handling.**
+  Worktree-per-Consumer (ADR-0003) was previously at odds with
+  path-based identity; the GitHub-based scheme makes it work
+  by construction.
+- **Multi-architect-on-same-host alignment is correct by
+  default.** Two architects on the same host who clone the same
+  repo share the per-`(host, repo)` configuration — one
+  authoritative copy of audit credentials, bootstrap progress,
+  cached Project IDs. Per-architect divergence is preserved
+  through `repo-clone` locality stages (`config.local.yml`,
+  `.venv/`), which remain physically per-clone.
+- **Identity is human-readable.** `<owner>-<repo>` directory
+  names stay self-explanatory in `ls
+  ~/.board-superpowers/repos/`.
+
+### Negative
+
+- **Pre-v1 breaking change.** Existing v0.4.0 installs that
+  used path-based identity must delete
+  `~/.board-superpowers/repos/<old-path-id>/` and re-bootstrap
+  on upgrade. The redesign doc § "Decided" → "Pre-v1 breaking
+  changes are accepted" carries this posture; no in-place
+  migration logic ships.
+- **Repo-rename adds an out-of-band manual step.** The
+  architect runs `bsp-relocate-repo.sh <old> <new>` once after
+  a GitHub rename. Rare enough that a continuous
+  detect-and-prompt stage is not justified at v1; future
+  enhancement permitted.
+- **Cross-architect intent leak when sharing a host.** Two
+  architects on the same host who clone the same repo now
+  share the audit DSN. If they need independent audit trails,
+  they must use distinct hosts (or distinct user accounts).
+  The previous scheme accidentally isolated them; the new
+  scheme exposes the underlying assumption that `(host, repo)`
+  is the coordination unit, not `(host, path)`.
+
+## Alternatives considered
+
+### α — GitHub-based identity, cross-clone shared state (chosen)
+
+This ADR's decision. Identity is `<owner>-<repo>` from `origin`;
+state is shared across all clones and worktrees of the same
+`(host, repo)` pair.
+
+### β — Keep path-based identity (status quo)
+
+Rejected. Architect intent is per-`(host, repo)` configuration
+sharing; path-based isolation produces unnecessary divergence
+between clones, and the manual sync cost grows linearly with
+clone count. Worktree-per-Consumer (ADR-0003) makes the
+multi-clone case the common case, not the exception, so the
+divergence cost is felt on every Consumer session.
+
+### γ — GitHub numeric repo ID via `gh api`
+
+Rejected. The numeric ID (e.g., `123456789`) is stable across
+renames but completely non-readable as a directory name;
+`~/.board-superpowers/repos/123456789/` defeats the
+self-explanatory listing property. A `gh api repos/<owner>/<repo>`
+round-trip would also be required at first bootstrap, adding a
+network dependency to a stage that otherwise needs only `git`.
+The rare repo-rename case is handled adequately by
+`bsp-relocate-repo.sh` without sacrificing readability.
+
+### δ — Hybrid: display name + numeric ID alias in manifest
+
+Rejected. Two-layer identity (display + alias) introduces
+complexity without proportional value. Repo-rename frequency is
+too low to justify manifest-aliasing machinery; α's helper-script
+approach gives the architect one explicit action at rename time
+and zero ongoing overhead.
+
+## Notes
+
+This ADR amends I-13 wording in
+[`../0002-product-features-and-flows/07-cross-cutting-invariants.md`](../0002-product-features-and-flows/07-cross-cutting-invariants.md).
+Per the same-PR contract-update discipline
+([`../AGENTS.md`](../AGENTS.md) Doctrine #3), the PR that lands
+this ADR also rewrites § I-13 to the revised wording and updates
+[`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)
+to document the GitHub-based identity scheme (with `_path-`
+fallback) alongside the legacy path-based normalization rule.
+On acceptance, the ADR's status flips from `proposed` to
+`accepted` and supersedes the original I-13 phrasing in
+`07-cross-cutting-invariants.md`; this ADR then becomes the
+canonical reference for the revised invariant.
+
+The `_path-` prefix on the local-only-repo fallback is a
+deliberate namespace separator: GitHub identities never start
+with an underscore (GitHub username syntax forbids it), so the
+prefix guarantees no accidental collision with a real
+`<owner>-<repo>` identity.
+
+## Related
+
+- [ADR-0003](./0003-worktree-per-consumer.md) — One worktree per
+  Consumer session; the pattern that path-based identity broke
+  and GitHub-based identity restores.
+- [ADR-0012](./0012-unified-check-script-trigger-model.md) —
+  Unified check-script trigger model; partitioned status files
+  this ADR governs the physical location of.
+- ADR-0013 — Declarative state schema + 4-state lifecycle
+  (sibling, plain text placeholder until landed); defines the
+  `repo-shared` locality whose physical home this ADR specifies.
+- ADR-0014 — Stage registry contract (sibling, plain text
+  placeholder); the registry whose `locality` field this ADR
+  binds to a directory layout.
+- ADR-0015 — M4 audit per-repo locality (sibling, plain text
+  placeholder); per-repo `credentials.yml` lives inside the
+  identity-keyed directory this ADR defines.
+- ADR-0016 — Cross-platform parity contract (sibling, plain text
+  placeholder); orthogonal to identity, shares redesign-doc origin.
+- ADR-0018 — M7 multi-stage per-block routing-block protocol
+  (sibling, plain text placeholder); orthogonal to identity.
+- ADR-0019 — Pre-v1 breaking-change posture (sibling, plain text
+  placeholder); makes the no-in-place-migration posture in this
+  ADR's Negative consequences citable.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Repo identity" + § "Edge cases" +
+  § "I-13 invariant revision (cross-clone state sharing)" are
+  this ADR's authoritative reference.
+- [`../0002-product-features-and-flows/07-cross-cutting-invariants.md`](../0002-product-features-and-flows/07-cross-cutting-invariants.md)
+  § I-13 — Invariant whose wording this ADR amends.
+- [`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)
+  — Path-conventions contract; the same-PR update extends it
+  with the GitHub-based identity scheme alongside the legacy
+  path normalization rule.

--- a/docs/architecture/adr/0017-i13-invariant-revision-cross-clone-state-sharing.md
+++ b/docs/architecture/adr/0017-i13-invariant-revision-cross-clone-state-sharing.md
@@ -218,7 +218,7 @@ prefix guarantees no accidental collision with a real
 - [ADR-0012](./0012-unified-check-script-trigger-model.md) —
   Unified check-script trigger model; partitioned status files
   this ADR governs the physical location of.
-- ADR-0013 — Declarative state schema + 4-state lifecycle
+- ADR-0013 — Declarative state schema + 5-state lifecycle
   (sibling, plain text placeholder until landed); defines the
   `repo-shared` locality whose physical home this ADR specifies.
 - ADR-0014 — Stage registry contract (sibling, plain text

--- a/docs/architecture/adr/0018-m7-multi-stage-routing-block-protocol.md
+++ b/docs/architecture/adr/0018-m7-multi-stage-routing-block-protocol.md
@@ -34,7 +34,7 @@ each module's payload as a versioned contract:
    M7 block growing unbounded can push architect content past
    the limit and corrupt routing with no failure signal.
 
-The stage-registry shape (ADR-0014) plus the 4-state lifecycle
+The stage-registry shape (ADR-0014) plus the 5-state lifecycle
 (ADR-0013) give M7 a place to expose its internal structure as
 multiple registry rows. This ADR formalizes that restructuring.
 
@@ -204,7 +204,7 @@ future-ADR question; first cut errs safe.
 
 - ADR-0012 — Unified check-script trigger model. The
   per-stage diff this ADR's restructured M7 stages feed into.
-- ADR-0013 — Declarative state schema + 4-state lifecycle +
+- ADR-0013 — Declarative state schema + 5-state lifecycle +
   K8s-style three-layer fingerprint. The block-level
   fingerprint comparison this ADR exploits.
 - ADR-0014 — Stage registry contract. The YAML row shape

--- a/docs/architecture/adr/0018-m7-multi-stage-routing-block-protocol.md
+++ b/docs/architecture/adr/0018-m7-multi-stage-routing-block-protocol.md
@@ -1,0 +1,219 @@
+# ADR 0018: M7 multi-stage per-block routing protocol with form-detect prerequisite + Codex 32 KiB budget
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+Through `v0.4.0`, M7 (Agent routing — the module that injects
+plugin routing metadata into the user repo's `AGENTS.md` and
+`CLAUDE.md`) is a **single monolithic stage**:
+`bsp_inject_routing_block` writes one routing block bounded by
+one `<!-- board-superpowers:routing -->` marker pair. Three
+structural weaknesses surface once the bootstrap redesign treats
+each module's payload as a versioned contract:
+
+1. **No content-block versioning.** One opaque region, one
+   content hash. Adding a second routing block (e.g., Manager /
+   Consumer dispatch alongside the existing skill-routing
+   trigger) means rewriting the whole region; architect-modified
+   halves lose all granularity.
+2. **No form detection.** The script picks a target file by
+   filesystem probe at each invocation — no cached `form`
+   (`cc-only` / `codex-only` / `dual` / `neither`) in state.
+   Architects who add `AGENTS.md` to a previously CC-only repo
+   (or remove one) cannot trigger re-injection without manual
+   intervention; the lifecycle model has no signal to flip M7
+   to `stale`.
+3. **No size-budget awareness.** Codex CLI walks Git root → cwd
+   concatenating every `AGENTS.md` and stops at
+   `project_doc_max_bytes` — default **32 KiB**
+   ([`PLUGIN_DEVELOPMENT.md`](../../../PLUGIN_DEVELOPMENT.md)
+   line 309). Past the cap is silently truncated. A monolithic
+   M7 block growing unbounded can push architect content past
+   the limit and corrupt routing with no failure signal.
+
+The stage-registry shape (ADR-0014) plus the 4-state lifecycle
+(ADR-0013) give M7 a place to expose its internal structure as
+multiple registry rows. This ADR formalizes that restructuring.
+
+## Decision
+
+M7 is restructured as a **multi-stage per-block protocol** with
+three structural elements:
+
+### 1. Prerequisite form-detect stage
+
+A new automated stage `m7.repo.detect-agentsmd-form` runs
+**before** any inject-block stage. Its `target_state` records
+`form` (enum `cc-only` / `codex-only` / `dual` / `neither`,
+derived from probing `AGENTS.md` and `CLAUDE.md` presence) and
+`agentsmd_total_bytes` (post-concat-walk total used to gate
+downstream stages against the 32 KiB budget). Locality is
+`repo-shared` — the `form` value lives in the repo's
+`state.yml` (per-clone-physical, not git-tracked) so each clone
+re-detects on bootstrap rather than inheriting another clone's
+filesystem layout.
+
+### 2. Per-block inject stages
+
+One stage per content block, shape `m7.repo.inject-block.<name>`.
+The `v0.4.0+redesign` registry carries two **required** blocks:
+`m7.repo.inject-block.routing-rule` (skill-routing trigger
+prose, the v0.4.0 single-block era's content restructured) and
+`m7.repo.inject-block.skill-routing` (Manager / Consumer
+dispatch rules, split out from the same monolithic block). Each
+block carries its own marker pair
+(`<!-- board-superpowers:<block-name> -->` /
+`<!-- /board-superpowers:<block-name> -->`), its own content
+hash fed through the three-layer fingerprint (ADR-0013) for
+independent block-level drift detection, a `kind` flag
+(`required` / `optional`) controlling injection authority, and
+a `block_max_bytes` registry field (default **4096** = 4 KiB)
+enforced at write time.
+
+### 3. `form` propagation through `target_state`
+
+Every `m7.repo.inject-block.*` stage's `target_state` includes
+the `form` value cached by the prerequisite. Because the
+fingerprint compares `target_state` structurally (ADR-0013),
+any change to the repo's routing-target file structure
+(architect adds AGENTS.md to a previously CC-only repo; removes
+CLAUDE.md; etc.) flips **every** M7 inject stage to `stale`
+simultaneously and triggers full re-injection on next session —
+no separate "re-run all blocks" signal needed; the lifecycle
+model surfaces it mechanically.
+
+### 4. Required vs optional `kind`
+
+`kind=required` blocks are auto-injected by
+`scripts/bootstrap-project.sh` with no architect interaction
+(both current blocks are required). `kind=optional` blocks
+(recommended-but-not-load-bearing prompt hints) are surfaced by
+the `bootstrapping-repo` SKILL and injected only after explicit
+architect accept; the optional list is **currently empty**. The
+SKILL flow MUST contain a
+`for each optional block in registry → prompt architect` loop
+(no-op when empty) so future optional blocks land via
+registry-only edits without SKILL code changes.
+
+### 5. Codex 32 KiB budget enforcement
+
+Two hard caps complement the lifecycle:
+
+- **Single-block size cap**: ≤ 4 KiB per block
+  (`block_max_bytes` registry field, default 4096).
+- **Plugin total budget on AGENTS.md**: ≤ 8 KiB across all M7
+  blocks plus all sub-directory AGENTS.md contributions —
+  leaving ≥ 24 KiB headroom for the architect's own
+  AGENTS.md content.
+
+The `m7.repo.detect-agentsmd-form` stage measures
+post-concat-walk total size; if a pending injection would push
+the AGENTS.md total over budget, the stage refuses to inject
+and surfaces a warning marker for architect attention rather
+than silently corrupting routing through Codex truncation.
+
+## Consequences
+
+### Positive
+
+- **Per-block independent versioning.** Plugin upgrades touching
+  one block re-run only that block's stage; architect edits to a
+  different block survive — marker-pair content hash detects
+  per-block drift, not file-level drift.
+- **Mechanical re-injection on file-structure change.** `form`
+  propagation means the same lifecycle diff handles "architect
+  adopted CC + Codex dual-platform" cleanly — no special
+  "re-detect routing targets" code path.
+- **Production-safe Codex integration.** 32 KiB budget enforced
+  as explicit refusal, not silent truncation. Failure mode is
+  "architect sees a warning marker", not "agent loads
+  half-truncated routing rule and hangs".
+- **Registry-driven extensibility.** New required block = one
+  row + `target_state` callable; new optional block = same plus
+  a one-line `kind` flag. No SKILL or script-shape change.
+
+### Negative
+
+- **More registry rows.** The single v0.4.0 row becomes three
+  (`detect-agentsmd-form` + two `inject-block.*`). Mitigated by
+  declarative registry + small count relative to the ~20 total.
+- **Pre-v1 breaking change.** v0.4.0-bootstrapped repos do not
+  auto-migrate; architects delete the legacy routing region and
+  re-bootstrap (per design doc's "Pre-v1 breaking changes
+  accepted").
+- **Budget enforcement adds a refusal path.** Sessions where
+  cumulative AGENTS.md content exceeds 24 KiB before M7 runs see
+  a warning marker instead of injection; architect must prune
+  AGENTS.md or raise `project_doc_max_bytes`.
+
+## Alternatives considered
+
+### α — Per-block multi-stage + form-detect prerequisite (chosen)
+
+This ADR's decision. Block-level resolution + mechanical
+file-structure re-evaluation + explicit budget enforcement.
+
+### β — Single monolithic M7 stage (status quo at v0.4.0)
+
+Rejected. Three failure modes documented in § "Context": no
+per-block versioning, no form detection, no size-budget
+awareness. Each is independently disqualifying for the
+bootstrap redesign's contract-versioning goal.
+
+### γ — Single per-file stage (monolithic but file-aware: "keep AGENTS.md in sync with current required + accepted optional blocks")
+
+Rejected. Keeps file-level atomicity (one stage per target
+file) but loses per-block independent versioning. An architect
+who accepts optional block 1 and declines optional block 2
+forces the stage to overwrite both or none — block-level
+resolution gone.
+
+### δ — No size cap, trust Codex to not truncate
+
+Rejected. Codex's 32 KiB is a documented hard limit
+([`PLUGIN_DEVELOPMENT.md`](../../../PLUGIN_DEVELOPMENT.md)
+line 309); silent truncation past the cap is documented
+behavior. Skipping enforcement turns a known contract into a
+production landmine — agents load half-truncated routing prose
+with no failure signal, surfacing only via downstream "why does
+the agent ignore the routing rule" debugging.
+
+## Notes
+
+The block-level marker pair convention
+(`<!-- board-superpowers:<block-name> -->`) extends the existing
+`<!-- board-superpowers:routing -->` shape from `v0.1.0-minimum`.
+Old single-block markers are not auto-rewritten; the v0.4.0 →
+redesign transition treats them as architect content (the
+block-content-hash check sees the old marker pair as "no current
+required block matches" and inject stages write fresh blocks
+alongside, leaving the architect to delete the legacy region
+manually). The `bootstrapping-repo` SKILL surfaces this as a
+prompt the first time the lifecycle observes the legacy region.
+
+The 4 KiB / 8 KiB figures are deliberately conservative:
+8 KiB plugin + 24 KiB architect headroom = 32 KiB Codex cap, no
+slack for sibling sub-directory AGENTS.md contributions in
+deeply nested repos. Bumping the per-plugin budget is a
+future-ADR question; first cut errs safe.
+
+## Related
+
+- ADR-0012 — Unified check-script trigger model. The
+  per-stage diff this ADR's restructured M7 stages feed into.
+- ADR-0013 — Declarative state schema + 4-state lifecycle +
+  K8s-style three-layer fingerprint. The block-level
+  fingerprint comparison this ADR exploits.
+- ADR-0014 — Stage registry contract. The YAML row shape
+  this ADR's three new M7 rows occupy.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Functional modules" → M7 +
+  § "Stages" M7 rows + § "Decided" entries on M7 are this
+  ADR's authoritative reference.
+- [`../../../PLUGIN_DEVELOPMENT.md`](../../../PLUGIN_DEVELOPMENT.md)
+  line 309 — Codex `project_doc_max_bytes` 32 KiB
+  documentation; the load-bearing constraint for § "Decision"
+  element 5.

--- a/docs/architecture/adr/0019-zero-config-sqlite-default-audit-backend.md
+++ b/docs/architecture/adr/0019-zero-config-sqlite-default-audit-backend.md
@@ -1,0 +1,160 @@
+# ADR 0019: Zero-config SQLite as default per-repo audit backend
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+[ADR-0009](./0009-allow-sqlite-as-byo-audit-db.md) added
+`sqlite://` / `sqlite3://` to the BYO audit-DB allowlist
+alongside Postgres and MySQL, motivated by solo-developer
+ergonomics. ADR-0009 left the picker unchanged:
+`bootstrap-project.sh` step 2e still presents a 6-scheme
+interactive prompt at first bootstrap, with SQLite as one
+branch among others.
+
+At v0.4.0 — after the bootstrap redesign promoted M4 audit
+locality from host-shared to per-repo (per ADR-0015) — the
+prompt friction surfaces in sharper relief. The modal architect
+runs `bootstrapping-repo` once per `(host, GitHub repo)` pair
+and has **no preference** over Postgres / MySQL / SQLite at
+that moment; the prompt cannot meaningfully educate either,
+since a one-line scheme list does not surface the trade-offs
+(concurrent-writer semantics, backup, query cost) needed for
+an informed pick without docs. The `(host, repo) → 1 architect`
+modal deployment that ADR-0009 § "Forces preserved" accepted
+**eliminates multi-writer contention as a real concern at
+first bootstrap**. SQLite is the right answer for the modal
+case; the prompt is a tax on the answer being right.
+
+The unified check-script trigger model (ADR-0012) +
+declarative state schema (ADR-0013) already provide the
+mechanism to honor a post-bootstrap override: changing
+`credentials.yml` bumps `m4.repo.acquire-dsn`'s
+`target_state_hash`, the next hook flips the stage to `stale`,
+and `m4.repo.apply-audit-ddl` re-runs against the new DSN.
+The redesign foundation makes a "default + override" pattern
+cheap; the 6-scheme picker is no longer the only way to expose
+the choice.
+
+## Decision
+
+The `m4.repo.acquire-dsn` stage's first-bootstrap path is
+**zero-config**: it initializes SQLite at
+`~/.board-superpowers/repos/<repo-identity>/audit.db` with
+no architect prompt, then prints a one-line override hint on
+stderr.
+
+Concretely:
+
+- **No DSN prompt at first bootstrap.** The stage writes
+  per-repo `credentials.yml` (chmod 0600) with
+  `audit_db_url: sqlite:////absolute/path/to/audit.db`
+  (4-slash absolute form per ADR-0009) automatically.
+- **One-line override note** printed once on stderr after the
+  write: `Audit log: SQLite at <path>. To switch DSN, edit
+  credentials.yml or run scripts/setup-audit-db.sh`. Not a
+  blocking confirmation.
+- **WAL mode default** (already in `audit-init.sh` at v0.4.0;
+  this ADR formalizes it as the default-path expectation).
+- **Override path is post-bootstrap edit.** Architects who
+  want Postgres / MySQL edit per-repo `credentials.yml`
+  directly; the next session's lifecycle diff detects the DSN
+  change and `m4.repo.apply-audit-ddl` re-runs. No migration.
+- **Path constraint preserved.** Default lives under
+  `~/.board-superpowers/repos/<repo-identity>/audit.db` per
+  [`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)
+  § "Per-host layout". Project-tree `audit.db` remains
+  forbidden (ADR-0009's existing rejection).
+
+This makes `m4.repo.acquire-dsn` **automated** on the
+first-bootstrap happy path (was `agentic` at v0.3.0); it
+escalates to architect attention only if the default-path
+parent directory is non-writable.
+
+## Consequences
+
+### Positive
+
+- **First-bootstrap friction drops by one prompt.** The modal
+  solo-developer flow no longer pauses on a database picker
+  whose right answer is "the one the picker is asking about."
+- **Audit log adoption goes from "implicit opt-in" to
+  "default-on."** Closes the gap ADR-0009 § "Context"
+  identified — architects defer DB provisioning indefinitely
+  → audit log never comes online.
+- **Override path is honest and discoverable.** A single
+  stderr line names both the file to edit and the helper
+  script — no buried docs.
+- **Lifecycle handles the override re-run for free** via
+  ADR-0013's declarative state schema — switching backends is
+  "edit yaml, restart session."
+
+### Negative
+
+- **Architects who would have picked Postgres get SQLite by
+  default.** They pay one extra step (edit `credentials.yml`,
+  restart) versus a hypothetical perfect picker. Mitigated by
+  the override note surfacing the cost immediately.
+- **Default path collisions are silent.** Two `(host, repo)`
+  pairs sharing the same `<repo-identity>` would share one
+  `audit.db` file. ADR-0015's GitHub-based identity scheme
+  makes this unlikely; transferred-repo edge cases are out of
+  v1 scope per P3.
+- **Pre-v1 v0.3.0 architects upgrade with manual cleanup**
+  (already documented as a pre-v1 breaking change in
+  `05-bootstrap-surface-redesign.md`; no new migration logic).
+
+## Alternatives considered
+
+**Keep prompting for DSN at first bootstrap (ADR-0009 status
+quo).** Rejected. The prompt does not surface trade-off
+information needed for an informed choice; most architects
+have no preference; first-bootstrap friction is paid every
+time the modal answer is the obvious one.
+
+**In-memory SQLite by default + opt-in persistence.** Rejected.
+The audit log exists for forensics — a non-persistent default
+defeats the purpose of having an audit schema at all.
+
+**Encrypted SQLite (sqlcipher) by default.** Rejected. The
+audit DB lives on the architect's own machine under
+`~/.board-superpowers/` (mode 0700 parent); the architect owns
+the threat model. Mandatory encryption adds a sqlcipher
+dependency and key-management story for a threat (host
+compromise) out of v1 scope per P3. At-rest encryption is the
+encrypted-volume layer's job — orthogonal to the plugin.
+
+**Federated audit (one shared DB across repos by default).**
+Rejected. Violates ADR-0015's per-repo isolation. Future
+federation ships as an explicit architect-chosen DSN.
+
+## Notes
+
+ADR-0019 promotes SQLite from "permitted option" (ADR-0009) to
+"zero-config default"; the 6-scheme allowlist is unchanged.
+`setup-audit-db.sh` (named in the override note) is
+implementation-time detail — likely a thin wrapper around
+`audit-init.sh`. The ADR fixes the name surfaced to architects
+so override discoverability is stable.
+
+## Related
+
+- [ADR-0009](./0009-allow-sqlite-as-byo-audit-db.md) — parent;
+  permits SQLite as a BYO scheme. ADR-0019 makes it the
+  default rather than a co-equal option.
+- [ADR-0006](./0006-producer-autonomy-boundary.md) §5 — BYO
+  RDBMS opt-in / R-class degradation. ADR-0019 narrows the
+  "opt-in" wording: the architect opts in to using the audit
+  log, not to provisioning a database.
+- ADR-0012 / ADR-0013 / ADR-0015 — unified trigger model,
+  declarative state schema, and M4 per-repo locality; together
+  they make the post-bootstrap override re-run automatic when
+  the architect edits `credentials.yml`.
+- [`../0005-contracts/07-path-conventions.md`](../0005-contracts/07-path-conventions.md)
+  § "Per-host layout" — `audit.db` sibling location;
+  project-tree `audit.db` forbidden rule preserved.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  § "Decided" → "Per-repo audit DB defaults to zero-config
+  SQLite" — living design doc this ADR formalizes.

--- a/docs/architecture/adr/0020-stage-applicability-and-not-applicable-state.md
+++ b/docs/architecture/adr/0020-stage-applicability-and-not-applicable-state.md
@@ -1,0 +1,240 @@
+# ADR 0020: Stage applicability — `applicable_when` predicate + `not-applicable` 5th lifecycle state
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+The unified check-script trigger model (ADR-0012) and the
+declarative state schema (ADR-0013) treat every stage in the
+registry (ADR-0014) as **always applicable**: the lifecycle
+diffs `(generation, target_state_hash)` for every stage on
+every session and emits a marker for any stage in `never-run`
+or `stale`. At v0.4.0 this assumption was implicit — no
+declarative way to express "this stage applies only when X."
+Conditional behavior was inlined in executor scripts: M3
+stages internally checked GitHub Project settings before
+acting, and M3 itself hard-coded GitHub Project as the only
+board backend.
+
+Three structural problems follow from inline-in-executor
+conditionality:
+
+1. **Invisible to the lifecycle.** A stage that no-ops because
+   its precondition fails still records `completed` (or
+   re-runs every session if the executor is non-idempotent).
+   Architect-facing summaries cannot distinguish "stage ran
+   and did real work" from "stage exited 0 because its
+   condition was false" — surfaces show
+   "stage X completed in 0ms" for stages that did nothing.
+2. **M3 is hard-coded to GitHub Project.** Per
+   [`05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+   § "Functional modules" → M3, the redesign reframes M3 as
+   "Board operations (BoardAdapter-driven)" — operations
+   dispatched through the
+   [ADR-0005](./0005-board-adapter-contract.md) BoardAdapter
+   abstraction. M3 stages need a declarative way to
+   participate only when the selected backend (chosen by
+   `m10.repo.choose-kanban-backend`) declares the relevant
+   capability. Without a registry-level gate, every M3 stage
+   inlines a backend-name check that drifts as adapters land.
+3. **No generic conditional-stage mechanism.** "Applies only
+   when X" recurs across non-board-related stages — Codex-only
+   stages already carry a `platforms` coarse predicate
+   (ADR-0016), and future stages may gate on architect-chosen
+   feature flags. A bespoke gate per recurrence is the exact
+   tech debt this redesign exists to eliminate.
+
+## Decision
+
+The stage registry gains an **`applicable_when` predicate**
+field (per ADR-0014 § "Column / field semantics"), and the
+4-state lifecycle (per ADR-0013) is extended to **five
+states** by adding **`not-applicable`** as a peer to
+`never-run` / `completed` / `stale` / `deprecated`.
+
+`applicable_when` is an optional per-stage field. When
+present, the hook evaluates the predicate before the
+generation / hash diff. The predicate has three forms:
+
+1. **Declarative setting-path.**
+   `applicable_when: {setting_path: <dot.path>, one_of: [<values>]}`.
+   True when the value at `<dot.path>` in the merged settings
+   (per ADR-0021 layering) is one of `<values>`. Most stages
+   use this form.
+2. **Declarative board-capability.**
+   `applicable_when: {board_capability: <name>}`. True when
+   the BoardAdapter selected by
+   `m10.repo.choose-kanban-backend` declares `<name>` in its
+   capability set (capability declaration on the adapter
+   contract, ADR-0005, extended by ADR-0022). M3 stages use
+   this form — `m3.repo.ensure-labels` declares
+   `{board_capability: ensure-labels}`,
+   `m3.repo.validate-status-field` declares
+   `{board_capability: status-field-schema}`.
+3. **Python predicate reference.**
+   `applicable_when_fn: <module.callable>`. Escape hatch for
+   conditions that cannot be expressed declaratively. The
+   callable receives the merged settings dict and returns a
+   bool. Authors are pushed toward forms 1 and 2 by the
+   schema — form 3 requires a justification comment and a
+   CI determinism test.
+
+`not-applicable` is the 5th lifecycle state. Detection rule:
+`applicable_when` evaluates false. Behavior: the hook **does
+not emit a marker** for `not-applicable` stages and the SKILL
+**does not execute** them even if invoked manually — the
+lifecycle state takes precedence. If `applicable_when` later
+evaluates true (architect changed the gating setting), state
+flips on next session: `never-run` if no historical entry
+exists, or `completed` if an entry from a prior applicable
+window matches the current generation / hash. No re-prompt
+for re-entry into the applicable window — the existing
+entry's fingerprint is authoritative.
+
+Predicate evaluation is **hook-side and IO-free**. Forms 1
+and 2 are settings-dict lookups + small comparisons; form 3
+is a pure Python call. None perform IO (no GitHub API call,
+no DB query, no network egress). Evaluation MUST stay within
+ADR-0012's ≤200ms hook budget — predicates that need IO are
+a registry bug caught by CI.
+
+## Consequences
+
+### Positive
+
+- **Conditional stages are first-class.** Backend-aware,
+  feature-flag-gated, and platform-gated stages all use one
+  registry field; the lifecycle surfaces them with a
+  distinct state instead of hiding the condition inside an
+  executor.
+- **M3 hard-coding is dissolved.** `m3.repo.*` stages
+  declare capability requirements; v0.5.0's
+  GitHub-Project-v2 adapter declares
+  `[ensure-labels, status-field-schema]` and both stages
+  participate; future Linear / Jira adapters declare their
+  own capability sets and M3 stages re-route automatically
+  via `not-applicable`. No backend-name comparison anywhere
+  in stage executors.
+- **Architect-readable summaries.** Output distinguishes
+  "completed" from "not-applicable (predicate false:
+  kanban_backend=linear)." No more zero-work
+  "completed in 0ms" rows.
+- **Re-applicability is automatic.** Architect flips
+  `kanban_backend` from `github-project-v2` to `linear` →
+  next session the M3 stages flip from `completed` to
+  `not-applicable` (entry preserved) and the new backend's
+  capability stages flip from `not-applicable` to
+  `never-run`. No explicit migration step.
+
+### Negative
+
+- **Predicate registry surface to validate.** The JSON
+  Schema (ADR-0014) must reject malformed `applicable_when`
+  blocks, missing `board_capability` names not declared by
+  any registered adapter, and `setting_path`s that don't
+  resolve in the settings schema. CI gating absorbs the
+  cost.
+- **`applicable_when_fn` escape hatch.** Form 3 admits
+  arbitrary Python; a non-deterministic predicate (clock
+  read, random) breaks lifecycle stability. Mitigation: CI
+  round-trips every form 3 predicate against fixed inputs
+  and asserts determinism.
+- **Capability declaration becomes adapter-contract
+  surface.** ADR-0005 gains a capability declaration
+  mechanism (specified in ADR-0022). New adapters that
+  forget to declare a capability silently make all stages
+  requiring it `not-applicable` — visible in summaries but
+  easy to miss. CI test asserts every shipped adapter
+  declares the capability set its dependent stages need.
+
+## Alternatives considered
+
+### α — `applicable_when` predicate + `not-applicable` 5th state (chosen)
+
+The decision recorded above. Single declarative mechanism;
+hook-cheap; lifecycle-visible; covers board-capability,
+setting-path, and escape-hatch cases under one schema.
+
+### β — Inline-in-executor conditions (status quo at v0.4.0)
+
+Rejected. The model the redesign exists to replace.
+Conditions live inside executor scripts; lifecycle sees only
+"completed" / "never-run" / "stale" and cannot surface why a
+stage no-op'd. M3's hard-coded GitHub Project assumption is
+v0.4.0's instance of this anti-pattern; without a
+registry-level gate, every future conditional stage repeats
+the mistake.
+
+### γ — Per-backend stage families (`M3-GitHub` / `M3-Linear` / ...)
+
+Rejected. Splitting M3 into one module per backend
+duplicates the module structure for what is fundamentally
+one capability surface — labels are labels regardless of
+backend. The split also doesn't solve generic conditional
+applicability for non-board-related stages (overrides,
+Codex hook registration, feature flags), which would still
+need a parallel mechanism. One mechanism handling all
+conditional cases is strictly simpler than N module-family
+conventions.
+
+### δ — Always-applicable stages; let executors no-op
+
+Rejected. Same "invisible to lifecycle" problem as β, with
+added clutter in summaries ("stage X completed in 0ms" for
+the no-op path) and code-duplication of the precondition
+check across every executor. Predicate evaluation belongs in
+one place (the hook, gating execution) not N places.
+
+## Notes
+
+`applicable_when` is **independent of** `platforms` (the
+coarse `cc-only` / `codex-only` / `both` filter, per
+ADR-0016). `platforms` is the special-cased
+runtime-environment predicate; `applicable_when` is the
+fine settings / capability predicate. Both must be true for
+a stage to participate — a stage with `platforms: codex-only`
+AND `applicable_when: {board_capability: status-field-schema}`
+participates only on Codex AND only when the selected adapter
+declares that capability. The composition rule lives in
+ADR-0016.
+
+The transient SKILL-only states (`failed`,
+`pending-architect-input`, per ADR-0013) are orthogonal to
+applicability. A stage that was `pending-architect-input`
+and then becomes `not-applicable` (architect changed the
+gating setting) is treated as `not-applicable` next session;
+the pending entry is preserved as history but no longer
+drives execution.
+
+## Related
+
+- [ADR-0005](./0005-board-adapter-contract.md) — BoardAdapter
+  contract; the `board_capability` predicate form resolves
+  through this contract's capability declaration surface
+  (extended by ADR-0022).
+- ADR-0012 — Unified check-script trigger model; predicate
+  evaluation runs inside the hook flow defined there and
+  inherits the ≤200ms budget.
+- ADR-0013 — Declarative state schema + lifecycle; this ADR
+  extends the 4-state lifecycle to 5 states.
+- ADR-0014 — Stage registry contract; this ADR adds the
+  `applicable_when` field to the column-semantics
+  enumeration and JSON Schema validation.
+- ADR-0016 — Cross-platform parity contract; defines
+  `platforms` (coarse predicate) and the composition rule
+  with `applicable_when` (fine predicate).
+- ADR-0021 — Settings modular layering; settings paths
+  resolved by `applicable_when: {setting_path: ...}` follow
+  layering and merge semantics defined there.
+- ADR-0022 — BoardAdapter capability dispatch; defines how
+  adapters declare capability sets that the
+  `board_capability` predicate form resolves against.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Stage lifecycle states" (5-state
+  table including `not-applicable`), § "Stage registry
+  contract" → "Column / field semantics" (`applicable_when`
+  row), § "What the lifecycle model asks of each stage" (MAY
+  bullet for `applicable_when`), and § "Functional modules"
+  → M3 are this ADR's authoritative references.

--- a/docs/architecture/adr/0021-settings-modular-layering.md
+++ b/docs/architecture/adr/0021-settings-modular-layering.md
@@ -1,0 +1,204 @@
+# ADR 0021: Settings modular layering — two-section split + per-module schema_version
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+ADR-0013 declared `settings.yml` (one per non-`external`
+locality) as the unified architect-facing surface and fixed
+the per-stage entry shape (three-layer fingerprint:
+`generation` int + `target_state_hash` + structured
+`target_state`). ADR-0014 fixed the registry supplying the
+target. Neither fixed the **internal layout of a settings
+file**. Two questions remained:
+
+1. Architects open `settings.yml` to *configure* the plugin
+   (audit DSN, autonomy presets, kanban backend, WIP limit).
+   A flat `stages_completed[]` is machine-shaped —
+   fingerprints, hashes, timestamps, internal `stage_id` keys
+   — so architects reading it see lifecycle bookkeeping
+   instead of the few knobs that matter to them.
+2. Modules evolve schemas at different cadences (M4 audit
+   when a DDL column lands; M8 autonomy when preset semantics
+   shift; M10 kanban when a BoardAdapter capability ships).
+   Coupling them through one file-level `schema_version`
+   forces co-evolution and single-moment mass migration.
+
+Both resolve through the same move: a second top-level
+section namespaced by module, with its own version axis per
+module.
+
+## Decision
+
+Every `settings.yml` carries **two top-level data structures
+plus file-level metadata** (`schema_version`,
+`plugin_version`, locality-specific bookkeeping):
+
+1. **`stages_completed[]`** — flat list of stage entries with
+   the three-layer fingerprint per ADR-0013. **Authoritative**
+   lifecycle source of truth. Hook reads this for the
+   `(generation, target_state_hash)` diff against the registry.
+   Machine-optimized; architects do not edit it directly.
+2. **`modules.<id>`** — namespaced config-item projection,
+   one section per Axis-C module. **Derived** view holding
+   only architect-facing config items of that module's
+   stages. Re-written deterministically by SKILL on stage
+   completion (atomic `mktemp + mv`).
+
+Authority direction is **`stages_completed[]` → `modules.<id>`**:
+the fingerprint belongs with the lifecycle source-of-truth,
+not the projection. The projection regenerates
+deterministically on every stage completion; architect
+hand-edits to `modules.<id>` are detected on the next SKILL
+pass (projection vs. source comparison) and trigger
+validation + re-elicitation rather than direct mutation.
+Mirrors Helm `values.yaml` vs. chart-default values —
+projection editing passes through the chart's interface, not
+the values storage.
+
+Each `modules.<id>` carries an independent `schema_version`
+for **module-local schema migration**, decoupled from the
+file-level `schema_version` (only changes when the flat
+`stages_completed[]` entry shape itself changes — rare,
+additive only per
+[`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md))
+and from other modules (M4 bumping `m4_audit.schema_version`
+does not move `m8_autonomy.schema_version`). A module schema
+bump → that module's stages emit new `target_state` shape →
+`target_state_hash` changes → ADR-0013's lifecycle flips them
+to `stale` → SKILL re-runs with structural diff messages.
+
+Module section keys follow `m{number}_{snake_case_name}`
+(e.g., `m4_audit`, `m7_routing`, `m8_autonomy`,
+`m10_kanban`) — number prefix preserves Axis-C module
+identity, snake-case suffix is architect-readable, ADR-0014's
+JSON Schema gate enforces it at load time. The per-stage
+registry field `module_section_path` (ADR-0014) names the
+dotted path under `modules.` where projection lands; SKILL
+writes both `stages_completed[].target_state` and
+`modules.<path>` synchronously on completion.
+
+**Future-module inclusion procedure.** When plugin v(N+1)
+introduces a new module, three artifacts change and **no
+SKILL or hook code does**: (1) add stages to
+`scripts/stages-registry.yml` under unique `stage_id`s
+(`m11.host.*` etc.); (2) define the projection schema in
+`scripts/stages-registry.schema.json` under
+`definitions/modules/m11_<name>`; (3) implement per-stage
+callables in `scripts/stages_lib/<stage_id>.py`. Registry-only
+edits are the **only** supported path for new architect-facing
+features — any module bypassing this re-introduces the
+bespoke per-feature UX cost the redesign exists to eliminate.
+
+## Consequences
+
+### Positive
+
+- **Architect read path is clean.** `modules.<id>` surfaces
+  the few knobs architects edit; lifecycle bookkeeping in
+  `stages_completed[]` sits below the fold, labeled
+  machine-managed. One physical file serves both roles.
+- **Module schemas evolve independently.** M4 DDL bumps move
+  only `m4_audit.schema_version`; M8 autonomy evolves its
+  own. No file-wide migration cascade.
+- **Single authority eliminates drift.** With
+  `stages_completed[]` authoritative, the projection cannot
+  silently diverge — SKILL's next pass detects manual edits
+  to `modules.<id>` and forces resolution.
+- **Future-module path is registry-only.** Three artifacts
+  change; SKILL bodies and hook code stay untouched. The
+  pluggable-module promise becomes architecturally enforced
+  rather than convention-dependent.
+- **Mirrors mature industry pattern.** VSCode `settings.json`
+  (prefix-namespaced — `editor.x` / `python.x` / `git.x`),
+  Helm `values.yaml` (chart-namespaced sections), Kubernetes
+  API groups, Cargo features / Bazel BUILD files all
+  converge on the same shape.
+
+### Negative
+
+- **Two writes per stage completion.** SKILL writes both
+  `stages_completed[]` and `modules.<id>` atomically — a few
+  extra YAML lines plus a projection-rebuild step;
+  negligible at this file size.
+- **Hand-edit divergence detection adds a SKILL step.** Every
+  re-entry compares projection vs. source-of-truth and
+  prompts on divergence. The alternative (silent
+  re-derivation overwriting architect edits) is worse.
+- **Module naming convention is one more rule.**
+  `m{number}_{snake_case}` adds discipline overhead;
+  mitigated by ADR-0014's JSON Schema gate at PR time.
+
+## Alternatives considered
+
+### α — Two-section split + per-module `schema_version` (chosen)
+
+Single file, two sections, one authoritative + one derived,
+per-module schema axis. Matches VSCode / Helm / K8s industry
+pattern.
+
+### β — Single flat structure (no module sections)
+
+Rejected. Mixes machine view (`stages_completed[]`
+fingerprints) with architect view (config items) — architects
+mentally filter lifecycle bookkeeping out of every read.
+Module schema migration also collapses onto the file-level
+`schema_version`, forcing co-evolution when any one bumps.
+The v0.4.0 `state.yml` carried this shape; the redesign
+exists in part to fix it.
+
+### γ — Multi-file (one settings file per module per locality)
+
+Rejected. Splitting by module yields ~10 modules × 4 localities
+= 40 settings files for a fully-bootstrapped repo. IDE
+navigation, `grep` across configuration, and human reading all
+suffer at that fan-out; cross-module reads become multi-file
+aggregations instead of single-file scans.
+
+### δ — Make `modules.<id>` authoritative + derive `stages_completed[]`
+
+Rejected. The fingerprint is lifecycle metadata —
+registry-derived machine fields, not architect-edited.
+Putting it under `modules.<id>` either pollutes the
+architect view or forces lifecycle recomputation on every
+read. Two authoritative sources (architect-edited
+`modules.<id>` + machine-recomputed lifecycle) would also
+drift the moment an architect saved an out-of-date buffer.
+
+## Notes
+
+Second of two structural moves giving the redesign its
+architect-facing shape: ADR-0013 partitioned the file family
+by locality; this ADR fixes each file's internal layout.
+Together they deliver "one mental model, one filename
+family, one in-file shape" across all four non-`external`
+localities. The default `module_section_path` (derive
+`modules.<m{N}_{name}>` from the stage's Axis-C `module`
+field) is sufficient for v1; the field exists for the rare
+case where a stage projects into a sibling module's section
+(none at v1).
+
+## Related
+
+- [ADR-0013](./0013-declarative-state-schema-and-lifecycle.md)
+  — Per-stage entry shape this ADR places into
+  `stages_completed[]`.
+- [ADR-0014](./0014-stage-registry-contract.md) — Defines
+  `module_section_path` and the JSON Schema gate validating
+  the module naming convention at load time.
+- ADR-0012 — Unified check-script trigger model. Hook reads
+  Section 1 only; the projection (Section 2) is never read
+  by the hook.
+- ADR-0017 — I-13 invariant revision; per-locality file
+  partitioning relies on the `(host, GitHub repo)`
+  repo-identity scheme.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  § "Declarative state schema" → "Settings modular layering"
+  / "Why both sections" / "Per-module schema versioning" /
+  "Module naming convention" / "Future-module inclusion
+  procedure" — authoritative references.
+- [`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+  — Migration policy (versioned-and-additive, lazy-on-read)
+  per-module `schema_version` evolution inherits.

--- a/docs/architecture/adr/0022-boardadapter-capability-dispatch.md
+++ b/docs/architecture/adr/0022-boardadapter-capability-dispatch.md
@@ -1,0 +1,200 @@
+# ADR 0022: BoardAdapter capability dispatch (M3 stages route via BoardAdapter capabilities) + M10 BoardAdapter-selection module
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+[ADR-0005](./0005-board-adapter-contract.md) committed the
+BoardAdapter contract as the seam every backend (GitHub Project
+v2, future Linear / Jira) must implement against. ADR-0005's
+own Notes call out the honesty gap: the contract ships as
+design intent, but the reference implementation is not yet
+refactored to call through a `BoardAdapter` interface.
+
+At v0.4.0 the bootstrap surface concretizes that gap. The two
+M3 stages — `m3.repo.ensure-labels` and
+`m3.repo.validate-status-field` — inline `gh` CLI invocations
+directly in their executor scripts. The stage registry has no
+notion of which backend the repo uses; both stages run
+unconditionally on every bootstrapped repo and silently presume
+GitHub Project v2. Three implicit assumptions fall out: backend
+identity is fixed (nothing records the architect's choice or
+dispatches on it); stages own backend knowledge ("swap in a
+Linear adapter" requires editing every M3 stage's executor);
+and there is no skip path for non-applicable backends.
+
+The bootstrap-surface redesign
+([`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md))
+closes this gap with two structural shifts: the `not-applicable`
+lifecycle state (per ADR-0020) gives stages a clean skip path,
+and the `applicable_when` predicate field on the stage registry
+lets each stage declare its conditions declaratively. M3 needs
+a predicate vocabulary and a selection seam to turn ADR-0005's
+"design intent" into a runtime dispatch surface.
+
+## Decision
+
+Two coupled additions land together:
+
+**(1) New module M10 — BoardAdapter selection.** A standalone
+module whose sole stage `m10.repo.choose-kanban-backend`
+(agentic, `repo-git` locality, `confirm-only` flag) elicits the
+architect's choice of board backend at first-time bootstrap and
+persists it into the repo-git settings file. The v0.5.0 enum
+contains exactly one option, `github-project-v2` (single-choice
+confirmation). Future `linear` / `jira` options land via
+registry-only enum extension; each option's `introduced_in`
+metadata gates re-prompt so existing repos are not asked again
+when the enum grows.
+
+**(2) M3 stages re-architect to dispatch through BoardAdapter
+capabilities.** The M3 module is renamed "Board operations
+(BoardAdapter-driven)". Each M3 stage carries an
+`applicable_when: {board_capability: <name>}` predicate (the
+declarative capability-check form added per ADR-0020). Each
+BoardAdapter implementation declares which capabilities it
+supports — the v0.5.0 GitHub-Project-v2 adapter declares
+`[ensure-labels, status-field-schema]`, exactly matching the
+two shipped M3 stages. The evaluator resolves each predicate
+by looking up M10's recorded `kanban_backend`, finding the
+matching adapter, and asking whether the named capability is
+declared. M3 stages depend on `m10.repo.choose-kanban-backend`
+so the backend is selected before any board operation runs.
+
+Concretely: each M3 stage's executor calls
+`BoardAdapter.<capability>()` instead of inline `gh` commands —
+the v0.5.0 GitHub-Project-v2 adapter delegates internally to
+`gh`; future adapters delegate to their own backends; the stage
+code knows nothing about backend identity. A future Linear
+adapter declaring `[ensure-labels]` only would let
+`m3.repo.ensure-labels` run normally while
+`m3.repo.validate-status-field` evaluates `applicable_when` to
+false → returns `not-applicable` per ADR-0020 → silently
+skipped (no marker, no executor invoked). An adapter declaring
+neither capability turns the entire M3 module into a no-op for
+that repo, with the skip reason visible in the lifecycle audit.
+
+## Consequences
+
+### Positive
+
+- **ADR-0005 becomes a runtime dispatch surface, not just a
+  design-intent contract.** M3 executors call into the
+  `BoardAdapter` interface; a second-adapter author has a
+  concrete dispatch entry point (the `applicable_when`
+  predicate plus the per-capability method) to implement
+  against.
+- **Adding a new backend is purely declarative.** A new adapter
+  registers in the M10 enum and declares its capability set; no
+  M3 stage edits required. Capability-matching scales with
+  adapter count, not stage count.
+- **Skip surfaces are observable.** `not-applicable` states
+  produced by capability mismatch flow through the same
+  lifecycle audit as any other state per ADR-0020 — the skip
+  reason is visible in bootstrap summaries.
+- **M3 module name now matches its character.** Rename from the
+  implicit "GitHub Project v2 operations" to "Board operations
+  (BoardAdapter-driven)" eliminates v0.4.0 naming debt.
+
+### Negative
+
+- **One additional agentic stage at first-time bootstrap.** The
+  architect now confirms a single-choice prompt
+  (`m10.repo.choose-kanban-backend`) that has only one option
+  at v0.5.0 — the seam exists for future expansion but at
+  v0.5.0 adds one extra interaction with no visible payoff.
+  Mitigated by treating it as a confirmation, not a decision
+  (default pre-selected; press enter).
+- **Capability declarations become a contract surface.** Adding
+  or renaming a capability requires coordinated edits across
+  every adapter declaring it and every M3 stage requiring it.
+  ADR-0005 supersession governs vocabulary changes; per-adapter
+  capability lists follow the same immutability discipline as
+  the contract surface.
+- **`applicable_when` evaluator depends on M10 having run.**
+  Encoded as `depends_on: [m10.repo.choose-kanban-backend]` on
+  every M3 stage — ADR-0012's topological executor enforces
+  ordering.
+
+## Alternatives considered
+
+**Per-backend stage families (`M3-GitHub` / `M3-Linear` /
+`M3-Jira` as separate modules).** Rejected. The registry gains
+N row families for one operational surface every time a backend
+is added — N independently-drifting codebases, the exact tech
+debt the redesign eliminates elsewhere (per ADR-0012's
+single-mechanism principle). Capability dispatch keeps M3 one
+module and shifts variance into the adapters where it belongs.
+
+**Backend-name matching via
+`applicable_when: {kanban_backend: github-project-v2}`.**
+Rejected. Couples the stage definition to backend identifiers —
+a future Linear adapter would require editing every M3 stage's
+`applicable_when` to add `linear` to the allowed list, even
+when Linear happens to support the same operation.
+Capability-matching inverts the dependency: adapters declare
+what they can do; stages declare what they need; the predicate
+resolves through that declaration. New adapters add capability
+declarations, never stage edits.
+
+**Inline backend dispatch in the executor (status quo at
+v0.4.0).** Rejected. Per ADR-0020's argument that
+`not-applicable` must surface through the lifecycle, hidden
+dispatch means the lifecycle cannot distinguish "ran and
+succeeded" from "skipped because inapplicable" — no skip
+reason, no audit entry, no surfacing in bootstrap summaries.
+Pushing backend-conditional behavior into the executor hides it
+from every observation surface the redesign exists to produce.
+
+**Bake capability declaration into ADR-0005 method
+signatures.** Considered. ADR-0005 could declare a
+`capabilities` enum on the BoardAdapter base class itself.
+Rejected as out-of-scope — ADR-0005 is immutable-modulo-
+supersession and the v1 contract surface is intentionally small.
+The capability mechanism lives in the adapter implementation
+layer (each adapter exposes `get_capabilities() -> set[str]`)
+and is consulted by the `applicable_when` evaluator, not by
+the public method surface. A future supersession candidate once
+second-adapter experience informs the right vocabulary.
+
+## Notes
+
+- Capability vocabulary at v0.5.0 is two strings
+  (`ensure-labels`, `status-field-schema`), matching M3 stages
+  1:1 because v0.5.0 has only the GitHub-Project-v2 adapter.
+  Registry-internal — no external surface depends on it — so
+  renames are cheap until a second adapter ships.
+- M10's single-option enum at v0.5.0 is intentional: the
+  agentic prompt + persisted-choice infrastructure ships now;
+  enum width is what future ADRs expand. Shipping the seam at
+  width-1 makes width-2 a registry-only edit later.
+- The M3-executor refactor (inline `gh` → `BoardAdapter`
+  calls) is bundled with ADR-0005's wrapper-port commitment
+  ("wrapper port lands before v1 GA"). This ADR formalizes the
+  dispatch surface; the wrapper-port PR delivers the
+  implementation.
+
+## Related
+
+- [ADR-0005](./0005-board-adapter-contract.md) — The
+  BoardAdapter contract this ADR turns into a runtime dispatch
+  surface; capability declarations layer on top of the v1
+  method surface without altering it.
+- ADR-0001 — Pluggable board backend; the architectural
+  commitment this ADR makes observable at runtime.
+- ADR-0020 — Stage applicability + `not-applicable` lifecycle
+  state; defines the predicate forms (including the
+  declarative capability-check form) and the surfacing
+  semantics this ADR's M3 stages depend on.
+- ADR-0012 — Unified check-script trigger model; the
+  topological executor that honors the
+  `depends_on: [m10.repo.choose-kanban-backend]` edge.
+- ADR-0013 / ADR-0014 — Lifecycle state schema + stage
+  registry contract; carry the `applicable_when` field
+  populated on M3 rows.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — Living design doc; § "Functional modules" M3 + M10 and
+  § "Stages" M3 + M10 rows are this ADR's authoritative
+  reference.

--- a/docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md
+++ b/docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md
@@ -20,9 +20,10 @@ be added by editing the SKILL. Three structural costs follow:
    items as the catalog grows.
 2. **No SPOT for "did we already ask this?".** Each prompt path
    answers it its own way (file-presence check, field test,
-   hand-rolled "needs setup" flag). ADR-0013's 4-state
-   lifecycle already answers it generically, but the v0.4.0
-   prompt paths predate the lifecycle and do not consume it.
+   hand-rolled "needs setup" flag). ADR-0013's lifecycle (4-state
+   when first sketched; extended to 5-state by ADR-0020) already
+   answers it generically, but the v0.4.0 prompt paths predate
+   the lifecycle and do not consume it.
 3. **"Skip" was contemplated as a fifth lifecycle state.** Early
    redesign drafts considered a `skipped` / `deferred` state for
    "architect declined to configure this item" — a concession to
@@ -97,11 +98,11 @@ no SKILL prompt code is written per item.
    plus required-or-optional, default, and enum option list
    with `introduced_in_version` per option for graceful
    enum-bump compatibility.
-2. **Detection** — the lifecycle 4-state model (per ADR-0013)
-   computes whether the item needs eliciting. `never-run` /
-   `stale` ⇒ elicit; `completed` ⇒ skip; `deprecated` /
-   `not-applicable` ⇒ ignore. No bespoke "is this set?" code
-   per item.
+2. **Detection** — the lifecycle 5-state model (per ADR-0013
+   + ADR-0020) computes whether the item needs eliciting.
+   `never-run` / `stale` ⇒ elicit; `completed` ⇒ skip;
+   `deprecated` / `not-applicable` ⇒ ignore. No bespoke "is
+   this set?" code per item.
 3. **Interaction** — a new `interactive_prompt` registry field
    declares the prompt template + kind (single-choice /
    multi-choice / free-text / boolean / numeric-range) +
@@ -126,9 +127,9 @@ no SKILL prompt code is written per item.
 
 An empty / null / "no presets selected" choice is itself a valid
 `target_state` value (when the schema permits empty list / null)
-and produces `completed`. The 4-state lifecycle covers all
-observable architect states; no `skipped` / `deferred` state is
-introduced.
+and produces `completed`. The 5-state lifecycle (ADR-0013 +
+ADR-0020) covers all observable architect states; no `skipped` /
+`deferred` state is introduced.
 
 ### Future-feature inclusion procedure
 
@@ -230,19 +231,27 @@ empty `target_state`."
 
 - ADR-0012 — unified check-script trigger model; emits the
   `INVOKE: bootstrapping-repo` marker the SKILL consumes.
-- ADR-0013 — 4-state lifecycle; supplies the detection element
-  (item 2) and re-prompt trigger element (item 5).
+- ADR-0013 — 5-state lifecycle (extended from 4 by ADR-0020);
+  supplies the detection element (item 2) and re-prompt trigger
+  element (item 5).
 - ADR-0014 — stage registry contract; supplies the schema
   declaration element (item 1) and absorbs the new
   `interactive_prompt` field for the interaction element
   (item 3).
+- ADR-0020 — Stage applicability + `not-applicable` 5th
+  lifecycle state; combined with ADR-0013 forms the lifecycle
+  detection surface this protocol's element 2 consumes; clarifies
+  that `not-applicable` is unrelated to skip semantics (see Notes
+  above).
 - ADR-0021 — settings layering; supplies the persistence
-  element (item 4) by mapping `locality` to settings file.
-- ADR-0022 — partitioned settings files; the file-level
-  contract the persistence step writes into.
-- ADR-0024 — pre-v1 breaking changes; the rename of v0.4.0
-  plumbing names that the protocol's persistence file paths
-  consume.
+  element (item 4) by mapping `locality` to settings file
+  internal layout (two-section split + `modules.<id>`
+  projection).
+- ADR-0024 — settings.yml rename + new config-item stages;
+  the pre-v1 file-naming change that the protocol's persistence
+  file paths consume, plus the two new stages
+  (`m5.repo.set-wip-limit`, `m10.repo.choose-kanban-backend`)
+  that exemplify the protocol.
 - [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
   § "Architect UX" — authoritative reference for the reframe,
   the sequential flow, the 5-element protocol, the

--- a/docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md
+++ b/docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md
@@ -1,0 +1,250 @@
+# ADR 0023: Architect UX — sequential per-stage flow + 5-element config item protocol
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+At v0.4.0 the `bootstrapping-repo` SKILL handles every
+architect-facing input through a bespoke prompt path baked into
+the SKILL body. Each input — audit DSN scheme, autonomy override
+presets, kanban backend, WIP limit — has its own inline prompt
+code. There is no shared protocol for "the plugin needs the
+architect to make a configuration choice"; new items can only
+be added by editing the SKILL. Three structural costs follow:
+
+1. **Per-item bespoke UX cost.** Every new architect-facing
+   feature requires SKILL code changes — its own prompt string,
+   validation, and persistence call; UX drifts subtly across
+   items as the catalog grows.
+2. **No SPOT for "did we already ask this?".** Each prompt path
+   answers it its own way (file-presence check, field test,
+   hand-rolled "needs setup" flag). ADR-0013's 4-state
+   lifecycle already answers it generically, but the v0.4.0
+   prompt paths predate the lifecycle and do not consume it.
+3. **"Skip" was contemplated as a fifth lifecycle state.** Early
+   redesign drafts considered a `skipped` / `deferred` state for
+   "architect declined to configure this item" — a concession to
+   the bespoke-prompt mental model where each path carries an
+   implicit "skip me" branch.
+
+Per
+[`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+§ "Architect UX", the architect's interaction with bootstrap
+**is** the interactive configuration surface for the plugin.
+Every architect-facing item is the same shape of operation —
+elicit a structured choice, validate, persist. The redesign
+formalizes that operation as a protocol so future plugin
+versions add new items by registry edit, not SKILL edit.
+
+## Decision
+
+The `bootstrapping-repo` SKILL processes pending agentic stages
+**sequentially** — one at a time, in topological order by
+`depends_on` — and every architect-facing decision is mediated
+by an agentic stage that satisfies a fixed **5-element config
+item protocol**.
+
+### Reframe — agentic stage = config-item elicitation flow
+
+A bootstrap stage's `character: agentic` (per Axis A) means
+exactly: this stage requires architect input to compute its
+`target_state`. From the architect's vantage point that input
+is "make a configuration choice"; from the runtime's vantage
+point it is "fill in this stage's `target_state` so the
+lifecycle flips to `completed`". The two perspectives describe
+the same operation with the same persistence and the same
+lifecycle. There is no separate "settings" UX — agentic stages
+**are** the settings UX.
+
+### Sequential per-stage flow
+
+The hook emits `INVOKE: bootstrapping-repo / REASON: <N> stages
+need running` (per ADR-0012). The SKILL reads partitioned
+settings files, recomputes the lifecycle diff, topologically
+orders pending stages by `depends_on`, and iterates them one at
+a time:
+
+- **Automated**: invokes the executor via `Bash` autonomously;
+  records completion.
+- **Agentic**: renders the stage's `interactive_prompt` by kind
+  (single-choice / multi-choice / free-text / boolean /
+  numeric-range); validates the response against
+  `target_state_schema`; persists `target_state`; marks
+  completed.
+- **Agentic, architect unreachable** (CI, scripted env):
+  records `status: pending-architect-input`; stage stays pending
+  until next session.
+
+The SKILL emits a final summary (completed / dependency-blocked /
+pending-architect-input counts). Architects interrupting
+mid-flow resume from lifecycle state on the next session — the
+lifecycle model (ADR-0013) **is** the resume primitive; there is
+no wizard restart.
+
+### 5-element config item protocol
+
+Every architect-facing config item is encoded as an agentic
+stage that satisfies all five elements. New plugin features add
+a registry entry plus per-stage Python helpers (per ADR-0014);
+no SKILL prompt code is written per item.
+
+1. **Schema declaration** — the stage's `target_state_schema`
+   field (per ADR-0014) declares the shape of the architect's
+   choice (e.g., `{wip_limit: int (1..20)}`,
+   `{kanban_backend: enum [github-project-v2, linear, jira]}`)
+   plus required-or-optional, default, and enum option list
+   with `introduced_in_version` per option for graceful
+   enum-bump compatibility.
+2. **Detection** — the lifecycle 4-state model (per ADR-0013)
+   computes whether the item needs eliciting. `never-run` /
+   `stale` ⇒ elicit; `completed` ⇒ skip; `deprecated` /
+   `not-applicable` ⇒ ignore. No bespoke "is this set?" code
+   per item.
+3. **Interaction** — a new `interactive_prompt` registry field
+   declares the prompt template + kind (single-choice /
+   multi-choice / free-text / boolean / numeric-range) +
+   options-source (literal list, computed-from-
+   `target_state_schema.enum`, or runtime-derived). The SKILL
+   ships a single generic prompt-renderer that consumes the
+   declaration and produces the architect-facing question.
+4. **Persistence** — the stage's `locality` (Axis B; per
+   ADR-0021's settings layering) decides which of the four
+   `settings.yml` files receives the resolved `target_state`
+   (`host-shared` / `repo-shared` / `repo-git` / `repo-clone`).
+   Atomic `mktemp + mv` write.
+5. **Re-prompt trigger** — three triggers, all derived from the
+   lifecycle: (a) plugin upgrade bumps `generation` → `stale` →
+   re-prompt; (b) manual settings-file edit fails
+   `target_state_schema` validation at load time → `stale` →
+   re-prompt; (c) explicit `scripts/bsp-stage-rerun.sh
+   <stage_id>` forces the stage to `never-run`. No new
+   re-prompt mechanism is introduced.
+
+### Skip semantics are eliminated
+
+An empty / null / "no presets selected" choice is itself a valid
+`target_state` value (when the schema permits empty list / null)
+and produces `completed`. The 4-state lifecycle covers all
+observable architect states; no `skipped` / `deferred` state is
+introduced.
+
+### Future-feature inclusion procedure
+
+When a future plugin version introduces a new feature that needs
+architect input: (1) author the new agentic stage's registry
+entry in `scripts/stages-registry.yml`, filling all five
+protocol elements; (2) author the per-stage Python helpers in
+`scripts/stages_lib/<stage_id>.py` per ADR-0014; (3) bump the
+SKILL test fixture so the prompt-renderer + persistence path is
+regression-tested. **No SKILL or hook code changes are
+required** — the prompt-renderer reads the new stage's
+`interactive_prompt` declaration and renders the question
+generically.
+
+## Consequences
+
+### Positive
+
+- **Adding a config item is a registry edit + Python helpers,
+  not a SKILL feature.** The per-feature bespoke-UX cost the
+  redesign exists to eliminate is structurally removed.
+- **Mid-flow resume is free.** Sequential iteration over the
+  lifecycle's pending list means an architect closing a session
+  mid-bootstrap returns to a partial state with no bookkeeping;
+  the next hook tick recomputes the diff and the SKILL picks up
+  from the next pending stage.
+- **One prompt-renderer, one persistence path.** UX drift
+  across config items is structurally prevented.
+- **No fifth lifecycle state for skip semantics.** Skip
+  collapses into a valid `target_state`; ADR-0013's compact
+  lifecycle is preserved.
+
+### Negative
+
+- **`interactive_prompt` is a new registry field.** ADR-0014's
+  contract grows by one declarative field; the JSON Schema gate
+  absorbs the new validation rule.
+- **Generic prompt-renderer is a constraint.** Stages wanting
+  non-standard interaction shapes (e.g., dynamic multi-step
+  flows) cannot be expressed by the protocol's five prompt
+  kinds. Intentional — non-standard UX is exactly the per-item
+  drift the protocol prevents — but truly non-standard
+  interactions would force a protocol extension.
+- **Architect cannot "skip" by intent.** Every agentic stage is
+  elicited until its `target_state` lands. Architects wanting
+  to defer must use `applicable_when` predicates (lifecycle
+  `not-applicable`) or accept the schema's permitted empty
+  default; there is no "remind me later" bucket.
+
+## Alternatives considered
+
+### α — Sequential per-stage flow + 5-element config item protocol (chosen). The decision above.
+
+### β — Batch wizard (all decisions presented upfront)
+
+Rejected. A batch wizard front-loads every pending decision into
+one continuous flow. Two problems: it fragments the lifecycle
+resume primitive — a mid-flow interrupt loses partial progress
+because the wizard owns transient state outside the lifecycle's
+per-stage entries — and a single failure (architect closes the
+session, schema validation rejects one answer) aborts the whole
+wizard and forces a restart. The sequential model lets each
+stage's completion land independently; interruption costs at
+most the in-progress stage.
+
+### γ — Bespoke prompt code per agentic stage (status quo at v0.4.0)
+
+Rejected. The model the redesign exists to replace. Each stage
+carries its own prompt string, validation, and persistence
+call; UX drifts subtly across items; adding a new
+architect-facing item requires SKILL code change. The protocol
+exists exactly to retire this drift surface.
+
+### δ — Separate "skipped" lifecycle state for opt-out semantics
+
+Rejected. A fifth state purely to express "architect declined
+to configure this" duplicates what the schema already permits.
+Empty-list / null / "no presets selected" are valid
+`target_state` values when the schema allows; producing
+`completed` from such a value is the correct semantic. A
+`skipped` state would force every prompt-renderer and every
+settings consumer to handle "not really configured but also not
+pending" — a synthetic distinction with no operational meaning.
+
+## Notes
+
+The 5th lifecycle state `not-applicable` (per the redesign's
+`applicable_when` predicate decision) is unrelated to skip
+semantics. `not-applicable` is computed from predicate
+evaluation (e.g., M3 GitHub-Project stages become
+`not-applicable` when the architect chooses Linear via
+`m10.repo.choose-kanban-backend`); no architect interaction is
+required or offered. Skip semantics, by contrast, would have
+expressed "architect declined to interact with a stage that
+**is** applicable" — the protocol replaces that with "valid
+empty `target_state`."
+
+## Related
+
+- ADR-0012 — unified check-script trigger model; emits the
+  `INVOKE: bootstrapping-repo` marker the SKILL consumes.
+- ADR-0013 — 4-state lifecycle; supplies the detection element
+  (item 2) and re-prompt trigger element (item 5).
+- ADR-0014 — stage registry contract; supplies the schema
+  declaration element (item 1) and absorbs the new
+  `interactive_prompt` field for the interaction element
+  (item 3).
+- ADR-0021 — settings layering; supplies the persistence
+  element (item 4) by mapping `locality` to settings file.
+- ADR-0022 — partitioned settings files; the file-level
+  contract the persistence step writes into.
+- ADR-0024 — pre-v1 breaking changes; the rename of v0.4.0
+  plumbing names that the protocol's persistence file paths
+  consume.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  § "Architect UX" — authoritative reference for the reframe,
+  the sequential flow, the 5-element protocol, the
+  future-feature inclusion procedure, the settings file
+  naming, and the failure surfaces.

--- a/docs/architecture/adr/0024-settings-rename-and-config-item-stages.md
+++ b/docs/architecture/adr/0024-settings-rename-and-config-item-stages.md
@@ -191,7 +191,7 @@ unless the change introduces architectural-grade decisions.
   host-shared `settings.yml:modules.m8_autonomy`.
 - ADR-0012 — Unified check-script trigger model; the pre-v1
   delete-and-re-bootstrap posture is shared.
-- ADR-0013 — Declarative state schema + 4-state lifecycle;
+- ADR-0013 — Declarative state schema + 5-state lifecycle;
   `target_state` / `generation` / `target_state_hash` recorded
   inside each `settings.yml` follow this contract.
 - ADR-0014 — Stage registry contract; both new stages are

--- a/docs/architecture/adr/0024-settings-rename-and-config-item-stages.md
+++ b/docs/architecture/adr/0024-settings-rename-and-config-item-stages.md
@@ -1,0 +1,210 @@
+# ADR 0024: settings.yml rename + new config-item stages (`m5.repo.set-wip-limit`, `m10.repo.choose-kanban-backend`)
+
+**Status:** proposed
+**Date:** 2026-04-28
+**Deciders:** PanQiWei (architect)
+
+## Context
+
+Two related decisions emerge from the v0.5.0 bootstrap redesign
+(per
+[`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md))
+sharing the "redesign the architect-facing settings surface"
+context. Bundling keeps review pair-programmed — the rename
+rationale alongside the first two stages that consume it.
+
+**Part A — settings file naming.** v0.4.0 ships **four
+plumbing files with four different names**: host-shared
+`manifest.yml`, repo-shared `state.yml`, repo-git `config.yml`,
+repo-clone `config.local.yml`, plus `~/.board-superpowers/overrides.yml`
+holding host-shared autonomy presets per ADR-0006. The
+disparate naming reflects implementation history (each file
+landed in a different release window with whichever name fit
+at the time), not architectural meaning.
+
+**Part B — two new config-item stages.** Today's WIP limit
+lives only as a hard-coded default inside the consuming-card
+SKILL — no per-repo elicitation surface exists. ADR-0005's
+BoardAdapter contract describes a backend selection seam but
+v0.4.0 hard-codes GitHub-Project-v2 throughout M3 with no
+first-class "this repo uses backend X" declaration. Both gaps
+are blocked on the same prerequisite: a uniform place to put
+architect-facing config items, governed by a uniform
+elicitation protocol. ADR-0023 ships the protocol; this ADR
+ships the file-naming unification (Part A) and the two
+exemplar stages (Part B) that consume it.
+
+## Decision
+
+### Part A — rename to the `settings.yml` family
+
+Rename the four v0.4.0 plumbing files to a unified
+`settings.yml` family per locality, and fold `overrides.yml`
+content into the host-shared `settings.yml` under
+`modules.m8_autonomy`:
+
+| v0.4.0 path | v0.5.0 path | Locality |
+|-------------|-------------|----------|
+| `~/.board-superpowers/manifest.yml` | `~/.board-superpowers/settings.yml` | host-shared |
+| `~/.board-superpowers/overrides.yml` | folded into `~/.board-superpowers/settings.yml` `modules.m8_autonomy` | host-shared |
+| `~/.board-superpowers/repos/<repo-identity>/state.yml` | `~/.board-superpowers/repos/<repo-identity>/settings.yml` | repo-shared |
+| `<repo>/.board-superpowers/config.yml` | `<repo>/.board-superpowers/settings.yml` | repo-git |
+| `<repo>/.board-superpowers/config.local.yml` | `<repo>/.board-superpowers/settings.local.yml` | repo-clone |
+
+`~/.board-superpowers/repos/<repo-identity>/credentials.yml`
+**remains a separate file** (mode 0600) for secret isolation —
+the `settings.yml` family is mode 0644, so DSNs / tokens /
+passwords MUST NOT live in it.
+
+This is a **pre-v1 breaking rename** (mirroring ADR-0012). No
+in-place migration logic ships; architects upgrading from
+v0.4.0 delete legacy host-local state and re-bootstrap on
+first v0.5.0 session.
+
+**Boundary with ADR-0021**: ADR-0021 defines the **internal
+structure** of each `settings.yml` (two-section split + module
+namespacing + per-module `schema_version`). This ADR scopes
+only the **file naming** — what the four files are called and
+where they live.
+
+### Part B — two new agentic stages
+
+Both stages exemplify the ADR-0023 5-element config item
+protocol; both persist via Axis B locality into the
+appropriate `settings.yml` from Part A; both re-prompt via the
+ADR-0013 lifecycle.
+
+**`m5.repo.set-wip-limit`** — module M5, agentic
+(`confirm-only`), locality `repo-clone`. Schema
+`{wip_limit: int}`, default `5`, validation kind
+`numeric-range` (1..20); architect may accept the default to
+advance. Persists into
+`<repo>/.board-superpowers/settings.local.yml:modules.m5_repo_configuration.wip_limit`.
+
+**`m10.repo.choose-kanban-backend`** — module M10, agentic
+(`confirm-only`, `single-choice-currently`), locality
+`repo-git` (committed into git so every clone agrees on which
+backend M3 talks to). Schema
+`{kanban_backend: enum [github-project-v2]}`, validation kind
+`single-choice`. v0.5.0 enum has exactly one option; future
+Linear / Jira options land via registry-only enum extension
+(each option carries `introduced_in_version` per ADR-0023 so
+additive enum bumps don't gratuitously re-prompt repos that
+already picked an extant option). Persists into
+`<repo>/.board-superpowers/settings.yml:modules.m10_kanban.backend`.
+
+**Boundary with ADR-0022**: ADR-0022 governs the **capability
+dispatch behavior** of the chosen backend (M3 stages reading
+`BoardAdapter.<capability>()`, `applicable_when:
+board_capability=...` predicates). This ADR scopes only the
+**stage's existence** + its **persistence target** — where the
+choice is recorded so ADR-0022's dispatch logic has a
+deterministic input to read.
+
+## Consequences
+
+### Positive
+
+- **One filename family, one suffix variant.** `settings.yml`
+  + `.local.yml` replace five history-named files; cognitive
+  load drops from "five names" to "one name + locality
+  routing".
+- **Settings discovery is uniform** — "Where is X configured?"
+  is answered by Axis B locality alone, pairing cleanly with
+  ADR-0023 element 4 ("Persistence by locality").
+- **WIP limit becomes a real config item** — today's
+  hard-coded default disappears; per-repo customization works
+  through the same elicitation surface as every other knob.
+- **BoardAdapter selection has a home** — ADR-0005's contract
+  finally has a deterministic place to read its input from;
+  ADR-0022's dispatch logic does not have to invent one.
+
+### Negative
+
+- **Pre-v1 breaking rename** — every architect upgrading from
+  v0.4.0 deletes legacy state + re-bootstraps; no transitional
+  dual-name window. Mitigated by v0.4.0 being pre-v1 and the
+  breaking-change posture already accepted in the design doc.
+- **`overrides.yml` re-elicitation** — the fold to
+  `settings.yml:modules.m8_autonomy` causes M8 to re-prompt
+  on first v0.5.0 session. Mitigated by M8's "no presets,
+  skip" default (one-keystroke re-confirm).
+- **Two more stages in the registry** — both declarative-only
+  (registry entry + `stages_lib/<stage_id>.py` helpers per
+  ADR-0014), no per-stage SKILL code.
+
+## Alternatives considered
+
+### α — Rename + new stages bundled in one ADR (chosen)
+
+Both halves share the "v0.5.0 redesign the settings surface"
+motivation; reviewers benefit from seeing the rename rationale
+alongside the two stages that consume it.
+
+### β — Keep v0.4.0 plumbing names
+
+Rejected. Four different filenames for four locality variants
+is unhelpful disparate-naming-by-history. Architects already
+remember Axis B locality to know **which** file holds their
+setting; making them also remember **which name** at that
+locality doubles cognitive cost without adding signal.
+
+### γ — Add the new stages to v0.4.0 names without renaming
+
+Rejected. Writing `m5.repo.set-wip-limit` into
+`config.local.yml` while ADR-0023 calls it "settings
+persistence by locality" produces immediate documentation
+drift. Pre-v1 is the right window to rename — small user
+population, no semver compatibility contract exists, and every
+other v0.5.0 redesign decision already requires re-bootstrap.
+
+### δ — Bundle Part A and Part B into separate ADRs
+
+Rejected. Part A's rename motivates Part B's persistence target;
+Part B's stages exemplify why the rename matters. Splitting
+forces the reader to hold one decision in their head while
+reviewing the other.
+
+## Notes
+
+Two-name boundaries within the v0.5.0 ADR series:
+
+- **ADR-0021** = internal structure of each `settings.yml`;
+  this ADR = file naming.
+- **ADR-0022** = capability dispatch behavior of the chosen
+  backend; this ADR = selection stage existence + persistence
+  target.
+- **ADR-0023** = 5-element config item protocol; this ADR's
+  two new stages are exemplar consumers (they fill in the
+  protocol's five elements but do not modify the protocol).
+
+Future extensions to either new stage (e.g., `wip_limit_per_user`,
+a Linear backend) are **registry edit + helpers update** per
+ADR-0014 and ADR-0023's future-feature procedure — no new ADR
+unless the change introduces architectural-grade decisions.
+
+## Related
+
+- ADR-0005 — BoardAdapter contract; v0.5.0 enum
+  `[github-project-v2]` is its v1 reference adapter.
+- ADR-0006 — Autonomy boundary; `overrides.yml` folds into
+  host-shared `settings.yml:modules.m8_autonomy`.
+- ADR-0012 — Unified check-script trigger model; the pre-v1
+  delete-and-re-bootstrap posture is shared.
+- ADR-0013 — Declarative state schema + 4-state lifecycle;
+  `target_state` / `generation` / `target_state_hash` recorded
+  inside each `settings.yml` follow this contract.
+- ADR-0014 — Stage registry contract; both new stages are
+  authored against this contract.
+- ADR-0021 — Settings modular layering; defines the **internal
+  structure** of the files this ADR renames.
+- ADR-0022 — BoardAdapter capability dispatch; consumes the
+  selection persisted by `m10.repo.choose-kanban-backend`.
+- ADR-0023 — Architect UX + config item protocol; both new
+  stages exemplify it.
+- [`../0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](../0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
+  — § "Declarative state schema" → "Four settings files",
+  § "Stages" rows, § "Decided" resolution items.
+- [`../0005-contracts/03-config-schemas.md`](../0005-contracts/03-config-schemas.md)
+  — settings-file schema contract; updated in the replacement
+  PR to reflect the rename + folded `overrides.yml`.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -78,3 +78,16 @@ Omit if no such notes apply.
 | [0009](./0009-allow-sqlite-as-byo-audit-db.md) | Allow SQLite as a BYO audit DB scheme (supersedes ADR-0006 §5 partial) | accepted |
 | [0010](./0010-re-anchor-deadlines-ai-cadence.md) | Re-anchor ADR-0005 Consequences deadlines to v1 GA + project-wide AI cadence 100x convention (supersedes ADR-0005 § Consequences partial) | accepted |
 | [0011](./0011-defer-producer-routines-to-v1x.md) | Defer Producer routines F-03..F-07 + F-10..F-15 to v1.x pending demand pull | accepted |
+| [0012](./0012-unified-check-script-trigger-model.md) | Unified check-script trigger model (absorbs `migrating-repo-version` skill) | proposed |
+| [0013](./0013-declarative-state-schema-and-lifecycle.md) | Declarative state schema + 5-state lifecycle + K8s-style three-layer fingerprint | proposed |
+| [0014](./0014-stage-registry-contract.md) | Stage registry contract — YAML metadata + Python helpers + JSON Schema validation | proposed |
+| [0015](./0015-m4-audit-per-repo-locality.md) | M4 audit module per-repo locality (replaces host-shared `credentials.yml`) | proposed |
+| [0016](./0016-cross-platform-parity-contract.md) | Cross-platform parity contract via the `platforms` field on every stage | proposed |
+| [0017](./0017-i13-invariant-revision-cross-clone-state-sharing.md) | I-13 invariant revision — cross-clone state sharing via GitHub-based identity (revises I-13 in `07-cross-cutting-invariants.md`) | proposed |
+| [0018](./0018-m7-multi-stage-routing-block-protocol.md) | M7 multi-stage per-block routing protocol with form-detect prerequisite + Codex 32 KiB AGENTS.md budget | proposed |
+| [0019](./0019-zero-config-sqlite-default-audit-backend.md) | Zero-config SQLite as default per-repo audit backend (extends ADR-0009) | proposed |
+| [0020](./0020-stage-applicability-and-not-applicable-state.md) | Stage applicability — `applicable_when` predicate + `not-applicable` 5th lifecycle state | proposed |
+| [0021](./0021-settings-modular-layering.md) | Settings modular layering — two-section split + per-module `schema_version` | proposed |
+| [0022](./0022-boardadapter-capability-dispatch.md) | BoardAdapter capability dispatch + M10 BoardAdapter-selection module | proposed |
+| [0023](./0023-architect-ux-and-config-item-protocol.md) | Architect UX — sequential per-stage flow + 5-element config item protocol | proposed |
+| [0024](./0024-settings-rename-and-config-item-stages.md) | settings.yml rename + new config-item stages (`m5.repo.set-wip-limit`, `m10.repo.choose-kanban-backend`) | proposed |

--- a/hooks/AGENTS.md
+++ b/hooks/AGENTS.md
@@ -16,6 +16,15 @@
 >    snippet generator — Codex CLI does not auto-discover
 >    `hooks/hooks.json`, so a new event without an updated
 >    register script silently breaks Codex installs.
+> 4. **If your edit touches `session-start.sh`'s lifecycle
+>    diff path** (reading partitioned settings, computing
+>    stage state, emitting `INVOKE: bootstrapping-repo`) —
+>    **also Read
+>    [`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md)**
+>    end-to-end. The hook is observation-only by contract
+>    ([ADR-0012](../docs/architecture/adr/0012-unified-check-script-trigger-model.md));
+>    violating the hook-cheap or always-exit-0 invariants
+>    silently breaks every architect's session start.
 
 This contract is the per-directory operational checklist for
 hook authoring. The full platform contract lives in
@@ -164,3 +173,7 @@ cite "invariants 1–4" as a fixed enumeration.
 - Hook intent injection pattern rationale →
   [`../docs/architecture/0004-component-architecture.md`](../docs/architecture/0004-component-architecture.md)
   § "Hook intent injection pattern".
+- `session-start.sh` lifecycle-diff path semantics
+  (registry read, three-layer fingerprint, marker emission
+  for setup-stages) →
+  [`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md).

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -11,6 +11,17 @@
 > 2. Note: this directory is for **AI-callable tools**, not
 >    user-facing CLIs. The plugin is consumed via skills /
 >    slash commands, not a dedicated CLI binary.
+> 3. **If your work touches setup-stages files** —
+>    `stages-registry.yml`, `stages_lib/**`,
+>    `stages-registry.schema.json`, `lib/_canonical.py`, or any
+>    helper consumed by the lifecycle diff — **also Read
+>    [`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md)**
+>    end-to-end before the first edit. The guide carries the
+>    judgment calls (when to add a stage vs alternatives,
+>    common axis misclassifications, the canonicalization
+>    invariant, anti-patterns) the spec doesn't encode.
+>    Same-PR contract: any change that makes the guide stale
+>    fixes the guide in this PR.
 
 This contract is the per-directory operational checklist for
 bash tooling. The full platform contract lives in
@@ -90,3 +101,6 @@ shape for intent-injection markers (see
   [`../PLUGIN_DEVELOPMENT.md`](../PLUGIN_DEVELOPMENT.md).
 - Hook-specific contracts (timeout, marker grammar) →
   [`../hooks/AGENTS.md`](../hooks/AGENTS.md).
+- Setup-stages system (registry, 5-callable contract,
+  applicable_when, settings layering, anti-patterns) →
+  [`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md).

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -190,6 +190,39 @@ When adding / removing / renaming / re-layering any skill:
   directory (e.g., skill-bundled scripts under
   `<skill>/scripts/`).
 
+## Stage-touching SKILLs — additional read
+
+If your work edits **`skills/bootstrapping-repo/`** or
+introduces a new SKILL whose body executes setup-stage
+machinery (registry walk, lifecycle diff, agentic config-item
+elicitation per [ADR-0023](../docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md)),
+**also Read [`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md)**
+end-to-end before the first edit. The Process gate above
+(skill-creator + SKILL_DEVELOPMENT.md) covers SKILL-authoring
+discipline; the setup-stages guide covers the system the SKILL
+operates against (the 5-callable contract, three axes,
+`applicable_when` forms, partitioned settings layout, anti-
+patterns). Skill-authoring discipline + setup-stages
+discipline are independent concerns — both reads are required
+when the SKILL touches stages.
+
+Concrete trigger conditions (any one suffices):
+
+- The SKILL body invokes the bootstrap stage executor or the
+  lifecycle-diff helper.
+- The SKILL writes to any of the four partitioned
+  `settings.yml` files.
+- The SKILL adds a new `action_id` that classifies a
+  setup-stage operation through `classifying-actions` /
+  `auditing-actions`.
+- The SKILL's spec changes the consumer-side contract for
+  the agentic config-item protocol (the 5 protocol elements
+  per [ADR-0023](../docs/architecture/adr/0023-architect-ux-and-config-item-protocol.md)).
+
+Same-PR contract: any SKILL change that makes
+[`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md)
+or [`../SKILLS.md`](../SKILLS.md) stale fixes both in this PR.
+
 ## Where the long-form rules live
 
 This file is intentionally the per-directory checklist, not
@@ -204,3 +237,7 @@ the manual. For:
 - Subagent / Mode-2 orchestration constraints (`max_depth=1`,
   procedural fallback patterns, `Agent` tool use) →
   [`../MULTI_AGENT_DEVELOPMENT.md`](../MULTI_AGENT_DEVELOPMENT.md).
+- Setup-stages system (when the SKILL operates against
+  stages — registry, 5-callable contract, agentic config-item
+  protocol, partitioned settings layering) →
+  [`../SETUP_STAGES_DEVELOPMENT.md`](../SETUP_STAGES_DEVELOPMENT.md).


### PR DESCRIPTION
## Summary

Comprehensive redesign of the bootstrap mechanism into a unified
**setup-stages** system: declarative stage registry, K8s-style
three-layer fingerprint lifecycle, agentic config-item elicitation
flow, partitioned settings layering, BoardAdapter capability
dispatch, cross-platform parity contract.

20 commits, 22 files, +5509 / −2. Pure spec / docs PR — **no
runtime code changes**. Implementation lands as separate cards
through the manager → consumer flow.

## What ships

**Living design doc** (1694 lines):
[`docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md`](https://github.com/PanQiWei/board-superpowers/blob/feat/bootstrap-redesign/docs/architecture/0002-product-features-and-flows/05-bootstrap-surface-redesign.md)
— full structured analysis: 3 axes (module / character / locality),
22-stage registry, trigger model, 5-state lifecycle (incl.
\`not-applicable\`), three-layer fingerprint, declarative state
schema (4 partitioned settings.yml files + per-module
\`schema_version\`), repo identity (GitHub-based + I-13 revision),
stage registry contract (YAML + Python + JSON Schema),
architect UX (sequential per-stage flow + 5-element config
item protocol), 15-step replacement plan.

**13 setup-stages ADRs** (ADR-0012 .. ADR-0024):

| ADR | Decision |
|-----|----------|
| 0012 | Unified check-script trigger model — absorbs deferred \`migrating-repo-version\` SKILL |
| 0013 | Declarative state schema + 5-state lifecycle + K8s-style three-layer fingerprint |
| 0014 | Stage registry contract — YAML + Python helpers + JSON Schema validation |
| 0015 | M4 audit per-repo locality (replaces host-shared \`credentials.yml\`) |
| 0016 | Cross-platform parity contract via \`platforms\` field on every stage |
| 0017 | I-13 invariant revision — cross-clone state sharing via GitHub-based repo identity |
| 0018 | M7 multi-stage per-block routing protocol + Codex 32 KiB AGENTS.md budget |
| 0019 | Zero-config SQLite as default per-repo audit backend (extends ADR-0009) |
| 0020 | Stage applicability — \`applicable_when\` predicate + \`not-applicable\` 5th lifecycle state |
| 0021 | Settings modular layering — two-section split + per-module \`schema_version\` |
| 0022 | BoardAdapter capability dispatch + M10 BoardAdapter-selection module |
| 0023 | Architect UX — sequential per-stage flow + 5-element config item protocol |
| 0024 | settings.yml rename + new config-item stages (\`m5.repo.set-wip-limit\`, \`m10.repo.choose-kanban-backend\`) |

**Plugin-wide development guide** (905 lines):
[\`SETUP_STAGES_DEVELOPMENT.md\`](https://github.com/PanQiWei/board-superpowers/blob/feat/bootstrap-redesign/SETUP_STAGES_DEVELOPMENT.md)
— navigation layer over the design doc + 13 ADRs, plus the
development-time judgment the spec doesn't encode (when to
add a stage vs. lighter mechanisms, common axis
misclassifications, canonicalization footguns, anti-patterns,
graceful-degradation philosophy). Named **setup-stages** to
broaden beyond first-time-bootstrap framing; legacy filename
[\`BOOTSTRAP_STAGES_DEVELOPMENT.md\`](https://github.com/PanQiWei/board-superpowers/blob/feat/bootstrap-redesign/BOOTSTRAP_STAGES_DEVELOPMENT.md)
is a one-line shim.

**5 AGENTS.md updates** wire the new guide as the 4th
companion doc:

- \`AGENTS.md\` (root) — \"Cross-cutting reference docs\" table
  gains 4th row.
- \`scripts/AGENTS.md\` — prerequisite read for any work
  touching \`stages-registry.yml\`, \`stages_lib/\`,
  \`stages-registry.schema.json\`, \`lib/_canonical.py\`.
- \`hooks/AGENTS.md\` — prerequisite read for any edit to
  \`session-start.sh\`'s lifecycle-diff path.
- \`skills/AGENTS.md\` — prerequisite read for any edit to
  \`bootstrapping-repo/\` or any new SKILL whose body executes
  setup-stage machinery; complements (does not replace) the
  existing skill-creator + SKILL_DEVELOPMENT.md Process gate.
- \`docs/architecture/AGENTS.md\` — Same-PR contract clause adds
  SETUP_STAGES_DEVELOPMENT.md as the 4th companion doc; new
  change-impact-matrix row covers any edit to the redesign
  spec or any of ADR-0012..ADR-0024.

## What this PR does NOT touch

- **No runtime code changes.** \`scripts/stages-registry.yml\`,
  \`scripts/stages_lib/\`, the JSON Schema validator, the new
  \`session-start.sh\` lifecycle-diff path, the
  \`bootstrapping-repo\` SKILL body — all of these will land as
  implementation cards through the normal manager → consumer
  flow.
- **No replacement of \`05-bootstrap-surface.md\` (legacy spec).**
  Per the design doc § \"Replacement plan\", the legacy
  bootstrap-surface spec stays in place until the redesign's
  implementation cards land. The redesign coexists alongside
  it as \"05-bootstrap-surface-redesign.md\" so the legacy spec
  remains the SoT for v0.4.0 production behavior until cutover.
- **\`bootstrapping-repo\` SKILL is not yet renamed.** Despite
  the system rename to \"setup-stages\", the SKILL id remains
  \`bootstrapping-repo\` until a separate breaking-change PR
  retires the old name.

## Test plan

Pure docs PR — verification is doc-heavy review.

- [x] **Self-check (automated)**: cross-reference verification —
  all 17 ADR references (0005, 0006, 0008, 0009, 0012-0024)
  exist; all 15 design-doc anchor links resolve to actual
  section headers; all 14 ADR file paths resolve; no stale
  plumbing names (\`state.yml\` co-mention is correct per design
  doc § \"External stage TTL cache\").
- [ ] **Architect review**: human review of the design doc
  end-to-end + spot-check of remaining ADRs (0015, 0017, 0018,
  0019, 0024 not yet deep-reviewed in development).
- [ ] **Reviewer pass**: optional — dispatch independent
  reviewer agent for the SETUP_STAGES_DEVELOPMENT.md guide
  before merge if the architect wants extra eyes.

## After this lands

The next step is **manager-mode intake** for implementation:
running \`decomposing-into-milestones\` (or hand-decomposition)
to break the 15-step replacement plan into vertical-sliced
INVEST cards on the GitHub Project. Per AGENTS.md
\"Self-hosting\", spec architecture changes flow through
\`managing-board\` → \`consuming-card\` for delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)