### PR TITLE
Add composing-siblings atomic SKILL (sibling-plugin invocation SoT)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "board-superpowers",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agile scheduling layer for Claude Code: turn GitHub Projects into the central dispatcher, turn one session into one deliverable milestone (one PR). Depends on superpowers and gstack.",
   "author": {
     "name": "board-superpowers contributors"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "board-superpowers",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agile scheduling layer for Codex CLI: turn GitHub Projects into the central dispatcher, one session = one PR. Depends on superpowers and gstack.",
   "author": "board-superpowers contributors",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "interface": {
     "displayName": "board-superpowers",
     "shortDescription": "GitHub-Project-driven scheduling for AI coding sessions",
-    "longDescription": "board-superpowers turns a GitHub Project into the central dispatcher for AI-driven coding sessions. Routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode. Delegates real work — TDD, debugging, review, QA, security — to superpowers and gstack. v1 catalog complete: 1 entry + 4 molecular + 5 atomic = 10 skills, all shipped. Setup-stages substrate (per ADR-0012, which absorbs the formerly deferred migrating-repo-version SKILL into bootstrapping-repo as the single executor) shipped in v0.5.0 (#67).",
+    "longDescription": "board-superpowers turns a GitHub Project into the central dispatcher for AI-driven coding sessions. Routes every session into Manager (board orchestration) or Consumer (one-card-to-PR) mode. Delegates real work — TDD, debugging, review, QA, security — to superpowers and gstack. v1 catalog complete: 1 entry + 4 molecular + 6 atomic = 11 skills, all shipped. Sibling-plugin invocation SPOT (`composing-siblings` atomic) shipped in v0.6.0 (#71); setup-stages substrate shipped in v0.5.0 (#67).",
     "developerName": "board-superpowers contributors",
     "category": "developer-tools",
     "websiteURL": "https://github.com/PanQiWei/board-superpowers"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,23 +6,23 @@ user-facing overview.
 
 @SKILLS.md
 
-## Project status — v1 catalog 10/10 shipped
+## Project status — v1 catalog 11/11 shipped
 
 > **The plugin is loadable at runtime.** `hooks/`,
 > `scripts/`, and `skills/` directories exist at the repo root.
-> `SessionStart` fires. The 10 v1-catalog skills auto-match.
+> `SessionStart` fires. The 11 v1-catalog skills auto-match.
 > The plugin dogfoods itself for any new skill / script / hook.
 
-**v1 catalog = 10 of 10 skills shipped** (post-#67 —
-`migrating-repo-version` absorbed into `bootstrapping-repo` per
-[ADR-0012](./docs/architecture/adr/0012-unified-check-script-trigger-model.md);
-no separate SKILL ships), per [`SKILLS.md`](./SKILLS.md):
+**v1 catalog = 11 of 11 skills shipped** (post-#71 —
+`composing-siblings` atomic lands as the SPOT for sibling-plugin
+invocation discipline), per [`SKILLS.md`](./SKILLS.md):
 
 - **Shipped**: `using-board-superpowers` (entry),
   `managing-board` + `consuming-card` + `bootstrapping-repo` +
   `decomposing-into-milestones` (molecular), `board-canon` +
   `enforcing-pr-contract` + `classifying-actions` +
-  `auditing-actions` + `operating-kanban` (atomic).
+  `auditing-actions` + `operating-kanban` + `composing-siblings`
+  (atomic).
 
 **Remaining degraded behavior**: v1 catalog complete; no
 remaining v1-minimum workarounds. Plugin-upgrade reconvergence
@@ -167,7 +167,7 @@ it does four things:
    a local jsonl trace and the entry's `mode` field records the
    degradation cause (see spec 06 § "jsonl fallback mode-field").
 
-### Skills system — the v1 catalog (10 skills, 3 layers)
+### Skills system — the v1 catalog (11 skills, 3 layers)
 
 The `skills/` directory **is** the agent's action system. It is
 designed as a graph of nodes (skills) and edges (cross-skill
@@ -193,7 +193,7 @@ Molecular layer (4) — business workflows, state-machine-shaped
                               ADR-0012) + agentic config-item
                               elicitation
 
-Atomic layer (5) — single-purpose primitives, reflexive (no upward calls)
+Atomic layer (6) — single-purpose primitives, reflexive (no upward calls)
 ─────────────────────────────────────────────────────────────────
   board-canon                 state machine + Card schema + branch
                               naming + WIP rules (read-only contract)
@@ -202,6 +202,8 @@ Atomic layer (5) — single-purpose primitives, reflexive (no upward calls)
   auditing-actions            audit log schema + two-entry rule + BYO DB
   operating-kanban            8-action protocol dispatch over the active
                               projection (backend selection + Form A/B/C)
+  composing-siblings          sibling-plugin invocation SPOT — namespace
+                              prefix rules + Mode-2 compatibility checks
 ```
 
 Dependency direction is **strictly downward**: Entry → Molecular
@@ -640,6 +642,10 @@ and the spec-first companion ([`spec-first-checklist.md`](./skills/managing-boar
 are the manager-mode SoT for shape decisions and spec
 preconditions; this section provides the cross-plugin wiring
 they consume.
+
+**Runtime authority**: see `board-superpowers:composing-siblings` skill for the
+single source of truth on invocation rules, Mode-2 compatibility, and namespace
+prefix discipline at each sibling-plugin handoff point.
 <!-- /board-superpowers:routing -->
 
 ## Do Not

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,4 +1,4 @@
-# Skills system — board-superpowers v1 catalog (10 skills total, all shipped, 3 layers)
+# Skills system — board-superpowers v1 catalog (11 skills total, all shipped, 3 layers)
 
 > **Always loaded.** This document is referenced from
 > [`AGENTS.md`](./AGENTS.md) via `@SKILLS.md` and rides into
@@ -31,7 +31,7 @@ The reverse also holds: an edit to this document without the
 matching `skills/` change makes the spec drift. Both halves
 land together.
 
-The skills system has three layers, ten skills, and a fixed set
+The skills system has three layers, eleven skills, and a fixed set
 of cross-plugin edges. None of these numbers should change
 without an explicit decision recorded here first.
 
@@ -106,17 +106,18 @@ rationale that motivates the split.
 
 ## v1 minimum vs v1 complete
 
-The full v1 catalog defines **10 skills**. As of `v0.6.0`
-(post-#67-merge), **all 10 ship** — enough to make the plugin
+The v1 catalog defines **11 skills**. As of `v0.6.0`
+(post-#71-merge), **all 11 ship** — enough to make the plugin
 self-hostable on this very repo AND to bootstrap a fresh
 consuming repo from zero AND to govern every mutating action
 through classifying-actions + auditing-actions AND to decompose
 design artifacts into INVEST-compliant vertically-sliced cards
 via decomposing-into-milestones AND to dispatch the eight Kanban
 Protocol actions through the active projection via
-operating-kanban. The `migrating-repo-version` molecular SKILL
-that v0.5.0 carried as deferred has been **absorbed into
-`bootstrapping-repo`** per
+operating-kanban AND to consolidate the single source of truth
+for sibling-plugin invocation discipline via composing-siblings.
+The `migrating-repo-version` molecular SKILL that v0.5.0 carried
+as deferred has been **absorbed into `bootstrapping-repo`** per
 [ADR-0012](./docs/architecture/adr/0012-unified-check-script-trigger-model.md)
 (single sole-executor for setup-stages, including version-
 transition migrations). No separate migration SKILL ships.
@@ -133,6 +134,7 @@ transition migrations). No separate migration SKILL ships.
 | `operating-kanban` | Atomic | shipped (v0.5.0) | True SPOT shipped in v0.5.0 — every molecular SKILL routes the eight Kanban Protocol actions (per ADR-0025) and the bootstrap-side setup capabilities (per ADR-0027) through this skill's per-projection reference files. |
 | `classifying-actions` | Atomic | shipped (v0.3.0) | True SPOT shipped in v0.3.0 — every mutating SKILL consumes its D-AUTONOMY-1 matrix (14 Producer + 14 Consumer + 9 Bootstrap rows) + 5-step triage rule + autonomy_overrides parsing. |
 | `auditing-actions` | Atomic | shipped (v0.3.0) | True SPOT shipped in v0.3.0 — every mutating SKILL invokes audit-log-write.sh through this skill's payload templates and propose/resolve sequencing rules. |
+| `composing-siblings` | Atomic | shipped (v0.6.0) | True SPOT shipped in v0.6.0 — every molecular SKILL that delegates to `gstack:*` or `superpowers:*` consults this skill for invocation rules, procedural-vs-subagent decision, and Mode-2 max_depth=1 compatibility. |
 
 **Cross-platform hook delivery**: `hooks/session-start.sh` is
 identical on both platforms (uses `bsp_plugin_root()` from
@@ -149,7 +151,7 @@ means for board-superpowers" #3 for the full rationale.
 > Per-skill `layer`, `type`, `mode`, `bounded-context` live in
 > `<skill-dir>/.skill-meta.yaml`. The catalog below tags each
 > skill name as `(shipped vX)` for every skill in the catalog —
-> all 10 ship as of v0.6.0 (post-#67-merge). Tier 2 frontmatter
+> all 11 ship as of v0.6.0 (post-#71-merge). Tier 2 frontmatter
 > recommendations are listed for every skill.
 
 ### Entry layer (1 skill)
@@ -323,7 +325,7 @@ means for board-superpowers" #3 for the full rationale.
   vocabulary covering the architect-spoken fallback phrases plus
   the entry-skill state-probe trigger).
 
-### Atomic layer (5 skills, all shipped)
+### Atomic layer (6 skills, all shipped)
 
 #### `board-canon` (v1-minimum)
 
@@ -450,6 +452,43 @@ means for board-superpowers" #3 for the full rationale.
 - **Tier 2 frontmatter**: `user-invocable: false` (atomic
   reflex, never user-driven directly).
 
+#### `composing-siblings` (shipped v0.6.0)
+
+- **Role**: Sibling-plugin invocation discipline SPOT — owns
+  "how to invoke `gstack:*` / `superpowers:*` skills correctly"
+  across all 9 molecular handoff points. Consolidates: (a) the
+  invocation rules (SKILL invocation = content-loading, NOT
+  subagent spawn, per ADR-0008); (b) Mode-2 `max_depth=1`
+  compatibility check — procedural-vs-subagent decision tree
+  for every currently-composed sibling skill; (c) per-phase
+  skill routing (gstack bookends + superpowers middle per
+  ADR-0004); (d) `<plugin>:<skill>` namespace prefix rule
+  (cross-platform, prevents bare-reference ambiguity). See
+  `references/handoff-points.md` for the 9 caller × scenario
+  table; `references/sibling-plugin-table.md` for the current
+  sibling-skill quick-reference; `references/procedural-fallback-rules.md`
+  for the Mode-2 decision tree; `references/boundary.md` for
+  the atomic reflex constraint.
+- **Body target**: ≤ 200 lines (atomic budget).
+- **References folder**:
+  `references/{handoff-points,sibling-plugin-table,procedural-fallback-rules,boundary}.md`.
+- **Called by**: every molecular skill that delegates to sibling
+  plugins — today: `managing-board` (F-08 intake routing to
+  `gstack:/*` / `superpowers:*`), `consuming-card` (F-C4
+  implement, F-C9 verify, F-C11 conditional QA/security),
+  `decomposing-into-milestones` (plan synthesis + arch
+  validation handoff). Post Card #72 + #73 lifecycle
+  re-encode: same handoff semantics, named B1 / C1-C4
+  instead of F-08 / F-C4 etc.
+- **Calls**: nothing in-plugin. Atomic = reflexive.
+- **SPOT consolidates**: sibling-plugin invocation rules and
+  Mode-2 compatibility decision would otherwise be inlined into
+  3+ molecular callers (4 Producer routine SKILLs + 5 Consumer
+  lifecycle handoff points = 9 inline copies drifting
+  independently).
+- **Tier 2 frontmatter**: `user-invocable: false` (atomic
+  reflex, never user-driven directly).
+
 ## Call graph
 
 ```
@@ -467,11 +506,13 @@ means for board-superpowers" #3 for the full rationale.
       │ (Producer)  │ │ card │ │      │ │          │
       └──┬───┬───┬──┘ └─┬──┬─┘ └──┬───┘ └────┬─────┘
          │   │   │      │  │      │          │
-         │   │   │  (cross-plugin: 见 § "Cross-plugin edges")
-         │   │   │      │  │      │          │
-   ┌─────┼───┼───┼──────┼──┼──────┼──────────┘
-   │     │   │   │      │  │      │
-   ▼     ▼   ▼   ▼      ▼  ▼      ▼              (Atomic — 反射弧 — 5 skills)
+         │   │   │  ┌───┼──┼──────┼──┐ (sibling-plugin handoff — 9 callers)
+         │   │   │  │   │  │      │  └──────────────────────────────┐
+         │   │   │  │   │  │      │                                  ▼
+         │   │   │  └───┴──┴──────┴──┐                    ┌──────────────────┐
+   ┌─────┼───┼───┼──────────────────►│                    │ composing-       │
+   │     │   │   │                   └────────────────────►  siblings        │
+   ▼     ▼   ▼   ▼      (Atomic — 反射弧 — 6 skills)      └──────────────────┘
    ┌────────────┐  ┌─────────────────┐  ┌──────────────┐  ┌──────────────────┐  ┌──────────────────┐
    │ board-canon│  │enforcing-pr-    │  │ operating-   │  │classifying-      │  │ auditing-actions │
    │ (read-only │  │   contract      │  │   kanban     │  │   actions        │  │ (audit schema +  │
@@ -484,7 +525,12 @@ means for board-superpowers" #3 for the full rationale.
                                                                    (mutating skill MUST also call auditing-actions)
 ```
 
-## SPOT derivation — why exactly 5 atomic skills
+> The `composing-siblings` inbound edges above aggregate from 9 distinct
+> handoff points across the 3 (today) → 6 (post-#72/#73) caller SKILLs.
+> See the `composing-siblings` catalog row "Called by" field for the full
+> per-SKILL enumeration with spec-phase labels.
+
+## SPOT derivation — why exactly 6 atomic skills
 
 The atomic-layer count is not preference; it's the result of a
 SPOT (single-point-of-truth) census. Any contract that
@@ -498,6 +544,7 @@ candidate that MUST be promoted to atomic. v1 census:
 | 8-action protocol dispatch + projection routing + setup-capability registry | All 4 board-touching molecular (`managing-board`, `consuming-card`, `decomposing-into-milestones`, `bootstrapping-repo`) | `operating-kanban` |
 | D-AUTONOMY-1 matrix + override parsing | All 4 mutating molecular | `classifying-actions` |
 | Audit log schema + two-entry rule | All 4 mutating molecular | `auditing-actions` |
+| How to invoke sibling-plugin discipline (`gstack:*` / `superpowers:*`) + Mode-2 max_depth=1 compatibility + `<plugin>:<skill>` namespace prefix rule | 3 sibling-invoking molecular SKILLs today (`managing-board` / `consuming-card` / `decomposing-into-milestones`); 9 distinct handoff points across them, growing to 6 SKILL × 9 handoff points after Card #72 (Producer Shape Y) + Card #73 (Consumer Shape X) land | `composing-siblings` |
 
 Contracts that would NOT meet the SPOT threshold (only 1
 molecular inlines) stay inline:
@@ -518,7 +565,7 @@ Per
 | Bounded context | Owns / reads | Skill(s) acting on it |
 |-----------------|--------------|------------------------|
 | **Board** | Card + PR aggregates; GitHub Project + Issues + git refs | `managing-board` (R), `consuming-card` (R + W own card), `decomposing-into-milestones` (W new cards), `bootstrapping-repo` (R Status field), `board-canon` (schema authority), `operating-kanban` (per-projection dispatch authority) |
-| **Session** | ProducerSession + ConsumerLogical aggregates; OS processes + worktrees | `managing-board` (R lifecycle), `consuming-card` (own session) |
+| **Session** | ProducerSession + ConsumerLogical aggregates; OS processes + worktrees | `managing-board` (R lifecycle), `consuming-card` (own session), `composing-siblings` (read-only invocation rules for sibling-plugin handoffs in both roles) |
 | **Bootstrap** | HostBootstrap + RepoBootstrap + RepoConfig | `bootstrapping-repo` (R + W — sole executor for first-time setup AND plugin-upgrade reconvergence per ADR-0012), `using-board-superpowers` (R for state checks) |
 | **Audit** | AuditTrail aggregate; BYO RDBMS | `auditing-actions` (W via DB script) |
 | **Spec** | SpecPointer (thin) | `consuming-card` (R via thin pointer in F-C2) |

--- a/docs/architecture/0005-contracts/04-skill-contracts.md
+++ b/docs/architecture/0005-contracts/04-skill-contracts.md
@@ -156,17 +156,22 @@ ships.
 
 ## board-superpowers' own SKILL surface
 
-Five skills ship at v1. All five use only the portable
-(`name`, `description`) frontmatter subset, so all five are
-Codex-portable.
+Eleven skills ship at v1 (post-#71): 1 entry + 4 molecular + 6 atomic. All use
+only the portable (`name`, `description`) frontmatter subset and are Codex-portable.
 
-| Skill | Description (one-line summary) | Composes (sibling skills it invokes) | Mode-2 safe? |
-|-------|--------------------------------|--------------------------------------|--------------|
-| `using-board-superpowers` | Entry skill: preflight + role disambiguation + first-time bootstrap | `managing-board`, `consuming-card` (its own siblings) | yes — procedural |
-| `board-canon` | Shared contract: card schema + state machine + branching + WIP — the in-session SPOT for Kanban Protocol semantics (per [`00-kanban-protocol.md`](./00-kanban-protocol.md) + ADR-0025). | none (read-only) | yes — procedural, read-only |
-| `managing-board` | Manager session main skill (orchestration, not coding) | `decomposing-into-milestones` (own sibling); `gstack:/office-hours`, `/plan-eng-review`, `/review`, `/qa`, `/cso`; `superpowers:brainstorming`, `writing-plans`, `dispatching-parallel-agents` | yes — procedural; sibling-skill invocations are SKILL-invoked, not spawned |
-| `decomposing-into-milestones` | Producer's INVEST + slicing engine (turns design doc into cards) | `superpowers:writing-plans`; `gstack:/plan-eng-review` | yes — procedural |
-| `consuming-card` | Consumer session main skill (claim → implement → PR) | `superpowers:subagent-driven-development` (default; **TBD per F-C4**), `executing-plans` (fallback), `verification-before-completion`, `requesting-code-review`; `gstack:/review`, `/qa`, `/codex`, `/cso` | yes for the SKILL body itself; the F-C4 delegation depends on per-sibling verification |
+| Skill | Layer | Description (one-line summary) | Composes (sibling skills it invokes) | Mode-2 safe? |
+|-------|-------|--------------------------------|--------------------------------------|--------------|
+| `using-board-superpowers` | Entry | Entry skill: preflight + role disambiguation + first-time bootstrap | `managing-board`, `consuming-card` (its own siblings) | yes — procedural |
+| `managing-board` | Molecular | Manager session main skill (orchestration, not coding) | `decomposing-into-milestones` (own sibling); `gstack:/office-hours`, `/plan-eng-review`, `/review`, `/qa`, `/cso`; `superpowers:brainstorming`, `writing-plans`, `dispatching-parallel-agents` | yes — procedural; sibling-skill invocations are SKILL-invoked, not spawned |
+| `consuming-card` | Molecular | Consumer session main skill (claim → implement → PR) | `superpowers:subagent-driven-development` (default; **TBD per F-C4**), `executing-plans` (fallback), `verification-before-completion`, `requesting-code-review`; `gstack:/review`, `/qa`, `/codex`, `/cso` | yes for the SKILL body itself; the F-C4 delegation depends on per-sibling verification |
+| `decomposing-into-milestones` | Molecular | Producer's INVEST + slicing engine (turns design doc into cards) | `superpowers:writing-plans`; `gstack:/plan-eng-review` | yes — procedural |
+| `bootstrapping-repo` | Molecular | Sole executor for setup-stages — first-time setup + plugin-upgrade reconvergence | none | yes — procedural |
+| `board-canon` | Atomic | Shared contract: card schema + state machine + branching + WIP — the in-session SPOT for Kanban Protocol semantics (per [`00-kanban-protocol.md`](./00-kanban-protocol.md) + ADR-0025). | none (read-only) | yes — procedural, read-only |
+| `enforcing-pr-contract` | Atomic | PR three-section shape enforcement + card body AC sync | none | yes — procedural |
+| `operating-kanban` | Atomic | 8-action Kanban Protocol dispatch over the active backend projection | none in-plugin (dispatches to `gh` / MCP / REST externally) | yes — procedural |
+| `classifying-actions` | Atomic | D-AUTONOMY-1 matrix + override parsing — returns A/R/N decision | none | yes — procedural |
+| `auditing-actions` | Atomic | Audit log schema + two-entry rule + BYO RDBMS write | none in-plugin (invokes `audit-log-write.sh`) | yes — procedural |
+| `composing-siblings` | Atomic | Sibling-plugin invocation SPOT — namespace prefix rules + Mode-2 max_depth=1 compatibility for all `gstack:*` / `superpowers:*` handoffs | none in-plugin (defines rules, does not itself invoke siblings) | yes — procedural |
 
 ### Procedural-skill commitment (own surface)
 

--- a/skills/composing-siblings/.skill-meta.yaml
+++ b/skills/composing-siblings/.skill-meta.yaml
@@ -1,0 +1,8 @@
+# board-superpowers skill metadata (machine-readable, single source of truth).
+# Schema: maintainer-side metadata convention (board-superpowers internal; not read at runtime).
+# CI gate: scripts/verify-skill-metadata.sh.
+version: v0.1.0
+layer: atomic
+type: reference
+mode: both
+bounded-context: session

--- a/skills/composing-siblings/SKILL.md
+++ b/skills/composing-siblings/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: composing-siblings
+description: |
+  Use whenever a board-superpowers in-plugin SKILL (any of the molecular layer —
+  `managing-board` / `consuming-card` / `decomposing-into-milestones` /
+  `bootstrapping-repo` and their successors) is about to invoke a sibling plugin
+  SKILL from `gstack:*` or `superpowers:*` namespaces. Apply at every such handoff
+  point — examples: `superpowers:brainstorming` for intake design,
+  `superpowers:test-driven-development` for implementation, `gstack:/review` for
+  verification, `gstack:/qa` for UI testing. Use even when the invocation looks
+  routine — this skill is the single source of truth for namespace prefix rules and
+  Mode-2 max_depth=1 compatibility decisions. Do NOT use for: (a) board-superpowers
+  internal SKILL calls (those carry `board-superpowers:` prefix and are governed by
+  `SKILLS.md` topology); (b) user-facing direct invocations of sibling skills (when
+  the user explicitly says "brainstorm" or "review my diff", route directly to the
+  sibling per `using-board-superpowers/references/routing.md`).
+when_to_use: |
+  Use at every sibling-plugin handoff inside managing-board, consuming-card, and
+  decomposing-into-milestones. Specific trigger points: Producer intake B1 routing
+  (direction / architecture / plan sibling selection); Consumer lifecycle C1
+  (brainstorming/planning handoff), C2 (implementation delegation), C3 (pre-PR
+  verification chain), C4 (conditional QA/security passes). Use when deciding
+  whether a sibling skill is safe to invoke from a Mode-2 Consumer context.
+user-invocable: false
+---
+
+# composing-siblings
+
+This skill is the single source of truth for invoking sibling-plugin skills
+(`gstack:*` / `superpowers:*`) from any board-superpowers context. It does
+not perform actions itself; it provides the invocation contract that callers
+follow before routing to a sibling.
+
+## How to apply this skill
+
+| What you need | Where to look |
+|---------------|---------------|
+| Which sibling skill to invoke at a specific handoff | `references/handoff-points.md` (9 caller × scenario table) |
+| Current `gstack:*` / `superpowers:*` skill names and descriptions | `references/sibling-plugin-table.md` |
+| Whether a sibling skill is safe to invoke from Mode-2 Consumer | `references/procedural-fallback-rules.md` |
+| Namespace prefix rules + atomic reflex constraint | `references/boundary.md` |
+
+## Invocation rules
+
+**Rule 1 — SKILL invocation, not subagent spawn.**
+All cross-plugin composition uses SKILL invocation. The platform's skill matcher
+loads the sibling SKILL.md body into the calling agent's context as procedural
+guidance — no second context window, no `Agent` tool call. This is content-
+loading, not a spawn. The `max_depth` budget applies only to `Agent` tool calls;
+SKILL invocation does not consume depth.
+
+**Rule 2 — Always carry the namespace prefix.**
+Every sibling-plugin reference uses `<plugin>:<skill>` form:
+- `superpowers:test-driven-development` (correct)
+- `gstack:/review` (correct — gstack uses `/` prefix by convention)
+- `test-driven-development` (wrong — bare reference fails cross-plugin resolution)
+
+**Rule 3 — Procedural check before Mode-2 invocation.**
+A Mode-2 Consumer runs as a CC subagent (`max_depth=1`). SKILL invocation itself
+does not consume depth, but any spawn-instruction inside the invoked skill's body
+would. Before invoking any sibling from a Mode-2 context, verify it is procedural
+(its body does not instruct an `Agent` / `spawn_agents_on_csv` call). Consult
+`references/procedural-fallback-rules.md` for the current status of each sibling.
+
+**Rule 4 — Phase-based routing.**
+Route by phase, not by preference:
+- **Bookend phases** (direction-setting before a card is claimed; delivery-side
+  QA / review / security) → `gstack:/*` skills.
+- **Middle phase** (implementation loop: brainstorming → writing-plans → TDD →
+  debugging → verification → code-review) → `superpowers:*` skills.
+- Conflict arbitration: user instructions > skill > default behavior. A gstack
+  skill's "start coding" output does not override `superpowers:test-driven-development`
+  discipline unless the user explicitly says so in the current conversation.
+
+## Handoff points quick reference
+
+Nine callers use this skill. See `references/handoff-points.md` for the full
+table. High-frequency summary:
+
+| Caller | Phase label | Primary sibling(s) |
+|--------|-------------|-------------------|
+| `managing-board` (intake) | B1 — direction question | `gstack:/office-hours`, `gstack:/plan-ceo-review` |
+| `managing-board` (intake) | C1 — architecture question | `gstack:/plan-eng-review` |
+| `managing-board` (intake) | C1 — plan synthesis | `superpowers:brainstorming`, `superpowers:writing-plans` |
+| `consuming-card` | C1 — planning | `superpowers:writing-plans` |
+| `consuming-card` | C2 — implementation | `superpowers:subagent-driven-development`, `superpowers:test-driven-development` |
+| `consuming-card` | C3 — pre-PR verification | `superpowers:verification-before-completion`, `superpowers:requesting-code-review`, `gstack:/review` |
+| `consuming-card` | C4 — conditional QA/security | `gstack:/qa` (UI cards), `gstack:/cso` (security-flagged) |
+| `decomposing-into-milestones` | plan synthesis | `superpowers:writing-plans` |
+| `decomposing-into-milestones` | arch validation | `gstack:/plan-eng-review` |
+
+## What this skill does NOT cover
+
+- **Which sibling skill wins** when two could apply — that's the caller's
+  routing logic using the phase-based rule above.
+- **Whether to use a sibling at all** — that's the calling skill's decision
+  based on the card's Execution Hints and the architect's signal.
+- **Autonomy classification** of sibling-skill invocations — that's
+  `board-superpowers:classifying-actions`.
+- **Audit rows for sibling-skill handoffs** — that's
+  `board-superpowers:auditing-actions`.
+- **Same-plugin (board-superpowers internal) skill references** — those follow
+  the `SKILLS.md` call-graph topology, not this skill.

--- a/skills/composing-siblings/references/boundary.md
+++ b/skills/composing-siblings/references/boundary.md
@@ -1,0 +1,84 @@
+# Boundary rules — atomic reflex constraint + namespace prefix rule
+
+## Atomic reflex constraint
+
+`composing-siblings` is an atomic skill. Atomic skills in board-superpowers are
+reflexes: they are consumed by molecular skills, they do not call any same-plugin
+skill, and they do not orchestrate work. This constraint exists to prevent
+call-graph cycles and to preserve the SPOT (single-point-of-truth) property:
+each atomic consolidates one contract that would otherwise be inlined N times.
+
+Concretely:
+- `composing-siblings` MUST NOT invoke `board-superpowers:managing-board`,
+  `board-superpowers:consuming-card`, `board-superpowers:bootstrapping-repo`,
+  `board-superpowers:decomposing-into-milestones`, or any other skill in this
+  plugin.
+- If a future change to `composing-siblings` seems to require calling another
+  same-plugin skill, the design has gone wrong. Split or merge the atomics
+  instead of introducing the call.
+- Cross-plugin references (`gstack:*` / `superpowers:*`) are also not invoked
+  from this skill's body — this skill defines the invocation rules, it does not
+  itself invoke the siblings.
+
+This constraint is enforced by the `SKILLS.md` call-graph topology and reviewed
+in CI gate `scripts/verify-skill-metadata.sh`.
+
+## Namespace prefix rule
+
+Every reference to a sibling skill MUST carry the full `<plugin>:<skill>`
+namespace prefix. This rule applies in both SKILL.md bodies and in prose
+references in reference files.
+
+### Correct forms
+
+```
+superpowers:test-driven-development
+superpowers:brainstorming
+superpowers:writing-plans
+superpowers:verification-before-completion
+superpowers:requesting-code-review
+superpowers:subagent-driven-development
+superpowers:systematic-debugging
+gstack:/office-hours
+gstack:/plan-ceo-review
+gstack:/plan-eng-review
+gstack:/review
+gstack:/qa
+gstack:/cso
+gstack:/investigate
+```
+
+Note the asymmetry: `superpowers` uses `:` separator; `gstack` uses `:/`
+separator (this is gstack's convention for its skills, which use the slash
+prefix). Both forms are correct for their respective plugins.
+
+### Incorrect forms (never use)
+
+```
+test-driven-development          # bare — ambiguous across plugins
+brainstorming                    # bare — will not resolve correctly
+/office-hours                    # slash-only — missing plugin prefix
+qa                               # bare — will not resolve correctly
+```
+
+### Why the prefix matters
+
+When multiple plugins are loaded simultaneously (which is the normal state —
+board-superpowers requires both `superpowers` and `gstack`), a bare skill name
+is ambiguous: the platform may resolve it to a same-plugin skill, a sibling
+skill, or fail silently. The namespace prefix guarantees cross-platform
+unambiguous resolution on both Claude Code and Codex CLI.
+
+The prefix is also load-bearing for maintainability: greping for
+`superpowers:` or `gstack:/` in the codebase unambiguously finds all
+cross-plugin edges. Bare references scatter and become invisible.
+
+## What this skill does NOT govern
+
+- **board-superpowers internal skill references** — those use the
+  `board-superpowers:` prefix and their topology is defined in `SKILLS.md`.
+- **Script invocations** (`bash scripts/foo.sh`) — those are not skill
+  invocations and follow the script contract in `scripts/AGENTS.md`.
+- **MCP tool calls** — those are not skill invocations. The board-superpowers
+  composition model explicitly rules out MCP as the cross-plugin composition
+  channel; SKILL invocation is the canonical mechanism, not cross-process IPC.

--- a/skills/composing-siblings/references/handoff-points.md
+++ b/skills/composing-siblings/references/handoff-points.md
@@ -1,0 +1,74 @@
+# Handoff points — 9 caller × scenario table
+
+> **Forward-looking note**: The 4 Producer routine SKILLs (`briefing-daily` /
+> `intaking-requirement` / `reviewing-pr-queue` / `triaging-board`) referenced
+> below land via Card #72 (Producer Shape Y refactor); the Consumer 5 lifecycle
+> handoff points (B1 / C1 / C2 / C3 / C4) are introduced via Card #73 (Consumer
+> Shape X refactor). Today (post-#71-merge baseline), the SKILLs invoking sibling
+> plugins are `managing-board` (intake routing — turns a new requirement into a
+> design conversation or Ready card by delegating to gstack / superpowers),
+> `consuming-card` (implementation delegation + pre-PR verification chain +
+> conditional QA/security passes), `decomposing-into-milestones` (plan synthesis
+> + arch validation handoff). Same handoff semantics, different SKILL boundaries.
+
+This table is informational for the `composing-siblings` skill body. It tracks
+the current set of callers and their sibling-skill handoffs. The count (9) may
+grow or shrink as molecular skills evolve; the atomic body does not hard-code it.
+
+## Phase labels
+
+- **B1** — Pre-card bookend: direction or architecture question raised at intake
+  before a card exists. Producer-side.
+- **C1** — Post-claim planning: plan synthesis or architecture validation needed
+  before implementation starts.
+- **C2** — Implementation delegation: the Consumer delegates coding-discipline
+  work to the `superpowers:*` loop.
+- **C3** — Pre-PR verification: the Consumer runs the verification chain before
+  opening a PR.
+- **C4** — Conditional quality gates: UI or security-flagged cards trigger
+  additional passes.
+
+## 9 caller × scenario table
+
+| Caller skill | Phase | Trigger signal | Sibling(s) to invoke | Mode-2 safe? |
+|--------------|-------|---------------|----------------------|--------------|
+| `managing-board` (intake) | B1 | "is this worth doing", "should we build this", "real demand?" | `gstack:/office-hours` OR `gstack:/plan-ceo-review` | n/a (Producer, not Mode-2) |
+| `managing-board` (intake) | B1 | "rethink scope", "10-star product", "expand premise" | `gstack:/plan-ceo-review` | n/a |
+| `managing-board` (intake) | B1 | architecture trade-off: "which schema", "which adapter", "data flow" | `gstack:/plan-eng-review` | n/a |
+| `managing-board` (intake) | C1 | "explore this idea", direction set but design not locked | `superpowers:brainstorming` | n/a |
+| `managing-board` (decomp handoff) | C1 | design artifact exists, needs executable plan | `superpowers:writing-plans` | n/a |
+| `consuming-card` | C1 | plan phase before implementation | `superpowers:writing-plans` | yes — procedural |
+| `consuming-card` | C2 | implementation: TDD + debugging loop | `superpowers:test-driven-development`, `superpowers:subagent-driven-development` (TBD — see procedural-fallback-rules.md) | TBD — check procedural-fallback-rules.md |
+| `consuming-card` | C3 | pre-PR verification chain | `superpowers:verification-before-completion`, `superpowers:requesting-code-review`, `gstack:/review` | yes — all three are procedural |
+| `consuming-card` | C4 | UI card | `gstack:/qa` | yes — procedural |
+| `consuming-card` | C4 | security-flagged card | `gstack:/cso` | yes — procedural |
+| `decomposing-into-milestones` | C1 | plan synthesis after decomposition | `superpowers:writing-plans` | n/a (not consumer-mode skill) |
+| `decomposing-into-milestones` | B1 | non-trivial architecture validation | `gstack:/plan-eng-review` | n/a |
+
+## Row count note
+
+The table has more than 9 rows because some callers have multiple scenario rows.
+The "9 callers" figure in the SKILLS.md SPOT table counts distinct
+caller × lifecycle-position pairs:
+
+1. `managing-board` B1 — direction question
+2. `managing-board` B1 — scope challenge
+3. `managing-board` B1 — architecture question
+4. `managing-board` C1 — brainstorming
+5. `managing-board` C1 — plan synthesis (decomp handoff)
+6. `consuming-card` C1 — planning
+7. `consuming-card` C2 — implementation
+8. `consuming-card` C3 — verification
+9. `consuming-card` C4 — conditional QA/security
+
+`decomposing-into-milestones` shares the same sibling invocations as
+`managing-board` B1/C1 and is not counted as a separate position in the SPOT
+table because the wiring pattern is identical; it does, however, appear in the
+table above for completeness.
+
+## Updating this file
+
+When a new molecular skill adds a sibling-plugin handoff, add a row here.
+When an existing handoff is removed, remove the row. This file is the living
+record; `SKILLS.md` § "SPOT derivation" row for `composing-siblings` may also
+need a count update if the SPOT claim changes substantially.

--- a/skills/composing-siblings/references/procedural-fallback-rules.md
+++ b/skills/composing-siblings/references/procedural-fallback-rules.md
@@ -1,0 +1,87 @@
+# Procedural fallback rules — Mode-2 max_depth=1 decision tree
+
+This file documents the procedural-vs-subagent decision tree for sibling-plugin
+invocations from a Mode-2 Consumer context. It applies the platform constraints
+to the concrete sibling-skill catalog without re-deriving the underlying logic.
+
+## Core constraints (inline summary)
+
+Two platform constraints govern this decision:
+
+**Constraint A — SKILL invocation is content-loading, not a subagent spawn.**
+The platform's skill matcher loads a sibling SKILL.md body into the calling
+agent's context as procedural guidance. There is no second context window, no
+`Agent` tool call, no depth increment. The max_depth budget applies only to
+`Agent` tool calls (CC) and `spawn_agents_on_csv` (Codex); SKILL invocation
+simply does not enter that category. A Mode-2 Consumer can invoke any number of
+sibling SKILLs without consuming additional depth.
+
+**Constraint B — Subagents cannot spawn subagents.**
+A Mode-2 Consumer runs as a CC subagent. It cannot itself spawn further
+subagents. What CAN compound depth is whatever the *body* of an invoked SKILL
+instructs the agent to do: if a sibling SKILL.md body tells the agent "spawn an
+Agent subagent to do X", that instruction causes a depth increment. The
+requirement is therefore: every sibling skill invoked from Mode-2 MUST have a
+body that does not instruct a subagent spawn.
+
+## The decision tree
+
+When a Mode-2 Consumer is about to invoke a sibling skill, apply in order:
+
+```
+1. Is this a SKILL invocation (via the Skill tool)?
+   YES → SKILL invocation does not consume max_depth. Proceed to step 2.
+   NO  → If you are about to spawn an Agent subagent, STOP — max_depth=1
+         budget is exhausted. Use a procedural fallback instead.
+
+2. Does the sibling skill's SKILL.md body contain an Agent tool call
+   or spawn_agents_on_csv instruction?
+   NO  → Skill is procedural. Safe to invoke from Mode-2. Proceed.
+   YES → Skill is non-procedural. Use the fallback for this skill (see table below).
+   TBD → Treat as non-procedural until verified. Use the fallback.
+```
+
+## Per-skill status and fallback table
+
+| Sibling skill | Procedural? | Fallback if not procedural |
+|---------------|-------------|---------------------------|
+| `superpowers:brainstorming` | yes | n/a |
+| `superpowers:writing-plans` | yes | n/a |
+| `superpowers:test-driven-development` | yes | n/a |
+| `superpowers:subagent-driven-development` | TBD (verified procedural 2026-04-26; re-verify on each superpowers release) | Use `superpowers:executing-plans` as procedural substitute; note substitution in PR description |
+| `superpowers:systematic-debugging` | yes | n/a |
+| `superpowers:verification-before-completion` | yes | n/a |
+| `superpowers:requesting-code-review` | yes | n/a |
+| `gstack:/office-hours` | yes | n/a |
+| `gstack:/plan-ceo-review` | yes | n/a |
+| `gstack:/plan-eng-review` | yes | n/a |
+| `gstack:/review` | yes | n/a |
+| `gstack:/qa` | yes | n/a |
+| `gstack:/cso` | yes | n/a |
+| `gstack:/investigate` | yes | n/a |
+
+## When the fallback fires
+
+If a skill's body is found to have become non-procedural (e.g., a superpowers
+release introduces subagent spawning in `subagent-driven-development`):
+
+1. Mark it TBD or "no" in the table above.
+2. Use the listed fallback skill instead.
+3. Note the substitution in the PR description and in the card body
+   (card body sync per `consuming-card` Step 9.5).
+4. Open a follow-up card (or comment on the consuming-card thread) to track
+   the upstream skill returning to procedural — when it does, revert the fallback.
+
+The fallback table for `consuming-card`'s handoff-to-superpowers also lives in
+`skills/consuming-card/references/handoff-to-superpowers.md`. Keep both files in
+sync when a status changes (same-PR change-impact obligation).
+
+## Re-verification procedure
+
+1. Read the sibling skill's SKILL.md body.
+2. Search for `Agent` tool calls or `spawn_agents_on_csv` references.
+3. If found: skill is non-procedural — update the table.
+4. If not found: skill is procedural — update the table and the verification date.
+5. Record the verification date in `sibling-plugin-table.md`
+   § "Verification status" (see SKILL.md § "How to apply this skill"
+   for the full reference file index).

--- a/skills/composing-siblings/references/sibling-plugin-table.md
+++ b/skills/composing-siblings/references/sibling-plugin-table.md
@@ -1,0 +1,58 @@
+# Sibling-plugin table — quick reference for board-superpowers callers
+
+This table covers only the subset of `gstack:*` and `superpowers:*` skills
+that board-superpowers' 9 handoff-point callers actually invoke. It is NOT a
+full catalog of either plugin (~37 skills combined). For the full catalog, read
+each plugin's own entry skill (`superpowers:using-superpowers` or
+`gstack:/autoplan`).
+
+## How to read this table
+
+- **Invoke as**: the exact string to use in a skill reference. Namespace prefix
+  is mandatory (see SKILL.md § "Invocation rules" Rule 2 for the namespace prefix
+  discipline; the full boundary rules live in `boundary.md`).
+- **Phase**: which phase this skill belongs to per the board-superpowers composition model (bookends = direction-setting + delivery QA/security; middle = implementation discipline loop).
+- **Mode-2 safe**: whether the skill's body is procedural (does not itself
+  issue a subagent spawn instruction). "TBD" means empirical verification is
+  pending; do not invoke from Mode-2 without checking the decision tree in
+  SKILL.md § "Invocation rules" Rule 3 (full per-skill fallback table in
+  `procedural-fallback-rules.md`).
+- **When to use**: the trigger signal that routes to this skill.
+
+## superpowers:* skills (middle-phase disciplines)
+
+| Invoke as | Phase | Mode-2 safe | When to use |
+|-----------|-------|-------------|-------------|
+| `superpowers:brainstorming` | Middle | yes | Requirements not yet settled; direction set but design not locked; need to explore the space before writing a plan |
+| `superpowers:writing-plans` | Middle | yes | Design output exists and needs to be turned into an executable, ordered implementation plan |
+| `superpowers:test-driven-development` | Middle | yes | About to write any feature code or bugfix; enforces Red → Green → Refactor discipline |
+| `superpowers:subagent-driven-development` | Middle | TBD | Executing a multi-step implementation plan with parallelizable subtasks — see `procedural-fallback-rules.md` before invoking from Mode-2 |
+| `superpowers:systematic-debugging` | Middle | yes | A test is failing or behavior is unexpected and the root cause is not obvious |
+| `superpowers:verification-before-completion` | Middle | yes | About to claim implementation work is done; enforces evidence-first "done" standard |
+| `superpowers:requesting-code-review` | Middle | yes | Implementation complete; soliciting an independent second-eyes review before opening a PR |
+
+## gstack:/* skills (bookend disciplines)
+
+| Invoke as | Phase | Mode-2 safe | When to use |
+|-----------|-------|-------------|-------------|
+| `gstack:/office-hours` | Bookend (pre-card) | yes | "Is this worth building?" — demand validation, YC-style forcing questions |
+| `gstack:/plan-ceo-review` | Bookend (pre-card) | yes | "Rethink the problem" — scope expansion, 10-star product, premise challenge |
+| `gstack:/plan-eng-review` | Bookend (pre-card) | yes | Architecture trade-off decisions that warrant a durable record |
+| `gstack:/review` | Bookend (pre-PR) | yes | Production-bug-angle code review of the diff before the PR opens |
+| `gstack:/qa` | Bookend (conditional) | yes | UI-touching cards: real-browser QA before PR submission |
+| `gstack:/cso` | Bookend (conditional) | yes | Security-flagged cards: OWASP / STRIDE audit before PR submission |
+| `gstack:/investigate` | Bookend (debugging) | yes | Second-angle investigation when `superpowers:systematic-debugging` is not resolving the root cause |
+
+## Verification status
+
+The Mode-2 safe status above was last verified against the sibling-plugin
+codebases on **2026-05-03**. Re-verify when a sibling plugin ships a new major
+version or when a previously-TBD entry needs to be resolved. The verification
+procedure: read the skill's SKILL.md body; if the body contains an `Agent` tool
+call or `spawn_agents_on_csv` instruction, the skill is NOT Mode-2 safe.
+
+`superpowers:subagent-driven-development` is marked TBD because its name
+implies subagent spawning. An audit performed on 2026-04-26 found it to be
+procedural — the body instructs the agent on how to drive a subagent workflow
+but does not itself issue an `Agent` tool call. Re-verify on each superpowers
+release that touches this skill.

--- a/skills/managing-board/references/scope-shape-judgment.md
+++ b/skills/managing-board/references/scope-shape-judgment.md
@@ -223,3 +223,7 @@ a shape decision that the architect overrides, that is the
 signal to revise this file in the same PR as the override.
 The file is calibrated to project reality, not aspirational —
 overrides are evidence the calibration drifted.
+
+**Runtime authority**: see `board-superpowers:composing-siblings` skill for the
+single source of truth on sibling-plugin invocation rules (Mode-2 compatibility +
+`<plugin>:<skill>` namespace prefix discipline).

--- a/skills/managing-board/references/skill-routing.md
+++ b/skills/managing-board/references/skill-routing.md
@@ -302,3 +302,7 @@ If `AGENTS.md` ever drifts from this canonical text (anchor
 missing, wording diverged), the change-impact-matrix row
 referenced in the quote is the recovery path — re-injecting
 this anchor is a same-PR contract obligation.
+
+**Runtime authority**: see `board-superpowers:composing-siblings` skill for the
+single source of truth on invocation rules, Mode-2 compatibility, and namespace
+prefix discipline at each sibling-plugin handoff point.


### PR DESCRIPTION
## Summary

Lands the **11th board-superpowers SKILL** — `composing-siblings` (6th atomic) — implementing Card #71. Consolidates the SoT for sibling-plugin invocation discipline (`gstack:*` / `superpowers:*`) into a single atomic SKILL with 4 reference files.

Today's caller surface (3 SKILLs): `managing-board` (F-08 intake routing), `consuming-card` (F-C4 implement / F-C9 verify / F-C11 conditional QA-security), `decomposing-into-milestones` (plan + arch validation handoff). Post Card #72 + Card #73: 6 SKILLs × 9 handoff points using B1/C1-C4 encoding (forward-looking, not in this PR).

Plugin version: 0.5.0 → 0.6.0 (minor bump per `AGENTS.md` "Release flow" — new atomic SKILL = minor).

## Automated Verification

- [x] `bash scripts/verify-skill-frontmatter.sh skills/composing-siblings/` → exit 0 ("OK")
- [x] `bash scripts/verify-skill-metadata.sh` → exit 0 ("11 skills checked")
- [x] `bash scripts/verify-skill-anti-patterns.sh` → 38 violations (baseline pre-existing; this PR introduced 0 new violations)
- [x] `shellcheck -x scripts/**/*.sh hooks/*.sh` → exit 0 (clean)
- [x] `bash tests/test-skills-edit-gate.sh` → 27/27 pass
- [x] `grep -E '10 skills|all 10|10 of 10|10 v1' SKILLS.md AGENTS.md docs/architecture/0005-contracts/04-skill-contracts.md docs/architecture/0004-component-architecture.md` → 0 hits (post-fix; was stale in implementer's first round)
- [x] `grep 'v0\.7\.0' SKILLS.md AGENTS.md` → 0 hits (post-fix; version aligned to 0.6.0 across plugin.json + SKILLS.md catalog)
- [x] `grep '"version"' .claude-plugin/plugin.json .codex-plugin/plugin.json` → both `"0.6.0"`
- [x] AC-1 frontmatter: Tier 1 (`name` + `description`) + Tier 2 (`when_to_use` + `user-invocable: false`); no Tier 3 fields
- [x] AC-2 `.skill-meta.yaml`: 5 required fields (`version: v0.1.0`, `layer: atomic`, `type: reference`, `mode: both`, `bounded-context: session`); yaml ↔ SKILLS.md catalog consistent
- [x] AC-3 SKILL.md body 102 lines (≤ 200 atomic budget)
- [x] AC-4 4 reference files shipped: `handoff-points.md` / `sibling-plugin-table.md` / `procedural-fallback-rules.md` / `boundary.md`
- [x] AC-5 SKILLS.md updated: header `(11 skills, all shipped, 3 layers)`; atomic-layer subhead `(6 skills, all shipped)`; catalog row added; SPOT-census row added (with 3-current / 6-forward-looking dual layering); call-graph aggregated edge prose; bounded-context map updated
- [x] AC-6 AGENTS.md compose section + `skills/managing-board/references/skill-routing.md` + `scope-shape-judgment.md` all carry the 1-line "Runtime authority: see `composing-siblings`" pointer
- [x] AC-7 cross-impact-matrix walk: paired-PR rows handled (`docs/architecture/0005-contracts/04-skill-contracts.md` v1 catalog table updated to 11; ADR-0004 Decision 2 confirmed tier-agnostic, no change needed)
- [x] AC-8 9 callers untouched (`git diff main` for `skills/managing-board/SKILL.md`, `skills/consuming-card/SKILL.md`, `skills/decomposing-into-milestones/SKILL.md`, `skills/bootstrapping-repo/SKILL.md` is empty; only paired references files updated)
- [x] AC-9 all CI gates green (per first 5 lines above)

## Human Verification TODO

- [ ] In a fresh CC session, trigger an in-plugin sibling-plugin handoff (e.g., Producer intake → `gstack:/plan-ceo-review`) and confirm `composing-siblings` is consulted but does NOT intercept user-direct routing for sibling-scoped phrases (e.g., "brainstorm this with me" should still route directly to `superpowers:brainstorming`, not via `composing-siblings`).
- [ ] When Card #72 (Producer Shape Y) lands, verify each of the 4 routine SKILLs (`briefing-daily` / `intaking-requirement` / `reviewing-pr-queue` / `triaging-board`) invokes `composing-siblings` per the 9-handoff-point map in `references/handoff-points.md`.
- [ ] When Card #73 (Consumer Shape X) lands, verify C1 / C2 / C3 / C4 handoff points invoke `composing-siblings` and the Mode-2 `max_depth=1` decision tree resolves correctly for `subagent-driven-development` (currently TBD-hedged with `executing-plans` fallback).

## Retro Notes

- **Two-reviewer fan-out paid off.** Opus reviewer + Codex reviewer in parallel found 5 critical issues a single reviewer would likely have missed. Opus caught AGENTS.md line 170 internal stale + `plugin.json` version drift; Codex caught `description` over-greedy enumeration + `handoff-points.md` missing forward-looking annotation + SKILLS.md three-place number contradiction. Visible-overlap on the SKILLS.md numbers issue gave high-confidence signal; non-overlap parts caught complementary blind spots. Worth replicating for Card #72 / #73.
- **"Use delta not absolute counts" (Card-1 AC-5) held under double drift.** PR #70 then PR #75 shifted SKILLS.md baseline twice between intake and implementation; the delta-based AC encoding (`+1` header, `+1` atomic subhead) stayed valid. Absolute-count AC would have failed both times. Pattern to repeat for Card #72 / #73 (which still encode their "molecular +3" / counterpart updates as deltas).
- **TBD-hedge for `subagent-driven-development`** matches ADR-0008's "treated as non-procedural until verified" stance — better than asserting a yes/no that may go stale on the next sibling-plugin release. Re-verification trigger date noted in `procedural-fallback-rules.md`.
- **Numbers contradiction root cause**: implementer initially conflated "9 handoff points" with "9 caller SKILLs" — they're different cardinalities (3 SKILL × N points today; 6 SKILL × 9 points after Card #72 + #73). Now layered explicitly in SKILLS.md SPOT row + handoff-points.md forward-looking note.
- **`description` shape lesson**: enumerating all 13 sibling skills in a description (a) drifts at every sibling release, (b) reads as "I will intercept these" — greedy routing risk. Better: anchor 4 examples + "see references/sibling-plugin-table.md for full set" + explicit DO NOT use bullets covering user-direct sibling invocations. Reusable for future SoT-style atomic SKILLs.


---
Closes #71 — board-superpowers v0.4.0 claim trailer.
